### PR TITLE
Custom response status

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -27,6 +27,7 @@ export type Handler<IN, OUT, OPT> = (params: {
   input: IN;
   options: OPT;
   logger: Logger;
+  positiveStatusCode: number;
 }) => Promise<OUT>;
 
 export abstract class AbstractEndpoint {
@@ -49,6 +50,7 @@ export abstract class AbstractEndpoint {
   public abstract getScopes(): string[];
   public abstract getTags(): string[];
   public abstract _setSiblingMethods(methods: Method[]): void;
+  public abstract getPositiveStatusCode(): number;
 }
 
 type EndpointProps<
@@ -205,6 +207,10 @@ export class Endpoint<
     return this.tags;
   }
 
+  public override getPositiveStatusCode(): number {
+    return this.resultHandler.positiveStatusCode ?? 200;
+  }
+
   #getDefaultCorsHeaders(): Record<string, string> {
     const accessMethods = (this.methods as Array<Method | AuxMethod>)
       .concat(this.siblingMethods)
@@ -290,6 +296,7 @@ export class Endpoint<
       input: (await this.inputSchema.parseAsync(input)) as z.output<IN>,
       options,
       logger,
+      positiveStatusCode: this.getPositiveStatusCode(),
     });
   }
 
@@ -316,6 +323,7 @@ export class Endpoint<
         response,
         logger,
         input,
