### PR TITLE
Replacing `.substr()` with `.slice()`

### DIFF
--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -113,11 +113,10 @@ export function combineEndpointAndMiddlewareInputSchemas<
   return result;
 }
 
-// @todo substr replace .substr() with an alternative
 function areFilesAvailable(request: Request) {
   const contentType = request.header("content-type") || "";
   const isMultipart =
-    contentType.substr(0, mimeMultipart.length).toLowerCase() === mimeMultipart;
+    contentType.slice(0, mimeMultipart.length).toLowerCase() === mimeMultipart;
   return "files" in request && isMultipart;
 }
 


### PR DESCRIPTION
replacing the deprecated method