### PR TITLE
`endpointTags` in the generated client.

### DIFF
--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -117,6 +117,14 @@ export const jsonEndpoints = {
   "post /v1/avatar/upload": true,
 };
 
+export const endpointTags = {
+  "get /v1/user/retrieve": [],
+  "post /v1/user/:id": [],
+  "get /v1/avatar/send": [],
+  "get /v1/avatar/stream": [],
+  "post /v1/avatar/upload": [],
+};
+
 export type Provider = <M extends Method, P extends Path>(
   method: M,
   path: P,

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -118,11 +118,11 @@ export const jsonEndpoints = {
 };
 
 export const endpointTags = {
-  "get /v1/user/retrieve": [],
-  "post /v1/user/:id": [],
-  "get /v1/avatar/send": [],
-  "get /v1/avatar/stream": [],
-  "post /v1/avatar/upload": [],
+  "get /v1/user/retrieve": ["users"],
+  "post /v1/user/:id": ["users"],
+  "get /v1/avatar/send": ["files", "users"],
+  "get /v1/avatar/stream": ["users", "files"],
+  "post /v1/avatar/upload": ["files"],
 };
 
 export type Provider = <M extends Method, P extends Path>(

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -32,7 +32,10 @@ import { zodToTs } from "./zts";
 import { createTypeAlias, printNode } from "./zts-helpers";
 
 interface Registry {
-  [METHOD_PATH: string]: Record<"in" | "out", string> & { isJson: boolean };
+  [METHOD_PATH: string]: Record<"in" | "out", string> & {
+    isJson: boolean;
+    tags: string[];
+  };
 }
 
 interface IntegrationParams {
@@ -121,6 +124,7 @@ export class Integration {
             in: inputId,
             out: responseId,
             isJson: endpoint.getMimeTypes("positive").includes(mimeJson),
+            tags: endpoint.getTags(),
           };
         }
       },
@@ -189,12 +193,15 @@ export class Integration {
       makeConst(
         "endpointTags",
         f.createObjectLiteralExpression(
-          Object.keys(this.registry).map((methodPath) =>
-            f.createPropertyAssignment(
+          Object.keys(this.registry).map((methodPath) => {
+            const tags = this.registry[methodPath].tags.map((tag) =>
+              f.createStringLiteral(tag),
+            );
+            return f.createPropertyAssignment(
               `"${methodPath}"`,
-              f.createArrayLiteralExpression(),
-            ),
-          ),
+              f.createArrayLiteralExpression(tags),
+            );
+          }),
         ),
       ),
     );

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -193,15 +193,16 @@ export class Integration {
       makeConst(
         "endpointTags",
         f.createObjectLiteralExpression(
-          Object.keys(this.registry).map((methodPath) => {
-            const tags = this.registry[methodPath].tags.map((tag) =>
-              f.createStringLiteral(tag),
-            );
-            return f.createPropertyAssignment(
+          Object.keys(this.registry).map((methodPath) =>
+            f.createPropertyAssignment(
               `"${methodPath}"`,
-              f.createArrayLiteralExpression(tags),
-            );
-          }),
+              f.createArrayLiteralExpression(
+                this.registry[methodPath].tags.map((tag) =>
+                  f.createStringLiteral(tag),
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -184,6 +184,21 @@ export class Integration {
       ),
     );
 
+    const endpointTagsNode = f.createVariableStatement(
+      exportModifier,
+      makeConst(
+        "endpointTags",
+        f.createObjectLiteralExpression(
+          Object.keys(this.registry).map((methodPath) =>
+            f.createPropertyAssignment(
+              `"${methodPath}"`,
+              f.createArrayLiteralExpression(),
+            ),
+          ),
+        ),
+      ),
+    );
+
     const providerNode = makePublicType(
       "Provider",
       f.createFunctionTypeNode(
@@ -327,6 +342,7 @@ export class Integration {
 
     this.agg.push(
       jsonEndpointsNode,
+      endpointTagsNode,
       providerNode,
       implementationNode,
       clientNode,

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -33,6 +33,8 @@ export interface Response extends Record<MethodPath, any> {
 
 export const jsonEndpoints = { "post /v1/test-with-dashes": true };
 
+export const endpointTags = { "post /v1/test-with-dashes": [] };
+
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 
 export type Implementation = (method: Method, path: string, params: Record<string, any>) => Promise<any>;
@@ -98,6 +100,8 @@ export interface Response extends Record<MethodPath, any> {
 
 export const jsonEndpoints = { "post /v1/test-with-dashes": true };
 
+export const endpointTags = { "post /v1/test-with-dashes": [] };
+
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 
 export type Implementation = (method: Method, path: string, params: Record<string, any>) => Promise<any>;
@@ -162,6 +166,8 @@ export interface Response extends Record<MethodPath, any> {
 }
 
 export const jsonEndpoints = { "post /v1/test-with-dashes": true };
+
+export const endpointTags = { "post /v1/test-with-dashes": [] };
 
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 
@@ -299,6 +305,8 @@ export interface Response extends Record<MethodPath, any> {
 }
 
 export const jsonEndpoints = { "get /v1/user/retrieve": true, "post /v1/user/:id": true, "post /v1/avatar/upload": true };
+
+export const endpointTags = { "get /v1/user/retrieve": [], "post /v1/user/:id": [], "get /v1/avatar/send": [], "get /v1/avatar/stream": [], "post /v1/avatar/upload": [] };
 
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 
@@ -468,6 +476,8 @@ export interface Response extends Record<MethodPath, any> {
 }
 
 export const jsonEndpoints = { "post /v1/test-with-dashes": true };
+
+export const endpointTags = { "post /v1/test-with-dashes": [] };
 
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -306,7 +306,7 @@ export interface Response extends Record<MethodPath, any> {
 
 export const jsonEndpoints = { "get /v1/user/retrieve": true, "post /v1/user/:id": true, "post /v1/avatar/upload": true };
 
-export const endpointTags = { "get /v1/user/retrieve": [], "post /v1/user/:id": [], "get /v1/avatar/send": [], "get /v1/avatar/stream": [], "post /v1/avatar/upload": [] };
+export const endpointTags = { "get /v1/user/retrieve": ["users"], "post /v1/user/:id": ["users"], "get /v1/avatar/send": ["files", "users"], "get /v1/avatar/stream": ["users", "files"], "post /v1/avatar/upload": ["files"] };
 
 export type Provider = <M extends Method, P extends Path>(method: M, path: P, params: Input[\`\${M} \${P}\`]) => Promise<Response[\`\${M} \${P}\`]>;
 


### PR DESCRIPTION
According to discussion #1079 

### The result

```ts
export const endpointTags = {
  "get /v1/user/retrieve": ["users"],
  "post /v1/user/:id": ["users"],
  "get /v1/avatar/send": ["files", "users"],
  "get /v1/avatar/stream": ["users", "files"],
  "post /v1/avatar/upload": ["files"],
};
```
