### PR TITLE
Breaking: Removing the deprecated signature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 8
 
+### 8.0.0-beta2
+
+- **Breaking**: removing the signature deprecated in v7.6.1.
+  - The argument of `EndpointsFactory::addMiddleware()` has to be the result of `createMiddleware()`.
+
 ### 8.0.0-beta1
 
 - **Breaking**: Only the following Node versions are supported:

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -15,7 +15,6 @@ import {
   createMiddleware,
   ExpressMiddleware,
   ExpressMiddlewareFeatures,
-  MiddlewareCreationProps,
   MiddlewareDefinition,
 } from "./middleware";
 import { mimeJson, mimeMultipart } from "./mime";
@@ -71,52 +70,14 @@ export class EndpointsFactory<
     AIN extends IOSchema<"strip">,
     AOUT extends FlatObject,
     ASCO extends string
-  >(
-    definition: MiddlewareDefinition<AIN, OUT, AOUT, ASCO>
-  ): EndpointsFactory<
-    POS,
-    NEG,
-    ProbableIntersection<IN, AIN>,
-    OUT & AOUT,
-    SCO & ASCO
-  >;
-
-  /** @deprecated please use createMiddleware() for the argument */
-  public addMiddleware<
-    AIN extends IOSchema<"strip">,
-    AOUT extends FlatObject,
-    ASCO extends string
-  >(
-    props: MiddlewareCreationProps<AIN, OUT, AOUT, ASCO>
-  ): EndpointsFactory<
-    POS,
-    NEG,
-    ProbableIntersection<IN, AIN>,
-    OUT & AOUT,
-    SCO & ASCO
-  >;
-
-  public addMiddleware<
-    AIN extends IOSchema<"strip">,
-    AOUT extends FlatObject,
-    ASCO extends string
-  >(
-    subject:
-      | MiddlewareDefinition<AIN, OUT, AOUT, ASCO>
-      | MiddlewareCreationProps<AIN, OUT, AOUT, ASCO>
-  ) {
+  >(subject: MiddlewareDefinition<AIN, OUT, AOUT, ASCO>) {
     return EndpointsFactory.#create<
       POS,
       NEG,
       ProbableIntersection<IN, AIN>,
       OUT & AOUT,
       SCO & ASCO
-    >(
-      this.middlewares.concat(
-        "type" in subject ? subject : createMiddleware(subject)
-      ),
-      this.resultHandler
-    );
+    >(this.middlewares.concat(subject), this.resultHandler);
   }
 
   public use = this.addExpressMiddleware;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ type Middleware<IN, OPT, OUT> = (
   params: MiddlewareParams<IN, OPT>
 ) => Promise<OUT>;
 
-export interface MiddlewareCreationProps<
+interface MiddlewareCreationProps<
   IN extends IOSchema<"strip">,
   OPT,
   OUT extends FlatObject,

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -415,15 +415,16 @@ describe("Endpoint", () => {
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {
     test("should skip proprietary ones", async () => {
       const endpoint = new EndpointsFactory(defaultResultHandler)
-        .addMiddleware({
-          // testing also the backward compatibility (without createMiddleware)
-          input: z.object({
-            shouldNotBeHere: z.boolean(),
-          }),
-          middleware: async () => {
-            throw new Error("Should not be here");
-          },
-        })
+        .addMiddleware(
+          createMiddleware({
+            input: z.object({
+              shouldNotBeHere: z.boolean(),
+            }),
+            middleware: async () => {
+              throw new Error("Should not be here");
+            },
+          })
+        )
         .addExpressMiddleware((req, res, next) => {
           res.set("X-Custom-Header", "test");
           next();


### PR DESCRIPTION
the deprecated case of EndpointsFactory::addMiddleware() with using MiddlewareCreationProps as an argument