### PR TITLE
Fix warning on deprecated `set-output` in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: Get yarn cache dir
       id: yarnCache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-yarn
       with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Partially fixed, except Coveralls actions. Related issue: https://github.com/coverallsapp/github-action/issues/135