### PR TITLE
OpenAPI fix: avoid `nullable` when `type` is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Version 10
 
+### v10.1.1
+
+- Fixed issue #900, found and reported by [Max Cohn](https://github.com/maxcohn).
+  - Do not set `nullable` property to the depictions having no `type` property according to OpenAPI specification.
+  - Affected schemas: `z.any()` and `z.preprocess()`.
+
+```yaml
+# depiction of z.any() in the generated documentation
+before:
+  format: any
+  nullable: true
+after:
+  format: any
+```
+
 ### v10.1.0
 
 - Feature #876: Supporting `z.lazy()` (including circular schemas) for the client generator.

--- a/example/example.swagger.yaml
+++ b/example/example.swagger.yaml
@@ -306,7 +306,6 @@ paths:
                         type: object
                         additionalProperties:
                           format: any
-                          nullable: true
                     required:
                       - name
                       - size

--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -691,14 +691,14 @@ export const depicters: HandlingRules<
 export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
   schema,
   isResponse,
-  current,
+  prev,
 }) => {
-  if (isReferenceObject(current)) {
+  if (isReferenceObject(prev)) {
     return {};
   }
   const { description } = schema;
   const shouldAvoidParsing = schema instanceof z.ZodLazy;
-  const hasTypePropertyInDepiction = current.type !== undefined;
+  const hasTypePropertyInDepiction = prev.type !== undefined;
   const isResponseHavingCoercion = isResponse && hasCoercion(schema);
   const isActuallyNullable =
     !shouldAvoidParsing &&

--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -697,13 +697,16 @@ export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
   const shouldAvoidParsing = schema instanceof z.ZodLazy;
   const hasTypePropertyInDepiction =
     isSchemaObject(current) && current.type !== undefined;
+  const isResponseHavingCoercion = isResponse && hasCoercion(schema);
+  const isActuallyNullable =
+    !shouldAvoidParsing &&
+    hasTypePropertyInDepiction &&
+    !isResponseHavingCoercion &&
+    schema.isNullable();
   const examples = shouldAvoidParsing ? [] : getExamples(schema, isResponse);
   return {
     ...(description && { description }),
-    ...(!shouldAvoidParsing &&
-      hasTypePropertyInDepiction &&
-      schema.isNullable() &&
-      !(isResponse && hasCoercion(schema)) && { nullable: true }),
+    ...(isActuallyNullable && { nullable: true }),
     ...(examples.length > 0 && { example: examples[0] }),
   };
 };

--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -693,10 +693,12 @@ export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
   isResponse,
   current,
 }) => {
+  if (isReferenceObject(current)) {
+    return {};
+  }
   const { description } = schema;
   const shouldAvoidParsing = schema instanceof z.ZodLazy;
-  const hasTypePropertyInDepiction =
-    isSchemaObject(current) && current.type !== undefined;
+  const hasTypePropertyInDepiction = current.type !== undefined;
   const isResponseHavingCoercion = isResponse && hasCoercion(schema);
   const isActuallyNullable =
     !shouldAvoidParsing &&

--- a/src/open-api-helpers.ts
+++ b/src/open-api-helpers.ts
@@ -688,16 +688,20 @@ export const depicters: HandlingRules<
   ZodLazy: depictLazy,
 };
 
