### PR TITLE
Initial evaluation of schema refs

### DIFF
--- a/example/endpoints/update-user.ts
+++ b/example/endpoints/update-user.ts
@@ -19,20 +19,24 @@ export const updateUserEndpoint =
         name: z.string().min(1),
         birthday: z.dateIn(),
       })
-    ).example({
-      id: "12",
-      name: "John Doe",
-      birthday: "1963-04-21",
-    }),
+    )
+      .example({
+        id: "12",
+        name: "John Doe",
+        birthday: "1963-04-21",
+      })
+      .schema("UpdateUserRequest"),
     output: withMeta(
       z.object({
         name: z.string(),
         createdAt: z.dateOut(),
       })
-    ).example({
-      name: "John Doe",
-      createdAt: new Date("2021-12-31"),
-    }),
+    )
+      .example({
+        name: "John Doe",
+        createdAt: new Date("2021-12-31"),
+      })
+      .schema("UpdateUserResponse"),
     handler: async ({
       input: { id, name, key },
       options: { token },

--- a/example/example.swagger.yaml
+++ b/example/example.swagger.yaml
@@ -82,32 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum:
-                      - success
-                  data:
-                    example:
-                      name: John Doe
-                      createdAt: 2021-12-31T00:00:00.000Z
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      createdAt:
-                        description: YYYY-MM-DDTHH:mm:ss.sssZ
-                        type: string
-                        format: date-time
-                        externalDocs:
-                          url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
-                    required:
-                      - name
-                      - createdAt
-                required:
-                  - status
-                  - data
+                $ref: "#/components/schemas/UpdateUserResponse"
               examples:
                 example1:
                   value:
@@ -160,35 +135,7 @@ paths:
         content:
           application/json:
             schema:
-              description: POST /v1/user/:id request body
-              allOf:
-                - example:
-                    key: 1234-5678-90
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                      minLength: 1
-                  required:
-                    - key
-                - example:
-                    name: John Doe
-                    birthday: 1963-04-21
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      minLength: 1
-                    birthday:
-                      description: YYYY-MM-DDTHH:mm:ss.sssZ
-                      type: string
-                      format: date-time
-                      pattern: ^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?)?Z?$
-                      externalDocs:
-                        url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
-                  required:
-                    - name
-                    - birthday
+              $ref: "#/components/schemas/UpdateUserRequest"
             examples:
               example1:
                 value:
@@ -341,7 +288,62 @@ paths:
               required:
                 - avatar
 components:
-  schemas: {}
+  schemas:
+    UpdateUserRequest:
+      example:
+        key: 1234-5678-90
+        id: "12"
+        name: John Doe
+        birthday: 1963-04-21
+      allOf:
+        - example:
+            key: 1234-5678-90
+          type: object
+          properties:
+            key:
+              type: string
+              minLength: 1
+          required:
+            - key
+        - example:
+            id: "12"
+            name: John Doe
+            birthday: 1963-04-21
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+              minLength: 1
+            birthday:
+              description: YYYY-MM-DDTHH:mm:ss.sssZ
+              type: string
+              format: date-time
+              pattern: ^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?)?Z?$
+              externalDocs:
+                url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+          required:
+            - id
+            - name
+            - birthday
+    UpdateUserResponse:
+      example:
+        name: John Doe
+        createdAt: 2021-12-31T00:00:00.000Z
+      type: object
+      properties:
+        name:
+          type: string
+        createdAt:
+          description: YYYY-MM-DDTHH:mm:ss.sssZ
+          type: string
+          format: date-time
+          externalDocs:
+            url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+      required:
+        - name
+        - createdAt
   responses: {}
   parameters: {}
   examples: {}

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -132,6 +132,12 @@ export const getExamples = <T extends z.ZodTypeAny>(
   }, [] as z.output<typeof schema>[]);
 };
 
+export const getSchemaName = <T extends z.ZodTypeAny>(
+  schema: T
+): string | undefined => {
+  return getMeta(schema, "schemaName");
+};
+
 export const combinations = <T extends any>(
   a: T[],
   b: T[]

--- a/src/open-api.ts
+++ b/src/open-api.ts
@@ -4,7 +4,7 @@ import {
   SecuritySchemeObject,
   SecuritySchemeType,
 } from "openapi3-ts";
-import { defaultInputSources } from "./common-helpers";
+import { defaultInputSources, getSchemaName } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { mapLogicalContainer } from "./logical-container";
 import { Method } from "./method";
@@ -12,6 +12,7 @@ import {
   depictRequest,
   depictRequestParams,
   depictResponse,
+  depictSchema,
   depictSecurity,
   depictSecurityRefs,
   depictTags,
@@ -136,6 +137,25 @@ export class OpenAPI extends OpenApiBuilder {
       this.addPath(swaggerCompatiblePath, {
         [method]: operation,
       });
+
+      const inputSchemaName = getSchemaName(endpoint.getInputSchema());
+      if (inputSchemaName)
+        this.addSchema(
+          inputSchemaName,
+          depictSchema({
+            schema: endpoint.getInputSchema(),
+            isResponse: false,
+          })
+        );
+      const outputSchemaName = getSchemaName(endpoint.getOutputSchema());
+      if (outputSchemaName)
+        this.addSchema(
+          outputSchemaName,
+          depictSchema({
+            schema: endpoint.getOutputSchema(),
+            isResponse: true,
+          })
+        );
     };
     routingCycle({ routing, endpointCb });
     this.rootDoc.tags = config.tags ? depictTags(config.tags) : [];


### PR DESCRIPTION
OpenAPI client generators often create classes/types for requests and responses objects by looking at the `schemas` field in the `components` object ([reference](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#components-object)).

I drafted this PR that adds a `schema` field to the `withMeta()` method: with this meta, the schema is added to the global OpenAPI document (under `components`), and in the path the schema is [referenced](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object).

This doesn't consider:  
- nested schemas
- schema name uniqueness