### PR TITLE
Fix client-helpers `cleanId` function to properly clean the entire string

### DIFF
--- a/src/client-helpers.ts
+++ b/src/client-helpers.ts
@@ -200,7 +200,8 @@ export const cleanId = (path: string, method: string, suffix: string) => {
   return [method]
     .concat(path.split("/"))
     .concat(suffix)
-    .map((entry) => entry.replace(/[^A-Z0-9]/gi, ""))
+    .map((entry) => entry.split(/[^A-Z0-9]/gi))
+    .flat(1)
     .map(
       (entry) => entry.slice(0, 1).toUpperCase() + entry.slice(1).toLowerCase()
     )

--- a/src/client-helpers.ts
+++ b/src/client-helpers.ts
@@ -200,7 +200,7 @@ export const cleanId = (path: string, method: string, suffix: string) => {
   return [method]
     .concat(path.split("/"))
     .concat(suffix)
-    .map((entry) => entry.replace(/[^A-Z0-9]/i, ""))
+    .map((entry) => entry.replace(/[^A-Z0-9]/gi, ""))
     .map(
       (entry) => entry.slice(0, 1).toUpperCase() + entry.slice(1).toLowerCase()
     )

--- a/src/client-helpers.ts
+++ b/src/client-helpers.ts
@@ -200,8 +200,7 @@ export const cleanId = (path: string, method: string, suffix: string) => {
   return [method]
     .concat(path.split("/"))
     .concat(suffix)
-    .map((entry) => entry.split(/[^A-Z0-9]/gi))
-    .flat()
+    .flatMap((entry) => entry.split(/[^A-Z0-9]/gi))
     .map(
       (entry) => entry.slice(0, 1).toUpperCase() + entry.slice(1).toLowerCase()
     )

--- a/src/client-helpers.ts
+++ b/src/client-helpers.ts
@@ -201,7 +201,7 @@ export const cleanId = (path: string, method: string, suffix: string) => {
     .concat(path.split("/"))
     .concat(suffix)
     .map((entry) => entry.split(/[^A-Z0-9]/gi))
-    .flat(1)
+    .flat()
     .map(
       (entry) => entry.slice(0, 1).toUpperCase() + entry.slice(1).toLowerCase()
     )

--- a/tests/unit/__snapshots__/client.spec.ts.snap
+++ b/tests/unit/__snapshots__/client.spec.ts.snap
@@ -130,11 +130,11 @@ export class ExpressZodAPIClient {
 `;
 
 exports[`API Client Generator Should treat optionals the same way as z.infer() 1`] = `
-"type PostV1TestInput = {
+"type PostV1TestwithdashesInput = {
     opt?: string | undefined;
 };
 
-type PostV1TestResponse = {
+type PostV1TestwithdashesResponse = {
     status: "success";
     data: {
         similar?: number | undefined;
@@ -146,21 +146,21 @@ type PostV1TestResponse = {
     };
 };
 
-export type Path = "/v1/test";
+export type Path = "/v1/test-with-dashes";
 
 export type Method = "get" | "post" | "put" | "delete" | "patch";
 
 export type MethodPath = \`\${Method} \${Path}\`;
 
 export interface Input extends Record<MethodPath, any> {
-    "post /v1/test": PostV1TestInput;
+    "post /v1/test-with-dashes": PostV1TestwithdashesInput;
 }
 
 export interface Response extends Record<MethodPath, any> {
-    "post /v1/test": PostV1TestResponse;
+    "post /v1/test-with-dashes": PostV1TestwithdashesResponse;
 }
 
-export const jsonEndpoints = { "post /v1/test": true };
+export const jsonEndpoints = { "post /v1/test-with-dashes": true };
 
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 

--- a/tests/unit/__snapshots__/client.spec.ts.snap
+++ b/tests/unit/__snapshots__/client.spec.ts.snap
@@ -130,11 +130,11 @@ export class ExpressZodAPIClient {
 `;
 
 exports[`API Client Generator Should treat optionals the same way as z.infer() 1`] = `
-"type PostV1TestwithdashesInput = {
+"type PostV1TestWithDashesInput = {
     opt?: string | undefined;
 };
 
-type PostV1TestwithdashesResponse = {
+type PostV1TestWithDashesResponse = {
     status: "success";
     data: {
         similar?: number | undefined;
@@ -153,11 +153,11 @@ export type Method = "get" | "post" | "put" | "delete" | "patch";
 export type MethodPath = \`\${Method} \${Path}\`;
 
 export interface Input extends Record<MethodPath, any> {
-    "post /v1/test-with-dashes": PostV1TestwithdashesInput;
+    "post /v1/test-with-dashes": PostV1TestWithDashesInput;
 }
 
 export interface Response extends Record<MethodPath, any> {
-    "post /v1/test-with-dashes": PostV1TestwithdashesResponse;
+    "post /v1/test-with-dashes": PostV1TestWithDashesResponse;
 }
 
 export const jsonEndpoints = { "post /v1/test-with-dashes": true };

--- a/tests/unit/client.spec.ts
+++ b/tests/unit/client.spec.ts
@@ -10,7 +10,7 @@ describe("API Client Generator", () => {
   test("Should treat optionals the same way as z.infer()", () => {
     const client = new Client({
       v1: {
-        test: defaultEndpointsFactory.build({
+        "test-with-dashes": defaultEndpointsFactory.build({
           method: "post",
           input: z.object({
             opt: z.string().optional(),


### PR DESCRIPTION
The current function will only replace the first occurence of an invalid character. This fixes it to handle multiple invalid characters. Also, update the unit test for `client.ts` to exercise this code.

This resolves https://github.com/RobinTail/express-zod-api/issues/805