### PR TITLE
For v10: Stop re-exporting `zod`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
   schedule:
     - cron: '26 8 * * 1'
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
   pull_request:
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
 
 jobs:
   build:

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -2,9 +2,9 @@ name: OpenAPI Validation
 
 on:
   push:
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
   pull_request:
-    branches: [ master, v8 ]
+    branches: [ master, v8, v10-beta ]
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ _In case you need to customize the response, see [Response customization](#respo
 ## Create your first endpoint
 
 ```typescript
-import { z } from "express-zod-api";
+import { z } from "zod";
 
 const helloWorldEndpoint = defaultEndpointsFactory.build({
   method: "get",

--- a/example/endpoints/retrieve-user.ts
+++ b/example/endpoints/retrieve-user.ts
@@ -1,4 +1,5 @@
-import { createHttpError, z } from "../../src";
+import { z } from "zod";
+import { createHttpError } from "../../src";
 import { taggedEndpointsFactory } from "../factories";
 import { methodProviderMiddleware } from "../middlewares";
 

--- a/example/endpoints/send-avatar.ts
+++ b/example/endpoints/send-avatar.ts
@@ -1,4 +1,4 @@
-import { z } from "../../src";
+import { z } from "zod";
 import { fileSendingEndpointsFactory } from "../factories";
 import fs from "fs";
 

--- a/example/endpoints/stream-avatar.ts
+++ b/example/endpoints/stream-avatar.ts
@@ -1,4 +1,4 @@
-import { z } from "../../src";
+import { z } from "zod";
 import { fileStreamingEndpointsFactory } from "../factories";
 
 export const streamAvatarEndpoint = fileStreamingEndpointsFactory.build({

--- a/example/endpoints/update-user.ts
+++ b/example/endpoints/update-user.ts
@@ -1,4 +1,5 @@
-import { createHttpError, ez, withMeta, z } from "../../src";
+import { z } from "zod";
+import { createHttpError, ez, withMeta } from "../../src";
 import { keyAndTokenAuthenticatedEndpointsFactory } from "../factories";
 
 export const updateUserEndpoint =

--- a/example/endpoints/upload-avatar.ts
+++ b/example/endpoints/upload-avatar.ts
@@ -1,4 +1,5 @@
-import { ez, z } from "../../src";
+import { z } from "zod";
+import { ez } from "../../src";
 import crypto from "crypto";
 import { taggedEndpointsFactory } from "../factories";
 

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -4,11 +4,11 @@ import {
   createResultHandler,
   defaultResultHandler,
   ez,
-  z,
 } from "../src";
 import { config } from "./config";
 import { authMiddleware } from "./middlewares";
 import fs from "fs";
+import { z } from "zod";
 
 export const taggedEndpointsFactory = new EndpointsFactory({
   resultHandler: defaultResultHandler,

--- a/example/middlewares.ts
+++ b/example/middlewares.ts
@@ -1,4 +1,5 @@
-import { Method, createHttpError, createMiddleware, withMeta, z } from "../src";
+import { z } from "zod";
+import { Method, createHttpError, createMiddleware, withMeta } from "../src";
 
 export const authMiddleware = createMiddleware({
   security: {

--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
     "ramda": "0.28.0",
     "triple-beam": "1.3.0",
     "typescript": "4.9.5",
-    "winston": "3.8.2",
-    "zod": "3.21.4"
+    "winston": "3.8.2"
   },
   "peerDependencies": {
     "@types/jest": "*",
     "jest": ">=25 <30",
-    "typescript": "^4.1"
+    "typescript": "^4.1",
+    "zod": "^3.21.4"
   },
   "peerDependenciesMeta": {
     "jest": {
@@ -99,7 +99,8 @@
     "strip-ansi": "^6.0.1",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.1",
-    "tsd": "^0.26.0"
+    "tsd": "^0.26.0",
+    "zod": "3.21.4"
   },
   "engines": {
     "node": "^14.17.0 || ^16.10.0 || ^18.0.0 || ^19.0.0"

--- a/src/ez-namespace.ts
+++ b/src/ez-namespace.ts
@@ -1,7 +1,7 @@
-import { ZodDateIn } from "./date-in-schema";
-import { ZodDateOut } from "./date-out-schema";
-import { ZodFile } from "./file-schema";
-import { ZodUpload } from "./upload-schema";
+import { ZodDateIn, ZodDateInDef } from "./date-in-schema";
+import { ZodDateOut, ZodDateOutDef } from "./date-out-schema";
+import { ZodFile, ZodFileDef } from "./file-schema";
+import { ZodUpload, ZodUploadDef } from "./upload-schema";
 
 export namespace ez {
   export const file = ZodFile.create;
@@ -9,3 +9,9 @@ export namespace ez {
   export const dateIn = ZodDateIn.create;
   export const dateOut = ZodDateOut.create;
 }
+
+export type ProprietaryKinds =
+  | ZodFileDef["typeName"]
+  | ZodUploadDef["typeName"]
+  | ZodDateInDef["typeName"]
+  | ZodDateOutDef["typeName"];

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,6 @@ export {
 export { withMeta } from "./metadata";
 export { testEndpoint } from "./mock";
 export { Client } from "./client";
-
-export { z } from "zod";
 export { ez } from "./ez-namespace";
 
 import createHttpError from "http-errors";

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,5 +1,5 @@
 import { combinations } from "./common-helpers";
-import { z } from "./index";
+import { z } from "zod";
 import { mergeDeepRight } from "ramda";
 
 export const metaProp = "expressZodApiMeta";

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import { ZodDateInDef } from "./date-in-schema";
-import { ZodDateOutDef } from "./date-out-schema";
-import { ZodFileDef } from "./file-schema";
-import { ZodUploadDef } from "./upload-schema";
+import { ProprietaryKinds } from "./ez-namespace";
 
 export type HandlingVariant = "last" | "regular";
 type VariantDependingProps<
@@ -30,12 +27,6 @@ export type SchemaHandler<
   Context extends object = {},
   Variant extends HandlingVariant = "regular"
 > = (params: SchemaHandlingProps<T, U, Context, Variant>) => U;
-
-type ProprietaryKinds =
-  | ZodFileDef["typeName"]
-  | ZodUploadDef["typeName"]
-  | ZodDateInDef["typeName"]
-  | ZodDateOutDef["typeName"];
 
 export type HandlingRules<U, Context extends object = {}> = Partial<
   Record<

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,5 @@
 import jestConfig from "../jest.config";
-import { z } from "../src";
+import { z } from "zod";
 import { SchemaHandler, walkSchema } from "../src/schema-walker";
 
 export const esmTestPort = 8070;

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import http from "http";
 import fetch from "node-fetch";
+import { z } from "zod";
 import {
   EndpointsFactory,
   Method,
@@ -8,7 +9,6 @@ import {
   createResultHandler,
   createServer,
   defaultResultHandler,
-  z,
 } from "../../src";
 import { waitFor } from "../helpers";
 

--- a/tests/unit/client.spec.ts
+++ b/tests/unit/client.spec.ts
@@ -1,5 +1,6 @@
+import { z } from "zod";
 import { routing } from "../../example/routing";
-import { Client, defaultEndpointsFactory, z } from "../../src";
+import { Client, defaultEndpointsFactory } from "../../src";
 
 describe("API Client Generator", () => {
   test("Should generate a client for example API", () => {

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -15,14 +15,9 @@ import {
   isValidDate,
   makeErrorFromAnything,
 } from "../../src/common-helpers";
-import {
-  InputValidationError,
-  createHttpError,
-  ez,
-  withMeta,
-  z,
-} from "../../src";
+import { InputValidationError, createHttpError, ez, withMeta } from "../../src";
 import { Request } from "express";
+import { z } from "zod";
 
 describe("Common Helpers", () => {
   describe("defaultInputSources", () => {

--- a/tests/unit/depends-on-method.spec.ts
+++ b/tests/unit/depends-on-method.spec.ts
@@ -1,8 +1,8 @@
+import { z } from "zod";
 import {
   DependsOnMethod,
   EndpointsFactory,
   defaultResultHandler,
-  z,
 } from "../../src";
 
 describe("DependsOnMethod", () => {

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   EndpointsFactory,
   createMiddleware,
@@ -6,7 +7,6 @@ import {
   defaultResultHandler,
   ez,
   testEndpoint,
-  z,
 } from "../../src";
 import { Endpoint } from "../../src/endpoint";
 import { IOSchemaError } from "../../src/errors";

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -5,11 +5,11 @@ import {
   EndpointsFactory,
   createMiddleware,
   createResultHandler,
-  z,
 } from "../../src";
 import { Endpoint } from "../../src/endpoint";
 import { expectType } from "tsd";
 import { serializeSchemaForTest } from "../helpers";
+import { z } from "zod";
 
 describe("EndpointsFactory", () => {
   /* eslint-disable @typescript-eslint/dot-notation */

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -1,5 +1,6 @@
 import { expectNotType, expectType } from "tsd";
-import { IOSchema, createMiddleware, withMeta, z } from "../../src";
+import { z } from "zod";
+import { IOSchema, createMiddleware, withMeta } from "../../src";
 import { getFinalEndpointInputSchema } from "../../src/io-schema";
 import { getMeta } from "../../src/metadata";
 import { AnyMiddlewareDef } from "../../src/middleware";

--- a/tests/unit/metadata.spec.ts
+++ b/tests/unit/metadata.spec.ts
@@ -1,4 +1,5 @@
-import { withMeta, z } from "../../src";
+import { z } from "zod";
+import { withMeta } from "../../src";
 import {
   MetaDef,
   copyMeta,

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,4 +1,5 @@
-import { createMiddleware, z } from "../../src";
+import { z } from "zod";
+import { createMiddleware } from "../../src";
 import { IOSchemaError } from "../../src/errors";
 
 describe("Middleware", () => {

--- a/tests/unit/mock.spec.ts
+++ b/tests/unit/mock.spec.ts
@@ -1,4 +1,5 @@
-import { defaultEndpointsFactory, testEndpoint, z } from "../../src";
+import { z } from "zod";
+import { defaultEndpointsFactory, testEndpoint } from "../../src";
 
 describe("Mock", () => {
   describe("testEndpoint()", () => {

--- a/tests/unit/open-api-helpers.spec.ts
+++ b/tests/unit/open-api-helpers.spec.ts
@@ -1,12 +1,7 @@
 import { SchemaObject } from "openapi3-ts";
+import { z } from "zod";
 import { IOSchemaError } from "../../src/errors";
-import {
-  OpenAPIError,
-  defaultEndpointsFactory,
-  ez,
-  withMeta,
-  z,
-} from "../../src/index";
+import { OpenAPIError, defaultEndpointsFactory, ez, withMeta } from "../../src";
 import { getMeta } from "../../src/metadata";
 import {
   OpenAPIContext,

--- a/tests/unit/open-api.spec.ts
+++ b/tests/unit/open-api.spec.ts
@@ -9,10 +9,10 @@ import {
   defaultEndpointsFactory,
   ez,
   withMeta,
-  z,
 } from "../../src";
 import { expectType } from "tsd";
 import { mimeJson } from "../../src/mime";
+import { z } from "zod";
 
 describe("Open API generator", () => {
   const sampleConfig = createConfig({

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from "express";
+import { z } from "zod";
 import {
   InputValidationError,
   createHttpError,
   defaultResultHandler,
   withMeta,
-  z,
 } from "../../src";
 import { metaProp } from "../../src/metadata";
 

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -8,13 +8,13 @@ jest.mock("express", () => ({
 
 import { Express, Request, RequestHandler, Response } from "express";
 import { Logger } from "winston";
+import { z } from "zod";
 import {
   DependsOnMethod,
   EndpointsFactory,
   Routing,
   ServeStatic,
   defaultResultHandler,
-  z,
 } from "../../src";
 import { CommonConfig } from "../../src/config-type";
 import { mimeJson } from "../../src/mime";

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -29,12 +29,12 @@ jest.mock("compression", () => compressionMock);
 import express, { Request, Response } from "express"; // express is mocked above
 import https from "https";
 import { Logger } from "winston";
+import { z } from "zod";
 import {
   EndpointsFactory,
   attachRouting,
   createServer,
   defaultResultHandler,
-  z,
 } from "../../src";
 import { AppConfig, CommonConfig, ServerConfig } from "../../src/config-type";
 import { mimeJson } from "../../src/mime";

--- a/tests/unit/zts.spec.ts
+++ b/tests/unit/zts.spec.ts
@@ -25,7 +25,7 @@
  */
 
 import ts from "typescript";
-import { z } from "../../src";
+import { z } from "zod";
 import { zodToTs } from "../../src/zts";
 import { createTypeAlias, printNode } from "../../src/zts-helpers";
 

--- a/tools/esm-test.ts
+++ b/tools/esm-test.ts
@@ -18,7 +18,8 @@ const packageJson = `
     "express-zod-api": "../../dist-esm",
     "ts-node": "10.9.1",
     "typescript": "4.9.4",
-    "@types/node": "*"
+    "@types/node": "*",
+    "zod": "^3.21.4"
   }
 }
 `;

--- a/tools/integration-test.ts
+++ b/tools/integration-test.ts
@@ -16,7 +16,8 @@ const packageJson = `
     "express-zod-api": "../../dist",
     "ts-node": "10.9.1",
     "typescript": "4.9.4",
-    "@types/node": "*"
+    "@types/node": "*",
+    "zod": "^3.21.4"
   }
 }
 `;


### PR DESCRIPTION
For v10, #864 