### PR TITLE
Ability to specify multiple server URLs in Documentation

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -32,7 +32,7 @@ import { RoutingWalkerParams, walkRouting } from "./routing-walker";
 interface DocumentationParams {
   title: string;
   version: string;
-  serverUrl: string;
+  serverUrl: string | string[];
   routing: Routing;
   config: CommonConfig;
   /** @default Successful response */
@@ -125,7 +125,10 @@ export class Documentation extends OpenApiBuilder {
     serializer = defaultSerializer,
   }: DocumentationParams) {
     super();
-    this.addInfo({ title, version }).addServer({ url: serverUrl });
+    this.addInfo({ title, version });
+    for (const url of Array.isArray(serverUrl) ? serverUrl : [serverUrl]) {
+      this.addServer({ url });
+    }
     const onEndpoint: RoutingWalkerParams["onEndpoint"] = (
       endpoint,
       path,

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -126,7 +126,7 @@ export class Documentation extends OpenApiBuilder {
   }: DocumentationParams) {
     super();
     this.addInfo({ title, version });
-    for (const url of Array.isArray(serverUrl) ? serverUrl : [serverUrl]) {
+    for (const url of typeof serverUrl === "string" ? [serverUrl] : serverUrl) {
       this.addServer({ url });
     }
     const onEndpoint: RoutingWalkerParams["onEndpoint"] = (


### PR DESCRIPTION
Closes #1195 

This is a shorthand for `new Documentation().addServer()`