### PR TITLE
Improving context type for `SchemaWalker`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -19,6 +19,7 @@ import {
 import { omit } from "ramda";
 import { z } from "zod";
 import {
+  FlatObject,
   getExamples,
   hasCoercion,
   hasTopLevelTransformingEffect,
@@ -53,7 +54,7 @@ import { ZodUpload } from "./upload-schema";
 
 type MediaExamples = Pick<MediaTypeObject, "examples">;
 
-export interface OpenAPIContext {
+export interface OpenAPIContext extends FlatObject {
   isResponse: boolean;
   serializer: (schema: z.ZodTypeAny) => string;
   getRef: (name: string) => ReferenceObject | undefined;

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -62,22 +62,12 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
     "typeName" in schema._def
       ? rules[schema._def.typeName as keyof typeof rules]
       : undefined;
-  const context = rest as unknown as Context;
+  const ctx = rest as unknown as Context;
   const next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> = (params) =>
-    walkSchema({
-      ...params,
-      ...context,
-      onEach,
-      rules: rules,
-      onMissing,
-    });
+    walkSchema({ ...params, ...ctx, onEach, rules: rules, onMissing });
   const result = handler
-    ? handler({
-        schema,
-        ...context,
-        next,
-      })
-    : onMissing({ schema, ...context });
-  const overrides = onEach && onEach({ schema, prev: result, ...context });
+    ? handler({ schema, ...ctx, next })
+    : onMissing({ schema, ...ctx });
+  const overrides = onEach && onEach({ schema, prev: result, ...ctx });
   return overrides ? { ...result, ...overrides } : result;
 };

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { FlatObject } from "./common-helpers";
+import type { FlatObject } from "./common-helpers";
 import type { ZodDateInDef } from "./date-in-schema";
 import type { ZodDateOutDef } from "./date-out-schema";
 import type { ZodFileDef } from "./file-schema";

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -66,7 +66,7 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
   const next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> = (params) =>
     walkSchema({
       ...params,
-      ...(context as Context),
+      ...context,
       onEach,
       rules: rules,
       onMissing,
@@ -74,11 +74,10 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
   const result = handler
     ? handler({
         schema,
-        ...(context as Context),
+        ...context,
         next,
       })
-    : onMissing({ schema, ...(context as Context) });
-  const overrides =
-    onEach && onEach({ schema, prev: result, ...(context as Context) });
+    : onMissing({ schema, ...context });
+  const overrides = onEach && onEach({ schema, prev: result, ...context });
   return overrides ? { ...result, ...overrides } : result;
 };

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -26,19 +26,20 @@
 
 import ts from "typescript";
 import { z } from "zod";
+import { FlatObject } from "./common-helpers";
 import { SchemaHandler } from "./schema-walker";
 
 const { factory: f } = ts;
 
 export type LiteralType = string | number | boolean;
 
-export type ZTSContext = {
+export interface ZTSContext extends FlatObject {
   isResponse: boolean;
   getAlias: (name: string) => ts.TypeReferenceNode | undefined;
   makeAlias: (name: string, type: ts.TypeNode) => ts.TypeReferenceNode;
   serializer: (schema: z.ZodTypeAny) => string;
   optionalPropStyle: { withQuestionMark?: boolean; withUndefined?: boolean };
-};
+}
 
 export type Producer<T extends z.ZodTypeAny> = SchemaHandler<
   T,

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -197,12 +197,11 @@ const onPrimitive =
   () =>
     f.createKeywordTypeNode(syntaxKind);
 
-const onBranded: Producer<z.ZodBranded<z.ZodTypeAny, any>> = ({
-  next,
-  schema,
-}) => next({ schema: schema.unwrap() });
+const onBranded: Producer<
+  z.ZodBranded<z.ZodTypeAny, string | number | symbol>
+> = ({ next, schema }) => next({ schema: schema.unwrap() });
 
-const onReadonly: Producer<z.ZodReadonly<any>> = ({ next, schema }) =>
+const onReadonly: Producer<z.ZodReadonly<z.ZodTypeAny>> = ({ next, schema }) =>
   next({ schema: schema._def.innerType });
 
 const onCatch: Producer<z.ZodCatch<z.ZodTypeAny>> = ({ next, schema }) =>
@@ -250,7 +249,6 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodIntersection: onIntersection,
   ZodUnion: onSomeUnion,
   ZodFile: onPrimitive(ts.SyntaxKind.StringKeyword),
-  // ZodUpload:
   ZodAny: onPrimitive(ts.SyntaxKind.AnyKeyword),
   ZodDefault: onDefault,
   ZodEnum: onEnum,

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -266,7 +266,7 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
 
 export const zodToTs = ({
   schema,
-  ...context
+  ...ctx
 }: {
   schema: z.ZodTypeAny;
 } & ZTSContext) =>
@@ -274,5 +274,5 @@ export const zodToTs = ({
     schema,
     rules: producers,
     onMissing: () => f.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-    ...context,
+    ...ctx,
   });


### PR DESCRIPTION
Avoiding usage of `object` since [it accepts arrays](https://www.typescriptlang.org/play?#code/G4QwTgBA9gXNBGArApgYwC4G4BQUIF4IBvCABzClLgAYIBfTCAeiYgHkBpXAiAbQF1GLdlzyEALACYhrAKJgKYboQBEAZ3RgAlgDsA5ipkR5i5RABmIADZrkRk1CViIOgK5Wr9hY7OudAE2RzXWR-L1NsUEg2ODYkNCxsNh4SckoaeiNOJJ4BLK5kiWlmVmzCiHVNXQN8nMJLGzsSkTqXd09mhyVyv0DgnVDwn0jwMjgiBmxSFLIKKghaBmbs6cI85a5ViClarcrtfUMNqZ4G212eNw8hpS3eoJCwzu8lEcgAR3G+AGtkAE84BoDnp+HAQDo-plsO8Zml5otajC1oJjkjtsVhF1oTx9tUjpiXtj6tZzs9TGirh0CeSePd+oMycMohAwF9eL8ARAgdVQVyqvooZBCKk5nAAOTc-RizLHIXEWbpBYy6k+OXrFVKOU7RmanGSmo67Bys5NDVGy7tG7mwh0x5Wt5kUjzABKaEc-gAPPqADQQPzfHRQADuOgAfDgnVsRYrcQKVJNI7DRUq6FMnbkUWbE4RKRH0zaAg8BmFsEA).
Replacing it with extension of `FlatObject`

