### PR TITLE
Fix type of `arrayResultHandler`

### DIFF
--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -276,7 +276,7 @@ export const tryToTransform = ({
   effect,
   sample,
 }: {
-  effect: z.Effect<any> & { type: "transform" };
+  effect: z.TransformEffect<any>;
   sample: any;
 }) => {
   try {

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -9,17 +9,13 @@ type Refined<T extends z.ZodTypeAny> = T extends z.ZodType<infer O>
 /**
  * @desc The type allowed on the top level of Middlewares and Endpoints
  * @param U — only "strip" is allowed for Middlewares due to intersection issue (Zod) #600
- * @param S — the shape of the object which IOSchema is based on
  * */
-export type IOSchema<
-  U extends z.UnknownKeysParam = any,
-  S extends z.ZodRawShape = any,
-> =
-  | z.ZodObject<S, U>
-  | z.ZodUnion<[IOSchema<U, S>, ...IOSchema<U, S>[]]>
-  | z.ZodIntersection<IOSchema<U, S>, IOSchema<U, S>>
-  | z.ZodDiscriminatedUnion<string, z.ZodObject<S, U>[]>
-  | Refined<z.ZodObject<S, U>>;
+export type IOSchema<U extends z.UnknownKeysParam = any> =
+  | z.ZodObject<any, U>
+  | z.ZodUnion<[IOSchema<U>, ...IOSchema<U>[]]>
+  | z.ZodIntersection<IOSchema<U>, IOSchema<U>>
+  | z.ZodDiscriminatedUnion<string, z.ZodObject<any, U>[]>
+  | Refined<z.ZodObject<any, U>>;
 
 export type ProbableIntersection<
   A extends IOSchema<"strip"> | null,

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -1,4 +1,4 @@
-import { UnknownKeysParam, z } from "zod";
+import { z } from "zod";
 import { copyMeta } from "./metadata";
 import { AnyMiddlewareDef } from "./middleware";
 
@@ -12,7 +12,7 @@ type Refined<T extends z.ZodTypeAny> = T extends z.ZodType<infer O>
  * @param S — the shape of the object which IOSchema is based on
  * */
 export type IOSchema<
-  U extends UnknownKeysParam = any,
+  U extends z.UnknownKeysParam = any,
   S extends z.ZodRawShape = any,
 > =
   | z.ZodObject<S, U>

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -1,9 +1,6 @@
-import { z } from "zod";
+import { UnknownKeysParam, z } from "zod";
 import { copyMeta } from "./metadata";
 import { AnyMiddlewareDef } from "./middleware";
-
-// the copy of the private Zod utility type of ZodObject
-type UnknownKeysParam = "passthrough" | "strict" | "strip";
 
 type Refined<T extends z.ZodTypeAny> = T extends z.ZodType<infer O>
   ? z.ZodEffects<T | Refined<T>, O, O>

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -12,13 +12,17 @@ type Refined<T extends z.ZodTypeAny> = T extends z.ZodType<infer O>
 /**
  * @desc The type allowed on the top level of Middlewares and Endpoints
  * @param U — only "strip" is allowed for Middlewares due to intersection issue (Zod) #600
+ * @param S — the shape of the object which IOSchema is based on
  * */
-export type IOSchema<U extends UnknownKeysParam = any> =
-  | z.ZodObject<any, U>
-  | z.ZodUnion<[IOSchema<U>, ...IOSchema<U>[]]>
-  | z.ZodIntersection<IOSchema<U>, IOSchema<U>>
-  | z.ZodDiscriminatedUnion<string, z.ZodObject<any, U>[]>
-  | Refined<z.ZodObject<any, U>>;
+export type IOSchema<
+  U extends UnknownKeysParam = any,
+  S extends z.ZodRawShape = any,
+> =
+  | z.ZodObject<S, U>
+  | z.ZodUnion<[IOSchema<U, S>, ...IOSchema<U, S>[]]>
+  | z.ZodIntersection<IOSchema<U, S>, IOSchema<U, S>>
+  | z.ZodDiscriminatedUnion<string, z.ZodObject<S, U>[]>
+  | Refined<z.ZodObject<S, U>>;
 
 export type ProbableIntersection<
   A extends IOSchema<"strip"> | null,

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -35,9 +35,7 @@ export interface ResultHandlerDefinition<
   POS extends z.ZodTypeAny,
   NEG extends z.ZodTypeAny,
 > {
-  getPositiveResponse: <T extends IOSchema>(
-    output: T,
-  ) => POS | ApiResponse<POS>;
+  getPositiveResponse: (output: IOSchema) => POS | ApiResponse<POS>;
   getNegativeResponse: () => NEG | ApiResponse<NEG>;
   handler: ResultHandler<z.output<POS> | z.output<NEG>>;
 }
@@ -110,16 +108,14 @@ export const defaultResultHandler = createResultHandler({
  * @desc This handler expects your endpoint to have the property 'items' in the output object schema
  * */
 export const arrayResultHandler = createResultHandler({
-  getPositiveResponse: <S extends { items: z.ZodArray<any> }>(
-    output: IOSchema<any, S>,
-  ) => {
+  getPositiveResponse: (output) => {
     // Examples are taken for proxying: no validation needed for this
     const examples = getExamples({ schema: output });
     const responseSchema = withMeta(
       "shape" in output &&
         "items" in output.shape &&
         output.shape.items instanceof z.ZodArray
-        ? output.shape.items
+        ? (output.shape.items as z.ZodArray<any>)
         : z.array(z.any()),
     );
     return examples.reduce<typeof responseSchema>(

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -115,12 +115,15 @@ export const arrayResultHandler = createResultHandler({
       "shape" in output &&
         "items" in output.shape &&
         output.shape.items instanceof z.ZodArray
-        ? output.shape.items
+        ? (output.shape.items as z.ZodArray<any>)
         : z.array(z.any()),
     );
     return examples.reduce<typeof responseSchema>(
       (acc, example) =>
-        typeof example === "object" && example !== null && "items" in example
+        typeof example === "object" &&
+        example !== null &&
+        "items" in example &&
+        Array.isArray(example.items)
           ? acc.example(example.items)
           : acc,
       responseSchema,

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -35,7 +35,9 @@ export interface ResultHandlerDefinition<
   POS extends z.ZodTypeAny,
   NEG extends z.ZodTypeAny,
 > {
-  getPositiveResponse: (output: IOSchema) => POS | ApiResponse<POS>;
+  getPositiveResponse: <T extends IOSchema>(
+    output: T,
+  ) => POS | ApiResponse<POS>;
   getNegativeResponse: () => NEG | ApiResponse<NEG>;
   handler: ResultHandler<z.output<POS> | z.output<NEG>>;
 }
@@ -108,14 +110,16 @@ export const defaultResultHandler = createResultHandler({
  * @desc This handler expects your endpoint to have the property 'items' in the output object schema
  * */
 export const arrayResultHandler = createResultHandler({
-  getPositiveResponse: (output) => {
+  getPositiveResponse: <S extends { items: z.ZodArray<any> }>(
+    output: IOSchema<any, S>,
+  ) => {
     // Examples are taken for proxying: no validation needed for this
     const examples = getExamples({ schema: output });
     const responseSchema = withMeta(
       "shape" in output &&
         "items" in output.shape &&
         output.shape.items instanceof z.ZodArray
-        ? (output.shape.items as z.ZodArray<any>)
+        ? output.shape.items
         : z.array(z.any()),
     );
     return examples.reduce<typeof responseSchema>(

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -18,17 +18,6 @@ describe("I/O Schema and related helpers", () => {
     test("respects the UnknownKeys type argument", () => {
       expectNotType<IOSchema<"passthrough">>(z.object({}));
     });
-    test("respects the Shape type argument", () => {
-      expectType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
-        z.object({ items: z.array(z.string()) }),
-      );
-      expectNotType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
-        z.object({ items: z.array(z.any()) }),
-      );
-      expectNotType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
-        z.object({ items: z.any() }),
-      );
-    });
     test("accepts union of objects", () => {
       expectType<IOSchema>(z.union([z.object({}), z.object({})]));
       expectType<IOSchema>(z.object({}).or(z.object({})));

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -18,6 +18,17 @@ describe("I/O Schema and related helpers", () => {
     test("respects the UnknownKeys type argument", () => {
       expectNotType<IOSchema<"passthrough">>(z.object({}));
     });
+    test("respects the Shape type argument", () => {
+      expectType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
+        z.object({ items: z.array(z.string()) }),
+      );
+      expectNotType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
+        z.object({ items: z.array(z.any()) }),
+      );
+      expectNotType<IOSchema<"strip", { items: z.ZodArray<z.ZodString> }>>(
+        z.object({ items: z.any() }),
+      );
+    });
     test("accepts union of objects", () => {
       expectType<IOSchema>(z.union([z.object({}), z.object({})]));
       expectType<IOSchema>(z.object({}).or(z.object({})));


### PR DESCRIPTION
I noticed that currently it's compiled this way in DTS:

```ts
declare const arrayResultHandler: ResultHandlerDefinition<any, z.ZodString & {
    _def: z.ZodStringDef & MetaDef<z.ZodString>;
    example: (example: string) => z.ZodString & any;
}>;
```

After this improvement:

```ts
declare const arrayEndpointsFactory: EndpointsFactory<z.ZodArray<any, "many"> & {
    _def: z.ZodArrayDef<any> & MetaDef<z.ZodArray<any, "many">>;
    example: (example: any[]) => z.ZodArray<any, "many"> & any;
}, z.ZodString & {
    _def: z.ZodStringDef & MetaDef<z.ZodString>;
    example: (example: string) => z.ZodString & any;
}, null, {}, string, string>;
```