### PR TITLE
For v10: Making `typescript` a dev and optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "openapi3-ts": "3.2.0",
     "ramda": "0.28.0",
     "triple-beam": "1.3.0",
-    "typescript": "4.9.5",
     "winston": "3.8.2"
   },
   "peerDependencies": {
@@ -105,6 +104,7 @@
     "ts-jest": "^29.0.0",
     "ts-node": "^10.9.1",
     "tsd": "^0.26.0",
+    "typescript": "4.9.5",
     "zod": "3.21.4"
   },
   "engines": {


### PR DESCRIPTION
Typescript is only required for generating a client, the version may collide with the developer's local one.