### PR TITLE
Improving types: avoiding `any`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "unicorn"
   ],
   "rules": {
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/lines-between-class-members": "off",
     "sort-imports": ["warn", {
       "ignoreDeclarationSort": true

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -35,7 +35,7 @@ export const fileSendingEndpointsFactory = new EndpointsFactory({
         response.status(400).send(error.message);
         return;
       }
-      if ("data" in output) {
+      if (output && "data" in output && typeof output.data === "string") {
         response.type("svg").send(output.data);
       } else {
         response.status(400).send("Data is missing");
@@ -60,7 +60,11 @@ export const fileStreamingEndpointsFactory = new EndpointsFactory({
         response.status(400).send(error.message);
         return;
       }
-      if ("filename" in output) {
+      if (
+        output &&
+        "filename" in output &&
+        typeof output.filename === "string"
+      ) {
         createReadStream(output.filename).pipe(response.type(output.filename));
       } else {
         response.status(400).send("Filename is missing");

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -17,7 +17,7 @@ import { AuxMethod, Method } from "./method";
 import { mimeMultipart } from "./mime";
 import { ZodUpload } from "./upload-schema";
 
-export type FlatObject = Record<string, any>;
+export type FlatObject = Record<string, unknown>;
 
 /** @see https://expressjs.com/en/guide/routing.html */
 export const routePathParamsRegex = /:([A-Za-z0-9_]+)/g;
@@ -44,7 +44,7 @@ export const getActualMethod = (request: Request) =>
 export function getInput(
   request: Request,
   inputAssignment: CommonConfig["inputSources"],
-): any {
+): Readonly<unknown> {
   const method = getActualMethod(request);
   if (method === "options") {
     return {};
@@ -67,11 +67,13 @@ export function getInput(
     );
 }
 
-export function isLoggerConfig(logger: any): logger is LoggerConfig {
+export function isLoggerConfig(logger: unknown): logger is LoggerConfig {
   return (
     typeof logger === "object" &&
+    logger !== null &&
     "level" in logger &&
     "color" in logger &&
+    typeof logger.level === "string" &&
     Object.keys(loggerLevels).includes(logger.level) &&
     typeof logger.color === "boolean"
   );
@@ -81,7 +83,7 @@ export function isValidDate(date: Date): boolean {
   return !isNaN(date.getTime());
 }
 
-export function makeErrorFromAnything(subject: any): Error {
+export function makeErrorFromAnything(subject: unknown): Error {
   return subject instanceof Error
     ? subject
     : new Error(
@@ -123,7 +125,7 @@ export const logInternalError = ({
 }: {
   logger: Logger;
   request: Request;
-  input: any;
+  input: unknown;
   error: Error;
   statusCode: number;
 }) => {
@@ -171,7 +173,7 @@ export const getExamples = <
   return result;
 };
 
-export const combinations = <T extends any>(
+export const combinations = <T extends unknown>(
   a: T[],
   b: T[],
 ): { type: "single"; value: T[] } | { type: "tuple"; value: [T, T][] } => {
@@ -272,12 +274,12 @@ export const makeCleanId = (path: string, method: string, suffix?: string) => {
 export const defaultSerializer = (schema: z.ZodTypeAny): string =>
   createHash("sha1").update(JSON.stringify(schema), "utf8").digest("hex");
 
-export const tryToTransform = ({
+export const tryToTransform = <T>({
   effect,
   sample,
 }: {
-  effect: z.TransformEffect<any>;
-  sample: any;
+  effect: z.TransformEffect<T>;
+  sample: T;
 }) => {
   try {
     return typeof effect.transform(sample, {

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -4,6 +4,7 @@ import { Express, Request } from "express";
 import fileUpload from "express-fileupload";
 import { ServerOptions } from "node:https";
 import { Logger } from "winston";
+import { z } from "zod";
 import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
 import { ResultHandlerDefinition } from "./result-handler";
@@ -81,7 +82,7 @@ export interface CommonConfig<TAG extends string = string> {
   cors: boolean | HeadersProvider;
   // custom ResultHandlerDefinition for common errors,
   // default: defaultResultHandler()
-  errorHandler?: ResultHandlerDefinition<any, any>;
+  errorHandler?: ResultHandlerDefinition<z.ZodTypeAny, z.ZodTypeAny>;
   // logger configuration or your custom winston logger
   logger: LoggerConfig | Logger;
   // you can disable the startup logo, default: true

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -278,12 +278,12 @@ export class Endpoint<
     logger,
   }: {
     method: Method | AuxMethod;
-    input: Readonly<any>; // Issue #673: input is immutable, since this.inputSchema is combined with ones of middlewares
+    input: Readonly<unknown>; // Issue #673: input is immutable, since this.inputSchema is combined with ones of middlewares
     request: Request;
     response: Response;
     logger: Logger;
   }) {
-    const options: any = {};
+    const options = {} as OPT;
     let isStreamClosed = false;
     for (const def of this.middlewares) {
       if (method === "options" && def.type === "proprietary") {
@@ -325,8 +325,8 @@ export class Endpoint<
     options,
     logger,
   }: {
-    input: Readonly<any>;
-    options: any;
+    input: Readonly<unknown>;
+    options: OPT;
     logger: Logger;
   }) {
     let finalInput: z.output<IN>; // final input types transformations for handler

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -99,7 +99,7 @@ export class EndpointsFactory<
       OUT & AOUT,
       SCO & ASCO,
       TAG
-    >(this.middlewares.concat(subject), this.resultHandler);
+    >(this.middlewares.concat(subject as AnyMiddlewareDef), this.resultHandler);
   }
 
   public use = this.addExpressMiddleware;
@@ -140,7 +140,7 @@ export class EndpointsFactory<
         createMiddleware({
           input: z.object({}),
           middleware: async () => options,
-        }),
+        }) as AnyMiddlewareDef,
       ),
       this.resultHandler,
     );

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -38,14 +38,15 @@ export const getFinalEndpointInputSchema = <
 >(
   middlewares: AnyMiddlewareDef[],
   input: IN,
-): ProbableIntersection<MIN, IN> => {
+) => {
   const allSchemas = middlewares
     .map(({ input: schema }) => schema)
     .concat(input);
 
-  const finalSchema = allSchemas.reduce((acc, schema) =>
-    acc.and(schema),
-  ) as ProbableIntersection<MIN, IN>;
+  const finalSchema = allSchemas.reduce((acc, schema) => acc.and(schema));
 
-  return allSchemas.reduce((acc, schema) => copyMeta(schema, acc), finalSchema);
+  return allSchemas.reduce(
+    (acc, schema) => copyMeta(schema, acc),
+    finalSchema,
+  ) as ProbableIntersection<MIN, IN>;
 };

--- a/src/logical-container.ts
+++ b/src/logical-container.ts
@@ -9,7 +9,10 @@ export type LogicalContainer<T> =
   | T;
 
 const isObject = <
-  T extends LogicalContainer<any> | LogicalAnd<any> | LogicalOr<any>,
+  T extends
+    | LogicalContainer<unknown>
+    | LogicalAnd<unknown>
+    | LogicalOr<unknown>,
 >(
   subject: T,
 ): subject is Exclude<T & {}, null> =>

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -10,7 +10,7 @@ export type MetaDef<T extends z.ZodTypeAny> = {
     examples: z.input<T>[];
   };
 };
-type MetaKey = keyof MetaDef<any>[MetaProp];
+type MetaKey = keyof MetaDef<z.ZodTypeAny>[MetaProp];
 type MetaValue<T extends z.ZodTypeAny, K extends MetaKey> = Readonly<
   MetaDef<T>[MetaProp][K]
 >;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,7 +40,12 @@ export interface MiddlewareDefinition<
   type: "proprietary" | "express";
 }
 
-export type AnyMiddlewareDef = MiddlewareDefinition<any, any, any, any>;
+export type AnyMiddlewareDef = MiddlewareDefinition<
+  IOSchema<"strip">,
+  unknown,
+  FlatObject,
+  string
+>;
 
 export const createMiddleware = <
   IN extends IOSchema<"strip">,
@@ -64,7 +69,7 @@ export const createMiddleware = <
 export type ExpressMiddleware<R extends Request, S extends Response> = (
   request: R,
   response: S,
-  next: (error?: any) => void,
+  next: (error?: unknown) => void,
 ) => void | Promise<void>;
 
 export interface ExpressMiddlewareFeatures<

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -20,8 +20,8 @@ interface LastResortHandlerParams {
 
 interface ResultHandlerParams<RES> {
   error: Error | null;
-  input: any;
-  output: any;
+  input: unknown;
+  output: object | null;
   request: Request;
   response: Response<RES>;
   logger: Logger;
@@ -115,7 +115,7 @@ export const arrayResultHandler = createResultHandler({
       "shape" in output &&
         "items" in output.shape &&
         output.shape.items instanceof z.ZodArray
-        ? (output.shape.items as z.ZodArray<any>)
+        ? (output.shape.items as z.ZodArray<z.ZodTypeAny>)
         : z.array(z.any()),
     );
     return examples.reduce<typeof responseSchema>(
@@ -140,7 +140,7 @@ export const arrayResultHandler = createResultHandler({
       response.status(statusCode).send(error.message);
       return;
     }
-    if ("items" in output && Array.isArray(output.items)) {
+    if (output && "items" in output && Array.isArray(output.items)) {
       response.status(200).json(output.items);
     } else {
       response

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -3,6 +3,7 @@ import { Logger } from "winston";
 import { z } from "zod";
 import { ApiResponse } from "./api-response";
 import {
+  FlatObject,
   getExamples,
   getMessageFromError,
   getStatusCodeFromError,
@@ -21,7 +22,7 @@ interface LastResortHandlerParams {
 interface ResultHandlerParams<RES> {
   error: Error | null;
   input: unknown;
-  output: object | null;
+  output: FlatObject | null;
   request: Request;
   response: Response<RES>;
   logger: Logger;

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -17,7 +17,7 @@ export interface ZodUploadDef extends ZodTypeDef {
   typeName: typeof zodUploadKind;
 }
 
-const isUploadedFile = (data: any): data is UploadedFile =>
+const isUploadedFile = (data: unknown): data is UploadedFile =>
   typeof data === "object" &&
   data !== null &&
   "name" in data &&

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -38,7 +38,7 @@ import {
 
 const { factory: f } = ts;
 
-const samples: Partial<Record<ts.KeywordTypeSyntaxKind, any>> = {
+const samples = {
   [ts.SyntaxKind.AnyKeyword]: "",
   [ts.SyntaxKind.BigIntKeyword]: BigInt(0),
   [ts.SyntaxKind.BooleanKeyword]: false,
@@ -46,7 +46,7 @@ const samples: Partial<Record<ts.KeywordTypeSyntaxKind, any>> = {
   [ts.SyntaxKind.ObjectKeyword]: {},
   [ts.SyntaxKind.StringKeyword]: "",
   [ts.SyntaxKind.UndefinedKeyword]: undefined,
-};
+} satisfies Partial<Record<ts.KeywordTypeSyntaxKind, unknown>>;
 
 const onLiteral: Producer<z.ZodLiteral<LiteralType>> = ({
   schema: { value },
@@ -197,12 +197,11 @@ const onPrimitive =
   () =>
     f.createKeywordTypeNode(syntaxKind);
 
-const onBranded: Producer<z.ZodBranded<z.ZodTypeAny, any>> = ({
-  next,
-  schema,
-}) => next({ schema: schema.unwrap() });
+const onBranded: Producer<
+  z.ZodBranded<z.ZodTypeAny, string | number | symbol>
+> = ({ next, schema }) => next({ schema: schema.unwrap() });
 
-const onReadonly: Producer<z.ZodReadonly<any>> = ({ next, schema }) =>
+const onReadonly: Producer<z.ZodReadonly<z.ZodTypeAny>> = ({ next, schema }) =>
   next({ schema: schema._def.innerType });
 
 const onCatch: Producer<z.ZodCatch<z.ZodTypeAny>> = ({ next, schema }) =>

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,6 @@
 import jestConfig from "../jest.config";
 import { z } from "zod";
+import { FlatObject } from "../src";
 import { SchemaHandler, walkSchema } from "../src/schema-walker";
 
 export const esmTestPort = 8070;
@@ -19,20 +20,19 @@ export const waitFor = async (cb: () => boolean) =>
     }, 100);
   });
 
-export const serializeSchemaForTest = (
-  schema: z.ZodTypeAny,
-): Record<string, any> => {
+export const serializeSchemaForTest = (schema: z.ZodTypeAny): FlatObject => {
   const onSomeUnion: SchemaHandler<
-    z.ZodUnion<any> | z.ZodDiscriminatedUnion<any, any>,
-    object
+    | z.ZodUnion<z.ZodUnionOptions>
+    | z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>,
+    FlatObject
   > = ({ schema: subject, next }) => ({
     options: Array.from(subject.options.values()).map((option) =>
       next({ schema: option as z.ZodTypeAny }),
     ),
   });
   const onOptionalOrNullable: SchemaHandler<
-    z.ZodOptional<any> | z.ZodNullable<any>,
-    object
+    z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny>,
+    FlatObject
   > = ({ schema: subject, next }) => ({
     value: next({ schema: subject.unwrap() }),
   });

--- a/tests/unit/config-type.spec.ts
+++ b/tests/unit/config-type.spec.ts
@@ -1,5 +1,5 @@
 import { Express } from "express";
-import { createConfig } from "../../src";
+import { createConfig, defaultResultHandler } from "../../src";
 
 describe("ConfigType", () => {
   describe("createConfig()", () => {
@@ -29,6 +29,18 @@ describe("ConfigType", () => {
       };
       const config = createConfig(argument);
       expect(config).toEqual(argument);
+    });
+
+    test("should accept error handler", () => {
+      createConfig({
+        server: { listen: 3333 },
+        cors: true,
+        logger: {
+          level: "debug" as const,
+          color: false,
+        },
+        errorHandler: defaultResultHandler,
+      });
     });
   });
 });

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -96,7 +96,7 @@ describe("I/O Schema and related helpers", () => {
     });
 
     test("Should merge input object schemas", () => {
-      const middlewares: AnyMiddlewareDef[] = [
+      const middlewares = [
         createMiddleware({
           input: z.object({
             one: z.string(),
@@ -119,13 +119,16 @@ describe("I/O Schema and related helpers", () => {
       const endpointInput = z.object({
         four: z.boolean(),
       });
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
+      const result = getFinalEndpointInputSchema(
+        middlewares as AnyMiddlewareDef[],
+        endpointInput,
+      );
       expect(result).toBeInstanceOf(z.ZodIntersection);
       expect(serializeSchemaForTest(result)).toMatchSnapshot();
     });
 
     test("Should merge union object schemas", () => {
-      const middlewares: AnyMiddlewareDef[] = [
+      const middlewares = [
         createMiddleware({
           input: z
             .object({
@@ -160,13 +163,16 @@ describe("I/O Schema and related helpers", () => {
             six: z.number(),
           }),
         );
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
+      const result = getFinalEndpointInputSchema(
+        middlewares as AnyMiddlewareDef[],
+        endpointInput,
+      );
       expect(result).toBeInstanceOf(z.ZodIntersection);
       expect(serializeSchemaForTest(result)).toMatchSnapshot();
     });
 
     test("Should merge intersection object schemas", () => {
-      const middlewares: AnyMiddlewareDef[] = [
+      const middlewares = [
         createMiddleware({
           input: z
             .object({
@@ -201,7 +207,10 @@ describe("I/O Schema and related helpers", () => {
             six: z.number(),
           }),
         );
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
+      const result = getFinalEndpointInputSchema(
+        middlewares as AnyMiddlewareDef[],
+        endpointInput,
+      );
       expect(result).toBeInstanceOf(z.ZodIntersection);
       expect(serializeSchemaForTest(result)).toMatchSnapshot();
     });
@@ -222,7 +231,7 @@ describe("I/O Schema and related helpers", () => {
     });
 
     test("Should merge mixed object schemas", () => {
-      const middlewares: AnyMiddlewareDef[] = [
+      const middlewares = [
         createMiddleware({
           input: z
             .object({
@@ -251,13 +260,16 @@ describe("I/O Schema and related helpers", () => {
       const endpointInput = z.object({
         five: z.string(),
       });
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
+      const result = getFinalEndpointInputSchema(
+        middlewares as AnyMiddlewareDef[],
+        endpointInput,
+      );
       expect(result).toBeInstanceOf(z.ZodIntersection);
       expect(serializeSchemaForTest(result)).toMatchSnapshot();
     });
 
     test("Should merge examples in case of using withMeta()", () => {
-      const middlewares: AnyMiddlewareDef[] = [
+      const middlewares = [
         createMiddleware({
           input: withMeta(
             z
@@ -300,7 +312,10 @@ describe("I/O Schema and related helpers", () => {
       ).example({
         five: "some",
       });
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
+      const result = getFinalEndpointInputSchema(
+        middlewares as AnyMiddlewareDef[],
+        endpointInput,
+      );
       expect(getMeta(result, "examples")).toEqual([
         {
           one: "test",


### PR DESCRIPTION
> The key difference between unknown and any is that any allows you to perform any operation on a value without any type checking, whereas unknown requires you to perform type checking before performing any operations on the value. 