### PR TITLE
Upgrade mime dependency from v1 to v2

### DIFF
--- a/example/factories.ts
+++ b/example/factories.ts
@@ -1,4 +1,4 @@
-import {lookup} from 'mime';
+import {getType} from 'mime';
 import {
   createApiResponse,
   createResultHandler,
@@ -12,8 +12,8 @@ import fs from 'fs';
 export const keyAndTokenAuthenticatedEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
 
 export const fileDownloadEndpointsFactory = new EndpointsFactory(createResultHandler({
-  getPositiveResponse: () => createApiResponse(z.string(), lookup('svg')),
-  getNegativeResponse: () => createApiResponse(z.string(), lookup('txt')),
+  getPositiveResponse: () => createApiResponse(z.string(), getType('svg') as string),
+  getNegativeResponse: () => createApiResponse(z.string(), getType('txt') as string),
   handler: ({response, error, output}) => {
     if (error) {
       response.status(400).send(error.message);
@@ -29,7 +29,7 @@ export const fileDownloadEndpointsFactory = new EndpointsFactory(createResultHan
 
 export const fileStreamingEndpointsFactory = new EndpointsFactory(createResultHandler({
   getPositiveResponse: () => createApiResponse(z.file().binary(), 'image/*'),
-  getNegativeResponse: () => createApiResponse(z.string(), lookup('txt')),
+  getNegativeResponse: () => createApiResponse(z.string(), getType('txt') as string),
   handler: ({response, error, output}) => {
     if (error) {
       response.status(400).send(error.message);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "http-errors": "^1.8.0",
+    "mime": "^2.5.2",
     "openapi3-ts": "^2.0.1",
     "winston": "^3.3.3",
     "zod": "^3.5.1"
@@ -34,6 +35,7 @@
     "@types/express": "^4.17.11",
     "@types/http-errors": "^1.8.0",
     "@types/jest": "^26.0.20",
+    "@types/mime": "^2.0.3",
     "@types/node-fetch": "^2.5.8",
     "@types/triple-beam": "^1.3.2",
     "@typescript-eslint/eslint-plugin": "^4.15.1",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,6 @@
 import {Request} from 'express';
 import {HttpError} from 'http-errors';
-import {lookup} from 'mime';
+import {getType} from 'mime';
 import {z} from 'zod';
 import {LoggerConfig, loggerLevels} from './config-type';
 import {MiddlewareDefinition} from './middleware';
@@ -111,7 +111,7 @@ export type ApiResponse<A = z.ZodTypeAny> = {
   mimeTypes: string[];
 };
 
-export const createApiResponse = <S extends z.ZodTypeAny>(schema: S, mimeTypes: string | string[] = lookup('json')) => {
+export const createApiResponse = <S extends z.ZodTypeAny>(schema: S, mimeTypes: string | string[] = getType('json') as string) => {
   return {
     schema,
     mimeTypes: typeof mimeTypes === 'string' ? [mimeTypes] : mimeTypes,

--- a/src/open-api.ts
+++ b/src/open-api.ts
@@ -10,7 +10,7 @@ import {OpenAPIError} from './errors';
 import {ZodFile} from './file-schema';
 import {ArrayElement, extractObjectSchema} from './helpers';
 import {Routing, routingCycle, RoutingCycleParams} from './routing';
-import {lookup} from 'mime';
+import {getType} from 'mime';
 
 const describeSchema = (value: z.ZodTypeAny, isResponse: boolean): SchemaObject => {
   const otherProps: SchemaObject = {};
@@ -239,7 +239,7 @@ interface GenerationParams {
   errorResponseDescription?: string;
 }
 
-const mimeJson = lookup('json');
+const mimeJson = getType('json') as string;
 
 export class OpenAPI extends OpenApiBuilder {
   public constructor({

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,6 +726,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
+"@types/mime@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -3603,6 +3608,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
First off I wanted to say thanks for putting together this project, I really enjoy how you designed things!

I'm currently trying to use this within a monorepo as a part of a yarn workspace, but several of our other dependencies are relying on mime v2 instead of mime v1 which is causing some issues. This PR updates the mime dependency within express-zod-api.

Let me know if you'd like to go another direction with it and I can adjust things :)