### PR TITLE
Feat: the `operationId` provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Version 12
 
+### v12.4.0
+
+- Feature: ability to assign a function to the `operationId` property of the `EndpointsFactory::build()` argument.
+  - This can help to customize the Operation ID for the endpoints serving multiple methods.
+
+```typescript
+import { defaultEndpointsFactory } from "express-zod-api";
+
+defaultEndpointsFactory.build({
+  methods: ["get", "post"],
+  operationId: (method) => `${method}Something`,
+  // ...
+});
+```
+
 ### v12.3.0
 
 - Featuring the ability to customize the `operationId` in the generated documentation.

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -153,7 +153,7 @@ export class Documentation extends OpenApiBuilder {
       const operationId = this.ensureUniqOperationId(
         path,
         method,
-        endpoint.getOperationId(),
+        endpoint.getOperationId(method),
       );
       const operation: OperationObject = {
         operationId,

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -70,7 +70,7 @@ export abstract class AbstractEndpoint {
   public abstract getScopes(): string[];
   public abstract getTags(): string[];
   public abstract _setSiblingMethods(methods: Method[]): void;
-  public abstract getOperationId(): string | undefined;
+  public abstract getOperationId(method: Method): string | undefined;
 }
 
 type EndpointProps<
@@ -90,7 +90,7 @@ type EndpointProps<
   resultHandler: ResultHandlerDefinition<POS, NEG>;
   description?: string;
   shortDescription?: string;
-  operationId?: string;
+  operationId?: string | ((method: Method) => string);
 } & ({ scopes?: SCO[] } | { scope?: SCO }) &
   ({ tags?: TAG[] } | { tag?: TAG }) &
   MethodsDefinition<M>;
@@ -121,7 +121,7 @@ export class Endpoint<
   };
   readonly #scopes: SCO[] = [];
   readonly #tags: TAG[] = [];
-  readonly #operationId?: string;
+  readonly #operationId?: string | ((method: Method) => string);
 
   constructor({
     middlewares,
@@ -247,8 +247,10 @@ export class Endpoint<
     return this.#tags;
   }
 
-  public override getOperationId(): string | undefined {
-    return this.#operationId;
+  public override getOperationId(method: Method): string | undefined {
+    return typeof this.#operationId === "function"
+      ? this.#operationId(method)
+      : this.#operationId;
   }
 
   #getDefaultCorsHeaders(): Record<string, string> {

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -36,7 +36,7 @@ type BuildProps<
   handler: Handler<z.output<ProbableIntersection<MIN, IN>>, z.input<OUT>, OPT>;
   description?: string;
   shortDescription?: string;
-  operationId?: string;
+  operationId?: string | ((method: Method) => string);
 } & ({ scopes?: SCO[] } | { scope?: SCO }) &
   ({ tags?: TAG[] } | { tag?: TAG }) &
   MethodsDefinition<M>;

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -1272,6 +1272,134 @@ servers:
 "
 `;
 
+exports[`Documentation generator getSpecAsYaml() should be able to specify the operationId provider depending on method 1`] = `
+"openapi: 3.0.0
+info:
+  title: Testing Operation IDs
+  version: 3.4.5
+paths:
+  /v1/getSome/thing:
+    get:
+      operationId: getCoolOperationId
+      responses:
+        "200":
+          description: GET /v1/getSome/thing Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    type: object
+                    properties: {}
+                required:
+                  - status
+                  - data
+        "400":
+          description: GET /v1/getSome/thing Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+              examples:
+                example1:
+                  value:
+                    status: error
+                    error:
+                      message: Sample error message
+      description: thing is the path segment
+      summary: thing is the path segment
+    post:
+      operationId: postCoolOperationId
+      responses:
+        "200":
+          description: POST /v1/getSome/thing Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                  data:
+                    type: object
+                    properties: {}
+                required:
+                  - status
+                  - data
+        "400":
+          description: POST /v1/getSome/thing Error response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                      - message
+                required:
+                  - status
+                  - error
+              examples:
+                example1:
+                  value:
+                    status: error
+                    error:
+                      message: Sample error message
+      description: thing is the path segment
+      summary: thing is the path segment
+      requestBody:
+        description: POST /v1/getSome/thing request body
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+components:
+  schemas: {}
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes: {}
+  links: {}
+  callbacks: {}
+tags: []
+servers:
+  - url: https://example.com
+"
+`;
+
 exports[`Documentation generator getSpecAsYaml() should ensure the uniq operation ids 1`] = `
 "openapi: 3.0.0
 info:

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -713,6 +713,33 @@ describe("Documentation generator", () => {
       expect(spec).toMatchSnapshot();
     });
 
+    test("should be able to specify the operationId provider depending on method", () => {
+      const operationId = "CoolOperationId";
+      const spec = new Documentation({
+        config: sampleConfig,
+        routing: {
+          v1: {
+            getSome: {
+              thing: defaultEndpointsFactory.build({
+                description: "thing is the path segment",
+                methods: ["get", "post"],
+                operationId: (method) => `${method}${operationId}`,
+                input: z.object({}),
+                output: z.object({}),
+                handler: async () => ({}),
+              }),
+            },
+          },
+        },
+        version: "3.4.5",
+        title: "Testing Operation IDs",
+        serverUrl: "https://example.com",
+      }).getSpecAsYaml();
+
+      expect(spec).toContain(operationId);
+      expect(spec).toMatchSnapshot();
+    });
+
     test("should not be able to specify duplicated operation", () => {
       const operationId = "coolOperationId";
       const expectedError = new DocumentationError({


### PR DESCRIPTION
An addition to #1181 

For endpoints serving several methods.

@john-schmitz , I realized that endpoints may serve several methods, while Operation ID should be unique and is assigned to each method of endpoint. So I made this feature offering an ability to specify the operation ID provider based on a method being described by the documentation generator.