### PR TITLE
Fixing OpenAPI path params format

### DIFF
--- a/src/open-api.ts
+++ b/src/open-api.ts
@@ -7,6 +7,14 @@ import {
 } from "./open-api-helpers";
 import { Routing, routingCycle, RoutingCycleParams } from "./routing";
 
+const convertColonToBrackets = (path: string): string =>
+  path
+    .split('/')
+    .map(segment =>
+        segment[0] === ':' ? `{${segment.substr(1)}}` : segment,
+    )
+    .join('/')
+
 interface GeneratorParams {
   title: string;
   version: string;
@@ -55,6 +63,7 @@ export class OpenAPI extends OpenApiBuilder {
         // @todo involve config/inputSources in v4
         operation.requestBody = depictRequest(commonParams);
       }
+      path = convertColonToBrackets(path);
       this.addPath(path, {
         ...(this.rootDoc.paths?.[path] || {}),
         [method]: operation,


### PR DESCRIPTION
Hi Anna,

At least according to [this issue](https://github.com/OAI/OpenAPI-Specification/issues/1681), 'colon-style' path parameters (`/entity/:id`, as used by express) are not supported by the OpenAPI specification; instead the 'curly braces notation' (`/entity/{id}`) is preferred. The behaviour is deemed as 'tooling issue' and, as such, it is up to the tool generating the OpenAPI document to adjust it's output to match the specification. I'm no expert in OpenAPI related things, so my interpretation might be wrong. Nevertheless, I've tried to fix the issue. Hope I've done a not too terrible job, but I'm open to corrections.

I've just discovered your library today, after quite a while of searching for something similar and giving up at least half a dozen times after not finding enough time to develop something myself. Since I only had a few hours of testing the library I'm still preparing myself for future issues, but so far I love it. Great work!