### PR TITLE
Dropping the `MethodDefinition` and corresponding type argument

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -19,7 +19,7 @@ import {
 } from "./common-helpers";
 import { IOSchema } from "./io-schema";
 import { LogicalContainer, combineContainers } from "./logical-container";
-import { AuxMethod, Method, MethodsDefinition } from "./method";
+import { AuxMethod, Method } from "./method";
 import { AnyMiddlewareDef } from "./middleware";
 import { mimeJson, mimeMultipart } from "./mime";
 import {
@@ -77,12 +77,11 @@ type EndpointProps<
   IN extends IOSchema,
   OUT extends IOSchema,
   OPT extends FlatObject,
-  M extends Method,
   POS extends z.ZodTypeAny,
   NEG extends z.ZodTypeAny,
   SCO extends string,
   TAG extends string,
-> = {
+> = ({
   middlewares: AnyMiddlewareDef[];
   inputSchema: IN;
   outputSchema: OUT;
@@ -92,21 +91,20 @@ type EndpointProps<
   shortDescription?: string;
   operationId?: string;
 } & ({ scopes?: SCO[] } | { scope?: SCO }) &
-  ({ tags?: TAG[] } | { tag?: TAG }) &
-  MethodsDefinition<M>;
+  ({ tags?: TAG[] } | { tag?: TAG })) &
+  ({ method: Method } | { methods: Method[] });
 
 export class Endpoint<
   IN extends IOSchema,
   OUT extends IOSchema,
   OPT extends FlatObject,
-  M extends Method,
   POS extends z.ZodTypeAny,
   NEG extends z.ZodTypeAny,
   SCO extends string,
   TAG extends string,
 > extends AbstractEndpoint {
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
-  readonly #methods: M[] = [];
+  readonly #methods: Method[] = [];
   #siblingMethods: Method[] = [];
   readonly #middlewares: AnyMiddlewareDef[] = [];
   readonly #mimeTypes: Record<MimeVariant, string[]>;
@@ -132,7 +130,7 @@ export class Endpoint<
     description,
     shortDescription,
     ...rest
-  }: EndpointProps<IN, OUT, OPT, M, POS, NEG, SCO, TAG>) {
+  }: EndpointProps<IN, OUT, OPT, POS, NEG, SCO, TAG>) {
     super();
     [
       { name: "input schema", schema: inputSchema },
@@ -211,7 +209,7 @@ export class Endpoint<
     return this.#descriptions[variant];
   }
 
-  public override getMethods(): M[] {
+  public override getMethods(): Method[] {
     return this.#methods;
   }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -81,7 +81,7 @@ type EndpointProps<
   NEG extends z.ZodTypeAny,
   SCO extends string,
   TAG extends string,
-> = ({
+> = {
   middlewares: AnyMiddlewareDef[];
   inputSchema: IN;
   outputSchema: OUT;
@@ -90,9 +90,9 @@ type EndpointProps<
   description?: string;
   shortDescription?: string;
   operationId?: string;
-} & ({ scopes?: SCO[] } | { scope?: SCO }) &
-  ({ tags?: TAG[] } | { tag?: TAG })) &
-  ({ method: Method } | { methods: Method[] });
+} & ({ method: Method } | { methods: Method[] }) &
+  ({ scopes?: SCO[] } | { scope?: SCO }) &
+  ({ tags?: TAG[] } | { tag?: TAG });
 
 export class Endpoint<
   IN extends IOSchema,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -36,9 +36,9 @@ type BuildProps<
   description?: string;
   shortDescription?: string;
   operationId?: string;
-} & ({ scopes?: SCO[] } | { scope?: SCO }) &
-  ({ tags?: TAG[] } | { tag?: TAG }) &
-  ({ method: Method } | { methods: Method[] });
+} & ({ method: Method } | { methods: Method[] }) &
+  ({ scopes?: SCO[] } | { scope?: SCO }) &
+  ({ tags?: TAG[] } | { tag?: TAG });
 
 export class EndpointsFactory<
   POS extends z.ZodTypeAny,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -8,7 +8,7 @@ import {
   ProbableIntersection,
   getFinalEndpointInputSchema,
 } from "./io-schema";
-import { Method, MethodsDefinition } from "./method";
+import { Method } from "./method";
 import {
   AnyMiddlewareDef,
   ExpressMiddleware,
@@ -27,7 +27,6 @@ type BuildProps<
   OUT extends IOSchema,
   MIN extends IOSchema<"strip"> | null,
   OPT extends FlatObject,
-  M extends Method,
   SCO extends string,
   TAG extends string,
 > = {
@@ -39,7 +38,7 @@ type BuildProps<
   operationId?: string;
 } & ({ scopes?: SCO[] } | { scope?: SCO }) &
   ({ tags?: TAG[] } | { tag?: TAG }) &
-  MethodsDefinition<M>;
+  ({ method: Method } | { methods: Method[] });
 
 export class EndpointsFactory<
   POS extends z.ZodTypeAny,
@@ -147,16 +146,15 @@ export class EndpointsFactory<
     );
   }
 
-  public build<BIN extends IOSchema, BOUT extends IOSchema, M extends Method>({
+  public build<BIN extends IOSchema, BOUT extends IOSchema>({
     input,
     handler,
     output: outputSchema,
     ...rest
-  }: BuildProps<BIN, BOUT, IN, OUT, M, SCO, TAG>): Endpoint<
+  }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
     ProbableIntersection<IN, BIN>,
     BOUT,
     OUT,
-    M,
     POS,
     NEG,
     SCO,

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,11 +1,3 @@
 export type Method = "get" | "post" | "put" | "delete" | "patch";
 export const methods: Method[] = ["get", "post", "put", "delete", "patch"];
 export type AuxMethod = "options";
-
-export type MethodsDefinition<M extends Method> =
-  | {
-      methods: M[];
-    }
-  | {
-      method: M;
-    };


### PR DESCRIPTION
Due to #1196 
There is actually no need to maintain the type parameter having `Method` on `Endpoint` type.
It was only required for that reason, but still it was not enough, therefore all that is replaced by a simple programmatic check in the PR mentioned above.