### PR TITLE
Fix overly strict ISO date validation

### DIFF
--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -12,6 +12,7 @@ import { isValidDate } from "./common-helpers";
 
 // simple regex for ISO date, supports the following formats:
 // 2021-01-01T00:00:00.000Z
+// 2021-01-01T00:00:00.0Z
 // 2021-01-01T00:00:00Z
 // 2021-01-01T00:00:00
 // 2021-01-01

--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -16,7 +16,7 @@ import { isValidDate } from "./common-helpers";
 // 2021-01-01T00:00:00
 // 2021-01-01
 export const isoDateRegex =
-  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?)?Z?$/;
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)?Z?$/;
 
 const zodDateInKind = "ZodDateIn";
 

--- a/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
@@ -39,7 +39,7 @@ exports[`Open API helpers depictDateIn should depict ZodDateIn 1`] = `
     "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",
   },
   "format": "date-time",
-  "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?)?Z?$",
+  "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?)?Z?$",
   "type": "string",
 }
 `;

--- a/tests/unit/__snapshots__/open-api.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api.spec.ts.snap
@@ -1868,7 +1868,7 @@ paths:
                       description: YYYY-MM-DDTHH:mm:ss.sssZ
                       type: string
                       format: date-time
-                      pattern: ^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?)?Z?$
+                      pattern: ^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?)?Z?$
                       externalDocs:
                         url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                   required:
@@ -2135,7 +2135,7 @@ paths:
                   description: YYYY-MM-DDTHH:mm:ss.sssZ
                   type: string
                   format: date-time
-                  pattern: ^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?)?Z?$
+                  pattern: ^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?)?Z?$
                   externalDocs:
                     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
               required:


### PR DESCRIPTION
A customer had trouble calling one of our API endpoints because their request client (Java Spring `RestTemplate`) generates ISO dates where the sub-second digits aren't (always?) three. Instead of `2022-12-09T08:50:35.830Z`, their library would submit `2022-12-09T08:50:35.83Z`. This caused our API to return a 400 error because the validation of the relevant `dateIn` would fail.

I updated the relevant regex to allow any number of digits which seems to be valid [according to this](https://www.w3.org/TR/NOTE-datetime#:~:text=one%20or%20more%20digits%20representing%20a%20decimal%20fraction%20of%20a%20second) and is parsed perfectly fine by `new Date()`.