### PR TITLE
OpenAPI generator: Deny using z.file() in input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 8
 
+### v8.2.1
+
+- OpenAPI generator throws when attempting to use `z.file()` within input schema.
+
 ### v8.2.0
 
 - Feature #637: endpoint short description (summary).

--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -105,11 +105,17 @@ export const depictUpload: DepictHelper<ZodUpload> = ({
 export const depictFile: DepictHelper<ZodFile> = ({
   schema: { isBinary, isBase64 },
   initial,
-}) => ({
-  ...initial,
-  type: "string",
-  format: isBinary ? "binary" : isBase64 ? "byte" : "file",
-});
+  isResponse,
+}) => {
+  if (!isResponse) {
+    throw new OpenAPIError("Please use z.file() only within ResultHandler.");
+  }
+  return {
+    ...initial,
+    type: "string",
+    format: isBinary ? "binary" : isBase64 ? "byte" : "file",
+  };
+};
 
 export const depictUnion: DepictHelper<
   z.ZodUnion<[z.ZodTypeAny, ...z.ZodTypeAny[]]>

--- a/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
@@ -170,6 +170,8 @@ exports[`Open API helpers depictFile() should depict ZodFile 1`] = `
 }
 `;
 
+exports[`Open API helpers depictFile() should throw when using in input 1`] = `[Error: Please use z.file() only within ResultHandler.]`;
+
 exports[`Open API helpers depictIOExamples() should depict examples in case of request 1`] = `
 {
   "examples": {

--- a/tests/unit/open-api-helpers.spec.ts
+++ b/tests/unit/open-api-helpers.spec.ts
@@ -262,10 +262,23 @@ describe("Open API helpers", () => {
       expect(
         depictFile({
           schema: z.file().binary(),
-          isResponse: false,
+          isResponse: true,
           initial: { description: "test" },
         })
       ).toMatchSnapshot();
+    });
+    test("should throw when using in input", () => {
+      try {
+        depictFile({
+          schema: z.file().binary(),
+          isResponse: false,
+          initial: { description: "test" },
+        });
+        fail("Should not be here");
+      } catch (e) {
+        expect(e).toBeInstanceOf(OpenAPIError);
+        expect(e).toMatchSnapshot();
+      }
     });
   });
 


### PR DESCRIPTION
`z.file()` was introduced in v2.1.0.
It was not intended to be used in endpoint I/O.