### PR TITLE
fix typescript nodenext resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "types": "dist/index.d.ts",
   "module": "dist-esm/index.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist-esm/index.js"
   },


### PR DESCRIPTION
thanks for this amazing library! tiny fix here: while your ESModule build is working totally fine, when downstream consumers are set up to use `nodenext` for their `module` & `moduleResolution` settings, typescript reads your `package.json` and sees that the `exports.import` points to the `dist-esm` folder and tries to also look there for the typescript typings

as per [the typescript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) this just lets typescript know to still keep looking in the dist folder for the types :)