### PR TITLE
Adding `setHeader`, `header` and `send` methods to mocked response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 11
 
+### v11.5.0
+
+- The following methods added to the mocked `response` object for `testEndpoint()` method:
+  - `send`, `setHeader`, `header`.
+
 ### v11.4.0
 
 - Supporting `z.readonly()` of `zod` v3.22.

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -31,19 +31,25 @@ export const makeResponseMock = <RES>(responseProps?: RES) => {
       writableEnded: boolean;
       statusCode: number;
       statusMessage: string;
-    } & Record<"set" | "status" | "json" | "end", jest.Mock> &
+    } & Record<
+      "set" | "setHeader" | "header" | "status" | "json" | "send" | "end",
+      jest.Mock
+    > &
       (RES extends undefined ? {} : RES)
   >{
     writableEnded: false,
     statusCode: 200,
     statusMessage: http.STATUS_CODES[200],
     set: jest.fn(() => responseMock),
+    setHeader: jest.fn(() => responseMock),
+    header: jest.fn(() => responseMock),
     status: jest.fn((code: number) => {
       responseMock.statusCode = code;
       responseMock.statusMessage = http.STATUS_CODES[code]!;
       return responseMock;
     }),
     json: jest.fn(() => responseMock),
+    send: jest.fn(() => responseMock),
     end: jest.fn(() => {
       responseMock.writableEnded = true;
       return responseMock;

--- a/tests/unit/mock.spec.ts
+++ b/tests/unit/mock.spec.ts
@@ -1,8 +1,43 @@
 import { z } from "zod";
-import { defaultEndpointsFactory, testEndpoint } from "../../src";
+import {
+  createMiddleware,
+  defaultEndpointsFactory,
+  testEndpoint,
+} from "../../src";
 
 describe("Mock", () => {
   describe("testEndpoint()", () => {
+    test("Should test the endpoint", async () => {
+      const endpoint = defaultEndpointsFactory
+        .addMiddleware(
+          createMiddleware({
+            input: z.object({}),
+            middleware: async ({ response }) => {
+              response
+                .setHeader("X-Some", "header")
+                .header("X-Another", "header as well")
+                .send("this is just for testing mocked methods");
+              return {};
+            },
+          }),
+        )
+        .build({
+          method: "get",
+          input: z.object({}),
+          output: z.object({}),
+          handler: async () => ({}),
+        });
+      const { responseMock } = await testEndpoint({ endpoint });
+      expect(responseMock.setHeader).toHaveBeenCalledWith("X-Some", "header");
+      expect(responseMock.header).toHaveBeenCalledWith(
+        "X-Another",
+        "header as well",
+      );
+      expect(responseMock.send).toHaveBeenCalledWith(
+        "this is just for testing mocked methods",
+      );
+    });
+
     test("Should throw an error in case Jest is not installed", async () => {
       const endpoint = defaultEndpointsFactory.build({
         method: "get",


### PR DESCRIPTION
Hopefully closes #1067 