### PR TITLE
CI/CD: ESM test fails on Node 18.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,9 +92,9 @@
     "node-fetch": "^2.6.5",
     "prettier": "2.7.1",
     "ts-jest": "^27.0.7",
-    "ts-node": "^10.4.0",
+    "ts-node": "^10.9.1",
     "tsd": "^0.21.0",
-    "typescript": "^4.6.3",
+    "typescript": "^4.7.4",
     "winston-transport": "^4.4.0"
   },
   "engines": {

--- a/tools/esm-test.ts
+++ b/tools/esm-test.ts
@@ -16,8 +16,9 @@ const packageJson = `
   "dependencies": {
     "@tsconfig/node${tsconfigBase}": "latest",
     "express-zod-api": "../../dist-esm",
-    "ts-node": "10.7.0",
-    "typescript": "4.6.2"
+    "ts-node": "10.9.1",
+    "typescript": "4.7.4",
+    "@types/node": "*"
   }
 }
 `;

--- a/tools/integration-test.ts
+++ b/tools/integration-test.ts
@@ -14,8 +14,9 @@ const packageJson = `
   "dependencies": {
     "@tsconfig/node${tsconfigBase}": "latest",
     "express-zod-api": "../../dist",
-    "ts-node": "10.7.0",
-    "typescript": "4.6.2"
+    "ts-node": "10.9.1",
+    "typescript": "4.7.4",
+    "@types/node": "*"
   }
 }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4706,10 +4706,10 @@ ts-jest@^27.0.7:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-node@^10.4.0:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.2.tgz#3185b75228cef116bf82ffe8762594f54b2a23f2"
-  integrity sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
@@ -4823,7 +4823,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.3:
+typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
Related issues:
https://github.com/cypress-io/cypress/issues/22795#issuecomment-1184613764
https://github.com/TypeStrong/ts-node/issues/1839