### PR TITLE
Testing issue Non-empty array description by OpenAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "http-errors": "^1.8.0",
     "openapi3-ts": "^2.0.1",
     "winston": "^3.3.3",
-    "zod": "^3.5.1"
+    "zod": "^3.7.2"
   },
   "devDependencies": {
     "@tsconfig/node10": "^1.0.8",

--- a/tests/unit/__snapshots__/open-api.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api.spec.ts.snap
@@ -1,5 +1,146 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Open API generator Issue #98 Should describe non-empty array 1`] = `
+"openapi: 3.0.0
+info:
+  title: \\"Testing issue #98\\"
+  version: 3.4.5
+paths:
+  /v1/getSomething:
+    get:
+      responses:
+        \\"200\\":
+          description: GET /v1/getSomething Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    type: object
+                    properties:
+                      arr:
+                        type: array
+                        items:
+                          type: string
+                        minItems: 1
+                    required:
+                      - arr
+                required:
+                  - status
+                  - data
+        \\"400\\":
+          description: GET /v1/getSomething Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+      parameters:
+        - name: arr
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+            minItems: 1
+            description: GET /v1/getSomething parameter
+    post:
+      responses:
+        \\"200\\":
+          description: POST /v1/getSomething Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    type: object
+                    properties:
+                      arr:
+                        type: array
+                        items:
+                          type: string
+                        minItems: 1
+                    required:
+                      - arr
+                required:
+                  - status
+                  - data
+        \\"400\\":
+          description: POST /v1/getSomething Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                arr:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+              required:
+                - arr
+              description: POST /v1/getSomething request body
+components:
+  schemas: {}
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes: {}
+  links: {}
+  callbacks: {}
+tags: []
+servers:
+  - url: http://example.com
+"
+`;
+
 exports[`Open API generator generateOpenApi() should generate the correct schema for complex types 1`] = `
 "openapi: 3.0.0
 info:

--- a/tests/unit/open-api.spec.ts
+++ b/tests/unit/open-api.spec.ts
@@ -381,4 +381,34 @@ describe('Open API generator', () => {
       });
     });
   });
+
+  describe('Issue #98', () => {
+    test('Should describe non-empty array', () => {
+      // There is no such class as ZodNonEmptyArray in Zod v3.7.0+
+      // It existed though in Zod v3.6.x:
+      // @see https://github.com/colinhacks/zod/blob/v3.6.1/src/types.ts#L1204
+      const spec = new OpenAPI({
+        routing: {
+          v1: {
+            getSomething: defaultEndpointsFactory.build({
+              methods: ['get', 'post'],
+              input: z.object({
+                arr: z.array(z.string()).nonempty(),
+              }),
+              output: z.object({
+                arr: z.array(z.string()).nonempty()
+              }),
+              handler: async ({input}) => ({
+                arr: input.arr
+              })
+            })
+          }
+        },
+        version: '3.4.5',
+        title: 'Testing issue #98',
+        serverUrl: 'http://example.com'
+      }).getSpecAsYaml();
+      expect(spec).toMatchSnapshot();
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,7 +5359,7 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zod@^3.5.1:
+zod@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.7.2.tgz#b02505f8314aa99c05ef8a7e55464680f9a515f6"
   integrity sha512-JhYYcj+TS/a0+3kqxnbmuXMVtA+QkJUPu91beQTo1Y3xA891pHeMPQgVOSu97FdzAd056Yp87lpEi8Xvmd3zhw==


### PR DESCRIPTION
Testing issue #98 

There is no such **class** as `ZodNonEmptyArray` in Zod v3.7.0+
It existed though in [Zod v3.6.x](https://github.com/colinhacks/zod/blob/v3.6.1/src/types.ts#L1204)

The issue can not be reproduced.

`express-zod-api` is [using](https://github.com/RobinTail/express-zod-api/blob/v2.1.0/yarn.lock#L5310) Zod v3.7.1 since version 2.1.0.

I'd recommend to check that your package manager installs the correct version of dependencies.
If you're using `npm`, try `yarn`.