### PR TITLE
No uploads in response

### DIFF
--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -79,11 +79,19 @@ export const depictAny: DepictHelper<z.ZodAny> = ({ initial }) => ({
   format: "any",
 });
 
-export const depictUpload: DepictHelper<ZodUpload> = ({ initial }) => ({
-  ...initial,
-  type: "string",
-  format: "binary",
-});
+export const depictUpload: DepictHelper<ZodUpload> = ({
+  initial,
+  isResponse,
+}) => {
+  if (isResponse) {
+    throw new OpenAPIError("Please use z.upload() only for input.");
+  }
+  return {
+    ...initial,
+    type: "string",
+    format: "binary",
+  };
+};
 
 export const depictFile: DepictHelper<ZodFile> = ({
   schema: { isBinary, isBase64 },

--- a/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
@@ -511,6 +511,8 @@ Object {
 }
 `;
 
+exports[`Open API helpers depictUpload() should throw when using in response 1`] = `[Error: Please use z.upload() only for input.]`;
+
 exports[`Open API helpers excludeExampleFromDepiction() should remove example property of supplied object 1`] = `
 Object {
   "test": "some",

--- a/tests/unit/open-api-helpers.spec.ts
+++ b/tests/unit/open-api-helpers.spec.ts
@@ -130,6 +130,19 @@ describe("Open API helpers", () => {
         })
       ).toMatchSnapshot();
     });
+    test("should throw when using in response", () => {
+      try {
+        depictUpload({
+          schema: z.upload(),
+          isResponse: true,
+          initial: { description: "test" },
+        });
+        fail("Should not be here");
+      } catch (e) {
+        expect(e).toBeInstanceOf(OpenAPIError);
+        expect(e).toMatchSnapshot();
+      }
+    });
   });
 
   describe("depictFile()", () => {


### PR DESCRIPTION
`z.upload()` should not be used within output