### PR TITLE
Test of union type, including ZodObject::extend(). Does not require ZodUndefined

### DIFF
--- a/tests/unit/__snapshots__/open-api.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api.spec.ts.snap
@@ -1,5 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Open API generator Issue #98 should union schemas 1`] = `
+"openapi: 3.0.0
+info:
+  title: \\"Testing issue #98\\"
+  version: 3.4.5
+paths:
+  /v1/getSomething:
+    post:
+      responses:
+        \\"200\\":
+          description: POST /v1/getSomething Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          field1:
+                            type: string
+                        required:
+                          - id
+                          - field1
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          field2:
+                            type: string
+                        required:
+                          - id
+                          - field2
+                required:
+                  - status
+                  - data
+        \\"400\\":
+          description: POST /v1/getSomething Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                field1:
+                  type: string
+                field2:
+                  type: string
+              required: []
+              description: POST /v1/getSomething request body
+components:
+  schemas: {}
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes: {}
+  links: {}
+  callbacks: {}
+tags: []
+servers:
+  - url: http://example.com
+"
+`;
+
 exports[`Open API generator generateOpenApi() should generate the correct schema for complex types 1`] = `
 "openapi: 3.0.0
 info:

--- a/tests/unit/open-api.spec.ts
+++ b/tests/unit/open-api.spec.ts
@@ -1,5 +1,6 @@
 import {routing} from '../../example/routing';
 import {z, OpenAPI, defaultEndpointsFactory} from '../../src';
+import {expectType} from 'tsd';
 
 describe('Open API generator', () => {
   describe('generateOpenApi()', () => {
@@ -379,6 +380,47 @@ describe('Open API generator', () => {
           serverUrl: 'http://example.com'
         })).toThrowError(/Zod type Zod\w+ is unsupported/);
       });
+    });
+  });
+
+  describe('Issue #98', () => {
+    test('should union schemas', () => {
+      const baseSchema = z.object({ id: z.string() });
+      const subType1 = baseSchema.extend({ field1: z.string() });
+      const subType2 = baseSchema.extend({ field2: z.string() });
+      const unionSchema = z.union([subType1, subType2]);
+      type TestingType = z.infer<typeof unionSchema>;
+
+      expectType<TestingType>({id: 'string', field1: 'string'});
+      expectType<TestingType>({id: 'string', field2: 'string'});
+
+      const spec = new OpenAPI({
+        routing: {
+          v1: {
+            getSomething: defaultEndpointsFactory.build({
+              method: 'post',
+              input: unionSchema,
+              output: unionSchema,
+              handler: async ({input}) => {
+                if ('field1' in input) {
+                  return {
+                    id: `test, ${input.id}`,
+                    field1: input.field1
+                  };
+                }
+                return {
+                  id: 'other test',
+                  field2: input.field2
+                };
+              }
+            })
+          }
+        },
+        version: '3.4.5',
+        title: 'Testing issue #98',
+        serverUrl: 'http://example.com'
+      }).getSpecAsYaml();
+      expect(spec).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
### Testing Issue #98.

> Regarding ZodUndefined. In some cases, it's useful to implement subTypes. Because if we define the subtypes something like:

```typescript
const Base = z.object({ id: z.string() });
const SubType1 = Base.extend({ field1: z.string() });
const SubType2 = Base.extend({ field2: z.string() });
const Type = z.union([SubType1, SubType2]);
type Type = z.infer<typeof Type>;
```

> We can have a compilation error

![image](https://user-images.githubusercontent.com/13189514/129785309-6c90b90b-8799-41c3-a26c-d3471b482737.png)

### Proof of concept.

There is no need for ZodUndefined to avoid the compilation issue.
Please use `'field1' in ...` Typescript syntax within your `if` condition.

It's called `Type narrowing`, see docs:
https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing