### PR TITLE
For v10: Make `express` peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/http-errors": "^2.0.0",
     "@types/node": "*",
     "compression": "1.7.4",
-    "express": "4.18.2",
     "express-fileupload": "1.4.0",
     "http-errors": "2.0.0",
     "mime": "3.0.0",
@@ -54,6 +53,7 @@
   },
   "peerDependencies": {
     "@types/jest": "*",
+    "express": "^4.18.2",
     "jest": ">=25 <30",
     "typescript": "^4.1",
     "zod": "^3.21.4"
@@ -88,6 +88,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "express": "4.18.2",
     "form-data": "^4.0.0",
     "has-ansi": "^4.0.1",
     "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@types/compression": "^1.7.2",
-    "@types/express": "^4.17.13",
     "@types/express-fileupload": "^1.2.2",
     "@types/http-errors": "^2.0.0",
     "@types/node": "*",
@@ -52,6 +51,7 @@
     "winston": "3.8.2"
   },
   "peerDependencies": {
+    "@types/express": "^4.17.13",
     "@types/jest": "*",
     "express": "^4.18.2",
     "jest": ">=25 <30",
@@ -59,10 +59,13 @@
     "zod": "^3.21.4"
   },
   "peerDependenciesMeta": {
-    "jest": {
+    "@types/express": {
       "optional": true
     },
     "@types/jest": {
+      "optional": true
+    },
+    "jest": {
       "optional": true
     },
     "typescript": {
@@ -72,6 +75,7 @@
   "devDependencies": {
     "@tsconfig/node14": "^1.0.3",
     "@types/cors": "^2.8.12",
+    "@types/express": "^4.17.13",
     "@types/has-ansi": "^5.0.0",
     "@types/jest": "^29.0.0",
     "@types/mime": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,9 +1505,9 @@ content-disposition@0.5.4:
     safe-buffer "5.2.1"
 
 content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"


### PR DESCRIPTION
For the `attachRouting` case, developer may have their own version of `express` installed, which may cause collisions.
Doing similar thing as #865 