-export const onEach: Depicter<z.ZodTypeAny, "last"> = ({
+export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
   schema,
   isResponse,
+  current,
 }) => {
   const { description } = schema;
   const shouldAvoidParsing = schema instanceof z.ZodLazy;
+  const hasTypePropertyInDepiction =
+    isSchemaObject(current) && current.type !== undefined;
   const examples = shouldAvoidParsing ? [] : getExamples(schema, isResponse);
   return {
     ...(description && { description }),
     ...(!shouldAvoidParsing &&
+      hasTypePropertyInDepiction &&
       schema.isNullable() &&
       !(isResponse && hasCoercion(schema)) && { nullable: true }),
     ...(examples.length > 0 && { example: examples[0] }),

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 import { ProprietaryKinds } from "./ez-namespace";
 
-export type HandlingVariant = "last" | "regular";
+export type HandlingVariant = "last" | "regular" | "each";
 type VariantDependingProps<
   Variant extends HandlingVariant,
   U
 > = Variant extends "regular"
-  ? {
-      next: SchemaHandler<z.ZodTypeAny, U, {}, "last">;
-    }
+  ? { next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> }
+  : Variant extends "each"
+  ? { current: U }
   : {};
 
 type SchemaHandlingProps<
@@ -42,7 +42,7 @@ export const walkSchema = <U, Context extends object = {}>({
   onMissing,
   ...context
 }: SchemaHandlingProps<z.ZodTypeAny, U, Context, "last"> & {
-  onEach?: SchemaHandler<z.ZodTypeAny, U, Context & { current: U }, "last">;
+  onEach?: SchemaHandler<z.ZodTypeAny, U, Context, "each">;
   rules: HandlingRules<U, Context>;
   onMissing: (schema: z.ZodTypeAny) => U;
 }): U => {

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -2,13 +2,14 @@ import { z } from "zod";
 import { ProprietaryKinds } from "./ez-namespace";
 
 export type HandlingVariant = "last" | "regular" | "each";
+
 type VariantDependingProps<
   Variant extends HandlingVariant,
   U
 > = Variant extends "regular"
   ? { next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> }
   : Variant extends "each"
-  ? { current: U }
+  ? { prev: U }
   : {};
 
 type SchemaHandlingProps<
@@ -42,6 +43,7 @@ export const walkSchema = <U, Context extends object = {}>({
   onMissing,
   ...context
 }: SchemaHandlingProps<z.ZodTypeAny, U, Context, "last"> & {
+  /** @since 10.1.1 calling onEach _after_ handler and giving it its result */
   onEach?: SchemaHandler<z.ZodTypeAny, U, Context, "each">;
   rules: HandlingRules<U, Context>;
   onMissing: (schema: z.ZodTypeAny) => U;
@@ -66,6 +68,6 @@ export const walkSchema = <U, Context extends object = {}>({
       })
     : onMissing(schema);
   const overrides =
-    onEach && onEach({ schema, current: result, ...(context as Context) });
+    onEach && onEach({ schema, prev: result, ...(context as Context) });
   return overrides ? { ...result, ...overrides } : result;
 };

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -42,11 +42,10 @@ export const walkSchema = <U, Context extends object = {}>({
   onMissing,
   ...context
 }: SchemaHandlingProps<z.ZodTypeAny, U, Context, "last"> & {
-  onEach?: SchemaHandler<z.ZodTypeAny, U, Context, "last">;
+  onEach?: SchemaHandler<z.ZodTypeAny, U, Context & { current: U }, "last">;
   rules: HandlingRules<U, Context>;
   onMissing: (schema: z.ZodTypeAny) => U;
 }): U => {
-  const overrides = onEach && onEach({ schema, ...(context as Context) });
   const handler =
     "typeName" in schema._def
       ? rules[schema._def.typeName as keyof typeof rules]
@@ -66,5 +65,7 @@ export const walkSchema = <U, Context extends object = {}>({
         next,
       })
     : onMissing(schema);
+  const overrides =
+    onEach && onEach({ schema, current: result, ...(context as Context) });
   return overrides ? { ...result, ...overrides } : result;
 };

--- a/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
@@ -590,7 +590,7 @@ exports[`Open API helpers depictPipeline should depict as string (in) 1`] = `
 }
 `;
 
-exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 1`] = `
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 0 1`] = `
 {
   "additionalProperties": {
     "type": "boolean",
@@ -599,7 +599,7 @@ exports[`Open API helpers depictRecord() should set properties+required or addit
 }
 `;
 
-exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 2`] = `
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 1 1`] = `
 {
   "additionalProperties": {
     "type": "boolean",
@@ -608,7 +608,7 @@ exports[`Open API helpers depictRecord() should set properties+required or addit
 }
 `;
 
-exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 3`] = `
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 2 1`] = `
 {
   "properties": {
     "one": {
@@ -626,7 +626,7 @@ exports[`Open API helpers depictRecord() should set properties+required or addit
 }
 `;
 
-exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 4`] = `
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 3 1`] = `
 {
   "properties": {
     "testing": {
@@ -640,7 +640,7 @@ exports[`Open API helpers depictRecord() should set properties+required or addit
 }
 `;
 
-exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 5`] = `
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 4 1`] = `
 {
   "properties": {
     "one": {
@@ -654,6 +654,15 @@ exports[`Open API helpers depictRecord() should set properties+required or addit
     "one",
     "two",
   ],
+  "type": "object",
+}
+`;
+
+exports[`Open API helpers depictRecord() should set properties+required or additionalProperties props 5 1`] = `
+{
+  "additionalProperties": {
+    "format": "any",
+  },
   "type": "object",
 }
 `;

--- a/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api-helpers.spec.ts.snap
@@ -89,7 +89,6 @@ exports[`Open API helpers depictDiscriminatedUnion() should wrap next depicters 
       "properties": {
         "data": {
           "format": "any",
-          "nullable": true,
         },
         "status": {
           "enum": [
@@ -168,14 +167,12 @@ exports[`Open API helpers depictEffect() should depict as string (preprocess) 1`
 exports[`Open API helpers depictEffect() should handle edge cases 1`] = `
 {
   "format": "any",
-  "nullable": true,
 }
 `;
 
 exports[`Open API helpers depictEffect() should handle edge cases 2`] = `
 {
   "format": "any",
-  "nullable": true,
 }
 `;
 

--- a/tests/unit/__snapshots__/open-api.spec.ts.snap
+++ b/tests/unit/__snapshots__/open-api.spec.ts.snap
@@ -1615,7 +1615,6 @@ paths:
                               - success
                           data:
                             format: any
-                            nullable: true
                         required:
                           - status
                       - type: object
@@ -2362,7 +2361,6 @@ paths:
                         type: object
                         additionalProperties:
                           format: any
-                          nullable: true
                     required:
                       - name
                       - size
@@ -2828,7 +2826,6 @@ components:
               type: object
               additionalProperties:
                 format: any
-                nullable: true
           required:
             - name
             - size
@@ -3918,7 +3915,6 @@ paths:
                     properties:
                       any:
                         format: any
-                        nullable: true
                 required:
                   - status
                   - data
@@ -3956,7 +3952,6 @@ paths:
           description: GET /v1/getSomething parameter
           schema:
             format: any
-            nullable: true
 components:
   schemas: {}
   responses: {}
@@ -4037,7 +4032,6 @@ paths:
           description: GET /v1/getSomething parameter
           schema:
             format: string (preprocessed)
-            nullable: true
         - name: number
           in: query
           required: true

--- a/tests/unit/open-api-helpers.spec.ts
+++ b/tests/unit/open-api-helpers.spec.ts
@@ -496,8 +496,9 @@ describe("Open API helpers", () => {
       z.record(z.enum(["one", "two"]), z.boolean()),
       z.record(z.literal("testing"), z.boolean()),
       z.record(z.literal("one").or(z.literal("two")), z.boolean()),
+      z.record(z.any()), // Issue #900
     ])(
-      "should set properties+required or additionalProperties props",
+      "should set properties+required or additionalProperties props %#",
       (schema) => {
         expect(
           depictRecord({


### PR DESCRIPTION
Closes #900 