+        positiveStatusCode: this.getPositiveStatusCode(),
       });
     } catch (e) {
       lastResortHandler({

--- a/src/open-api.ts
+++ b/src/open-api.ts
@@ -85,7 +85,7 @@ export class OpenAPI extends OpenApiBuilder {
       });
       const operation: OperationObject = {
         responses: {
-          "200": depictResponse({
+          [endpoint.getPositiveStatusCode()]: depictResponse({
             ...commonParams,
             description: successfulResponseDescription,
             isPositive: true,

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -20,6 +20,7 @@ interface ResultHandlerParams<RES> {
   request: Request;
   response: Response<RES>;
   logger: Logger;
+  positiveStatusCode: number;
 }
 
 type ResultHandler<RES> = (
@@ -30,6 +31,7 @@ export interface ResultHandlerDefinition<
   POS extends ApiResponse,
   NEG extends ApiResponse
 > {
+  positiveStatusCode?: number;
   getPositiveResponse: (output: IOSchema) => POS;
   getNegativeResponse: () => NEG;
   handler: ResultHandler<z.output<POS["schema"]> | z.output<NEG["schema"]>>;
@@ -76,9 +78,17 @@ export const defaultResultHandler = createResultHandler({
     });
     return createApiResponse(responseSchema);
   },
-  handler: ({ error, input, output, request, response, logger }) => {
+  handler: ({
+    error,
+    input,
+    output,
+    request,
+    response,
+    logger,
+    positiveStatusCode,
+  }) => {
     if (!error) {
-      response.status(200).json({
+      response.status(positiveStatusCode).json({
         status: "success" as const,
         data: output,
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ export const createParserFailureHandler =
       logger,
       input: request.body,
       output: null,
+      positiveStatusCode: 200,
     });
   };
 
@@ -44,6 +45,7 @@ export const createNotFoundHandler =
         error,
         input: null,
         output: null,
+        positiveStatusCode: 200,
       });
     } catch (e) {
       lastResortHandler({

--- a/tests/unit/__snapshots__/open-api.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api.spec.ts.snap
@@ -3082,3 +3082,79 @@ servers:
   - url: http://example.com
 "
 `;
+
+exports[`Open API generator should generate OpenAPI spec with custom response status 1`] = `
+"openapi: 3.0.0
+info:
+  title: Testing custom response status
+  version: 3.4.5
+paths:
+  "/v1/{name}":
+    post:
+      responses:
+        "201":
+          description: POST /v1/:name Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    type: object
+                    properties: {}
+                required:
+                  - status
+                  - data
+        "400":
+          description: POST /v1/:name Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+              examples:
+                example1:
+                  value:
+                    status: error
+                    error:
+                      message: Sample error message
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: POST /v1/:name request body
+              type: object
+              properties: {}
+components:
+  schemas: {}
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes: {}
+  links: {}
+  callbacks: {}
+tags: []
+servers:
+  - url: http://example.com
+"
+`;

--- a/tests/unit/__snapshots__/server.spec.ts.snap
+++ b/tests/unit/__snapshots__/server.spec.ts.snap
@@ -12,6 +12,7 @@ exports[`Server createNotFoundHandler() the handler should call ResultHandler wi
       "warn": [MockFunction],
     },
     "output": null,
+    "positiveStatusCode": 200,
     "request": {
       "body": {
         "n": 453,

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -113,6 +113,7 @@ describe("Endpoint", () => {
         input: { n: 453 },
         options: { inc: 454 },
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(loggerMock.error).toBeCalledTimes(0);
       expect(responseMock.status).toBeCalledWith(200);
@@ -797,6 +798,40 @@ describe("Endpoint", () => {
         ["date in endpoint handler", "object"],
       ]);
       expect(responseMock.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  test("should respond with custom status code", async () => {
+    const factory = new EndpointsFactory({
+      ...defaultResultHandler,
+      positiveStatusCode: 201,
+    });
+    const handlerMock = jest
+      .fn()
+      .mockImplementationOnce(async () => ({ answer: 42 }));
+    const endpoint = factory.build({
+      method: "post",
+      input: z.object({}),
+      output: z.object({ answer: z.number() }),
+      handler: handlerMock,
+    });
+
+    const { responseMock, loggerMock } = await testEndpoint({
+      endpoint,
+      requestProps: { method: "POST" },
+    });
+    expect(handlerMock).toBeCalledTimes(1);
+    expect(handlerMock).toBeCalledWith({
+      input: {},
+      options: {},
+      logger: loggerMock,
+      positiveStatusCode: 201,
+    });
+    expect(loggerMock.error).toBeCalledTimes(0);
+    expect(responseMock.status).toBeCalledWith(201);
+    expect(responseMock.json).toBeCalledWith({
+      status: "success",
+      data: { answer: 42 },
     });
   });
 });

--- a/tests/unit/open-api.spec.ts
+++ b/tests/unit/open-api.spec.ts
@@ -1,10 +1,12 @@
 import { config as exampleConfig } from "../../example/config";
 import { routing } from "../../example/routing";
 import {
+  EndpointsFactory,
   OpenAPI,
   createConfig,
   createMiddleware,
   defaultEndpointsFactory,
+  defaultResultHandler,
   withMeta,
   z,
 } from "../../src";
@@ -863,5 +865,28 @@ describe("Open API generator", () => {
       }).getSpecAsYaml();
       expect(spec).toMatchSnapshot();
     });
+  });
+
+  test("should generate OpenAPI spec with custom response status", () => {
+    const spec = new OpenAPI({
+      config: sampleConfig,
+      routing: {
+        v1: {
+          ":name": new EndpointsFactory({
+            ...defaultResultHandler,
+            positiveStatusCode: 201,
+          }).build({
+            method: "post",
+            input: z.object({}),
+            output: z.object({}),
+            handler: jest.fn(),
+          }),
+        },
+      },
+      version: "3.4.5",
+      title: "Testing custom response status",
+      serverUrl: "http://example.com",
+    }).getSpecAsYaml();
+    expect(spec).toMatchSnapshot();
   });
 });

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -33,6 +33,7 @@ describe("ResultHandler", () => {
         request: requestMock as Request,
         response: responseMock as Response,
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(loggerMock.error).toBeCalledTimes(1);
       expect(loggerMock.error.mock.calls[0][0]).toMatch(
@@ -75,6 +76,7 @@ describe("ResultHandler", () => {
         request: requestMock as Request,
         response: responseMock as Response,
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(loggerMock.error).toBeCalledTimes(0);
       expect(responseMock.status).toBeCalledWith(400);
@@ -93,6 +95,7 @@ describe("ResultHandler", () => {
         request: requestMock as Request,
         response: responseMock as Response,
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(loggerMock.error).toBeCalledTimes(0);
       expect(responseMock.status).toBeCalledWith(404);
@@ -116,6 +119,7 @@ describe("ResultHandler", () => {
         request: requestMock as Request,
         response: responseMock as Response,
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(loggerMock.error).toBeCalledTimes(0);
       expect(responseMock.status).toBeCalledWith(200);

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -376,6 +376,7 @@ describe("Routing", () => {
         },
         options: {},
         logger: loggerMock,
+        positiveStatusCode: 200,
       });
       expect(responseMock.status).toBeCalledWith(200);
       expect(responseMock.json).toBeCalledWith({


### PR DESCRIPTION
Related to #824 

This PR adds the ability to use custom response status in both `ResultHandler` and `OpenAPI` classes.

