### PR TITLE
path-parse fix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v1 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v1 ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Version 1
 
+### v1.3.2
+
+- Updated the development package `path-parse` from 1.0.6 to 1.0.7.
+  An audit revealed a vulnerability, but this package is not included in the build.
+```
+info Reasons this module exists
+   - "jest#@jest#core#jest-resolve#resolve" depends on it
+   - Hoisted from "jest#@jest#core#jest-resolve#resolve#path-parse"
+```
+
 ### v1.3.1
 
 - Improving the coverage I found a bug and fixed it.

--- a/src/open-api.ts
+++ b/src/open-api.ts
@@ -166,7 +166,7 @@ export class OpenAPI {
   }
 
   public constructor({routing, title, version, serverUrl, successfulResponseDescription}: GenerationParams) {
-    const mimeJson = lookup('.json');
+    const mimeJson = lookup('json');
     this.builder = new OpenApiBuilder()
       .addInfo({title, version})
       .addServer({url: serverUrl});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,9 +4075,9 @@ path-key@^3.0.0, path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"


### PR DESCRIPTION
```
info Reasons this module exists
   - "jest#@jest#core#jest-resolve#resolve" depends on it
   - Hoisted from "jest#@jest#core#jest-resolve#resolve#path-parse"
```