### PR TITLE
export getMeta

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export {
   OutputValidationError,
   InputValidationError,
 } from "./errors";
-export { withMeta } from "./metadata";
+export { getMeta, withMeta } from "./metadata";
 export { testEndpoint } from "./mock";
 export { Integration } from "./integration";
 


### PR DESCRIPTION
hello!
I was trying to follow through https://ez.robintail.cz/v11.1.1/response-customization
and it seems that I can't continue due to `getMeta` not being exported.

this PR is a quick fix for that