### PR TITLE
Fixed warnings in tests and replacing deprecated methods of `jest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1886,9 +1886,9 @@ test("should respond successfully", async () => {
       body: { ... },
     },
   });
-  expect(loggerMock.error).toBeCalledTimes(0);
-  expect(responseMock.status).toBeCalledWith(200);
-  expect(responseMock.json).toBeCalledWith({
+  expect(loggerMock.error).toHaveBeenCalledTimes(0);
+  expect(responseMock.status).toHaveBeenCalledTimes(200);
+  expect(responseMock.json).toHaveBeenCalledWith({
     status: "success",
     data: { ... },
   });

--- a/README.md
+++ b/README.md
@@ -1004,9 +1004,9 @@ test("should respond successfully", async () => {
     },
     // responseProps, configProps, loggerProps
   });
-  expect(loggerMock.error).toBeCalledTimes(0);
-  expect(responseMock.status).toBeCalledWith(200);
-  expect(responseMock.json).toBeCalledWith({
+  expect(loggerMock.error).toHaveBeenCalledTimes(0);
+  expect(responseMock.status).toHaveBeenCalledWith(200);
+  expect(responseMock.json).toHaveBeenCalledWith({
     status: "success",
     data: { ... },
   });

--- a/tests/http-mock.ts
+++ b/tests/http-mock.ts
@@ -9,22 +9,20 @@ let httpsListenSpy: jest.SpyInstance;
 
 jest.spyOn(http, "createServer").mockImplementation((app) => {
   const server = realHttpCreator(app);
-  httpListenSpy = jest
-    .spyOn(server, "listen")
-    .mockImplementation((port, cb) => {
-      cb?.call(null);
-      return server;
-    });
+  httpListenSpy = jest.spyOn(server, "listen").mockImplementation(({}, cb) => {
+    cb?.call(null);
+    return server;
+  });
   return server;
 });
 
 const createHttpsServerSpy = jest
   .spyOn(https, "createServer")
-  .mockImplementation((options, app) => {
+  .mockImplementation(({}, app) => {
     const server = realHttpsCreator(app);
     httpsListenSpy = jest
       .spyOn(server, "listen")
-      .mockImplementation((port, cb) => {
+      .mockImplementation(({}, cb) => {
         cb?.call(null);
         return server;
       });

--- a/tests/unit/__snapshots__/upload-schema.spec.ts.snap
+++ b/tests/unit/__snapshots__/upload-schema.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`ZodUpload _parse() should accept UploadedFile 1`] = `
     "encoding": "utf-8",
     "md5": "",
     "mimetype": "image/jpeg",
-    "mv": [Function],
+    "mv": [MockFunction],
     "name": "avatar.jpg",
     "size": 100500,
     "tempFilePath": "",

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -213,7 +213,7 @@ describe("Documentation helpers", () => {
             z.object({ one: z.string() }).transform(() => []),
             requestCtx,
           ),
-        ).toThrowError(
+        ).toThrow(
           new IOSchemaError(
             "Using transformations on the top level of input schema is not allowed.\n" +
               "Caused by input schema of an Endpoint assigned to GET method of /v1/user/:id path.",

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -582,7 +582,14 @@ describe("Documentation generator", () => {
               title: "Testing unsupported types",
               serverUrl: "https://example.com",
             }),
-        ).toThrowError(/Zod type Zod\w+ is unsupported/);
+        ).toThrow(
+          new DocumentationError({
+            method: "post",
+            path: "/v1/getSomething",
+            isResponse: false,
+            message: `Zod type ${zodType._def.typeName} is unsupported.`,
+          }),
+        );
       });
     });
 

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -93,8 +93,8 @@ describe("Endpoint", () => {
           body: { n: 453 },
         },
       });
-      expect(middlewareMock).toBeCalledTimes(1);
-      expect(middlewareMock).toBeCalledWith({
+      expect(middlewareMock).toHaveBeenCalledTimes(1);
+      expect(middlewareMock).toHaveBeenCalledWith({
         input: { n: 453 },
         options: {
           inc: 454, // due to reassignment of options
@@ -103,15 +103,15 @@ describe("Endpoint", () => {
         response: responseMock,
         logger: loggerMock,
       });
-      expect(handlerMock).toBeCalledTimes(1);
-      expect(handlerMock).toBeCalledWith({
+      expect(handlerMock).toHaveBeenCalledTimes(1);
+      expect(handlerMock).toHaveBeenCalledWith({
         input: { n: 453 },
         options: { inc: 454 },
         logger: loggerMock,
       });
-      expect(loggerMock.error).toBeCalledTimes(0);
-      expect(responseMock.status).toBeCalledWith(200);
-      expect(responseMock.json).toBeCalledWith({
+      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(responseMock.status).toHaveBeenCalledWith(200);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "success",
         data: {
           inc2: 455,
@@ -141,12 +141,12 @@ describe("Endpoint", () => {
           }),
         },
       });
-      expect(loggerMock.error).toBeCalledTimes(0);
-      expect(responseMock.status).toBeCalledWith(200);
-      expect(responseMock.json).toBeCalledTimes(0);
-      expect(handlerMock).toBeCalledTimes(0);
-      expect(responseMock.set).toBeCalledTimes(4);
-      expect(responseMock.end).toBeCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(responseMock.status).toHaveBeenCalledWith(200);
+      expect(responseMock.json).toHaveBeenCalledTimes(0);
+      expect(handlerMock).toHaveBeenCalledTimes(0);
+      expect(responseMock.set).toHaveBeenCalledTimes(4);
+      expect(responseMock.end).toHaveBeenCalledTimes(1);
       expect(responseMock.set.mock.calls[0]).toEqual([
         "Access-Control-Allow-Origin",
         "*",
@@ -177,8 +177,8 @@ describe("Endpoint", () => {
       const { responseMock } = await testEndpoint({
         endpoint,
       });
-      expect(responseMock.status).toBeCalledWith(500);
-      expect(responseMock.json).toBeCalledWith({
+      expect(responseMock.status).toHaveBeenCalledWith(500);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "error",
         error: {
           message: "output/email: Invalid email",
@@ -203,9 +203,9 @@ describe("Endpoint", () => {
       const { responseMock, loggerMock } = await testEndpoint({
         endpoint,
       });
-      expect(loggerMock.error).toBeCalledTimes(1);
-      expect(responseMock.status).toBeCalledWith(500);
-      expect(responseMock.json).toBeCalledWith({
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(responseMock.status).toHaveBeenCalledWith(500);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "error",
         error: {
           message: "Something unexpected",
@@ -247,14 +247,14 @@ describe("Endpoint", () => {
       });
       expect(handlerMock).toHaveBeenCalledTimes(0);
       expect(middlewareMock).toHaveBeenCalledTimes(1);
-      expect(loggerMock.error).toBeCalledTimes(0);
-      expect(loggerMock.warn).toBeCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(loggerMock.warn).toHaveBeenCalledTimes(1);
       expect(loggerMock.warn.mock.calls[0][0]).toBe(
         "The middleware mockConstructor has closed the stream. Accumulated options:",
       );
       expect(loggerMock.warn.mock.calls[0][1]).toEqual({ inc: 454 });
-      expect(responseMock.status).toBeCalledTimes(0);
-      expect(responseMock.json).toBeCalledTimes(0);
+      expect(responseMock.status).toHaveBeenCalledTimes(0);
+      expect(responseMock.json).toHaveBeenCalledTimes(0);
       expect(responseMock.statusCode).toBe(200);
       expect(responseMock.statusMessage).toBe("OK");
     });
@@ -280,14 +280,14 @@ describe("Endpoint", () => {
         handler: async () => ({ test: "OK" }),
       });
       const { loggerMock, responseMock } = await testEndpoint({ endpoint });
-      expect(loggerMock.error).toBeCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
       expect(loggerMock.error.mock.calls[0][0]).toBe(
         "Result handler failure: Something unexpected happened.",
       );
-      expect(responseMock.status).toBeCalledTimes(1);
+      expect(responseMock.status).toHaveBeenCalledTimes(1);
       expect(responseMock.status.mock.calls[0][0]).toBe(500);
-      expect(responseMock.json).toBeCalledTimes(0);
-      expect(responseMock.end).toBeCalledTimes(1);
+      expect(responseMock.json).toHaveBeenCalledTimes(0);
+      expect(responseMock.end).toHaveBeenCalledTimes(1);
       expect(responseMock.end.mock.calls[0][0]).toBe(
         "An error occurred while serving the result: Something unexpected happened.",
       );
@@ -499,9 +499,9 @@ describe("Endpoint", () => {
       const { responseMock, loggerMock } = await testEndpoint({
         endpoint,
       });
-      expect(loggerMock.error).toBeCalledTimes(1);
-      expect(responseMock.status).toBeCalledWith(500);
-      expect(responseMock.json).toBeCalledWith({
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(responseMock.status).toHaveBeenCalledWith(500);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "error",
         error: {
           message: "Something unexpected",
@@ -529,14 +529,14 @@ describe("Endpoint", () => {
         handler: async () => ({ test: "OK" }),
       });
       const { loggerMock, responseMock } = await testEndpoint({ endpoint });
-      expect(loggerMock.error).toBeCalledTimes(1);
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
       expect(loggerMock.error.mock.calls[0][0]).toBe(
         "Result handler failure: Something unexpected happened.",
       );
-      expect(responseMock.status).toBeCalledTimes(1);
+      expect(responseMock.status).toHaveBeenCalledTimes(1);
       expect(responseMock.status.mock.calls[0][0]).toBe(500);
-      expect(responseMock.json).toBeCalledTimes(0);
-      expect(responseMock.end).toBeCalledTimes(1);
+      expect(responseMock.json).toHaveBeenCalledTimes(0);
+      expect(responseMock.end).toHaveBeenCalledTimes(1);
       expect(responseMock.end.mock.calls[0][0]).toBe(
         "An error occurred while serving the result: Something unexpected happened.",
       );
@@ -565,9 +565,9 @@ describe("Endpoint", () => {
           body: {},
         },
       });
-      expect(loggerMock.error).toBeCalledTimes(1);
-      expect(responseMock.status).toBeCalledWith(500);
-      expect(responseMock.json).toBeCalledWith({
+      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(responseMock.status).toHaveBeenCalledWith(500);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "error",
         error: { message: "Something went wrong" },
       });
@@ -735,7 +735,7 @@ describe("Endpoint", () => {
               handler: jest.fn(),
             },
           }),
-      ).toThrowError(
+      ).toThrow(
         new IOSchemaError(
           "Using transformations on the top level of endpoint input schema is not allowed.",
         ),
@@ -753,7 +753,7 @@ describe("Endpoint", () => {
               handler: jest.fn(),
             },
           }),
-      ).toThrowError(
+      ).toThrow(
         new IOSchemaError(
           "Using transformations on the top level of endpoint output schema is not allowed.",
         ),

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -134,7 +134,7 @@ describe("EndpointsFactory", () => {
           handler: jest.fn(),
         });
         const factory = new EndpointsFactory(resultHandlerMock);
-        const middleware: RequestHandler = jest.fn((req, res, next) => {
+        const middleware: RequestHandler = jest.fn((req, {}, next) => {
           req.body.test = "Here is the test";
           next();
         });
@@ -175,7 +175,7 @@ describe("EndpointsFactory", () => {
           handler: jest.fn(),
         });
         const factory = new EndpointsFactory(resultHandlerMock);
-        const middleware: RequestHandler = jest.fn((req, res, next) => {
+        const middleware: RequestHandler = jest.fn((req, {}, next) => {
           req.body.test = "Here is the test";
           next();
         });
@@ -209,7 +209,7 @@ describe("EndpointsFactory", () => {
           handler: jest.fn(),
         });
         const factory = new EndpointsFactory(resultHandlerMock);
-        const middleware: RequestHandler = jest.fn((req, res, next) => {
+        const middleware: RequestHandler = jest.fn(({}, {}, next) => {
           next(new Error("This one has failed"));
         });
         const newFactory = factory[method](middleware);
@@ -238,7 +238,7 @@ describe("EndpointsFactory", () => {
           handler: jest.fn(),
         });
         const factory = new EndpointsFactory(resultHandlerMock);
-        const middleware: RequestHandler = jest.fn((req, res, next) => {
+        const middleware: RequestHandler = jest.fn(({}, {}, next) => {
           next(new Error("This one has failed"));
         });
         const newFactory = factory[method](middleware, {

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -41,7 +41,7 @@ describe("Logger", () => {
       expect(logger.isDebugEnabled()).toBeFalsy();
       expect(logger.isSillyEnabled()).toBeFalsy();
       logger.error("test");
-      expect(transform).toBeCalledTimes(0);
+      expect(transform).toHaveBeenCalledTimes(0);
     });
 
     test("Should create warn logger", () => {
@@ -58,7 +58,7 @@ describe("Logger", () => {
       expect(logger.isDebugEnabled()).toBeFalsy();
       expect(logger.isSillyEnabled()).toBeFalsy();
       logger.warn("testing warn message", { withMeta: true });
-      expect(transform).toBeCalled();
+      expect(transform).toHaveBeenCalled();
       const params = transform.mock.calls[0][0];
       expect(params).toEqual({
         level: "warn",
@@ -87,7 +87,7 @@ describe("Logger", () => {
       expect(logger.isDebugEnabled()).toBeTruthy();
       expect(logger.isSillyEnabled()).toBeFalsy();
       logger.debug("testing debug message", { withColorful: "output" });
-      expect(transform).toBeCalled();
+      expect(transform).toHaveBeenCalled();
       const params = transform.mock.calls[0][0];
       expect(dropColorInObjectProps(params)).toEqual({
         level: "debug",
@@ -111,7 +111,7 @@ describe("Logger", () => {
       logger.profile("long-test");
       MockDate.set("2022-01-01T00:00:00.554Z");
       logger.profile("long-test");
-      expect(transform).toBeCalled();
+      expect(transform).toHaveBeenCalled();
       const params = transform.mock.calls[0][0];
       expect(dropColorInObjectProps(params)).toEqual({
         durationMs: 554,
@@ -138,7 +138,7 @@ describe("Logger", () => {
       expect(logger.isDebugEnabled()).toBeTruthy();
       expect(logger.isSillyEnabled()).toBeFalsy();
       logger.error({ someData: "test" });
-      expect(transform).toBeCalled();
+      expect(transform).toHaveBeenCalled();
       const params = transform.mock.calls[0][0];
       expect(dropColorInObjectProps(params)).toEqual({
         level: "error",

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -41,7 +41,7 @@ describe("Middleware", () => {
             .transform(() => []),
           middleware: jest.fn(),
         };
-        expect(() => createMiddleware(definition)).toThrowError(
+        expect(() => createMiddleware(definition)).toThrow(
           new IOSchemaError(
             "Using transformations on the top level of middleware input schema is not allowed.",
           ),

--- a/tests/unit/mime.spec.ts
+++ b/tests/unit/mime.spec.ts
@@ -1,8 +1,9 @@
-import { mimeJson, mimeMultipart } from "../../src/mime";
+import { mimeJson, mimeMultipart, mimeRaw } from "../../src/mime";
 
 describe("Mime", () => {
   test("should export predefined types", () => {
-    expect(mimeJson).toEqual("application/json");
-    expect(mimeMultipart).toEqual("multipart/form-data");
+    expect(mimeJson).toBe("application/json");
+    expect(mimeMultipart).toBe("multipart/form-data");
+    expect(mimeRaw).toBe("application/octet-stream");
   });
 });

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -58,7 +58,7 @@ describe("ResultHandler", () => {
           response: responseMock as Response,
           logger: loggerMock,
         });
-        expect(loggerMock.error).toBeCalledTimes(1);
+        expect(loggerMock.error).toHaveBeenCalledTimes(1);
         expect(loggerMock.error.mock.calls[0][0]).toMatch(
           /^Internal server error\nError: Some error/,
         );
@@ -70,7 +70,7 @@ describe("ResultHandler", () => {
         expect(loggerMock.error.mock.calls[0][1].payload).toEqual({
           something: 453,
         });
-        expect(responseMock.status).toBeCalledWith(500);
+        expect(responseMock.status).toHaveBeenCalledWith(500);
         expect(responseMock[errorMethod]).toHaveBeenCalledTimes(1);
         expect(responseMock[errorMethod].mock.calls[0]).toMatchSnapshot();
       });
@@ -98,8 +98,8 @@ describe("ResultHandler", () => {
           response: responseMock as Response,
           logger: loggerMock,
         });
-        expect(loggerMock.error).toBeCalledTimes(0);
-        expect(responseMock.status).toBeCalledWith(400);
+        expect(loggerMock.error).toHaveBeenCalledTimes(0);
+        expect(responseMock.status).toHaveBeenCalledWith(400);
         expect(responseMock[errorMethod]).toHaveBeenCalledTimes(1);
         expect(responseMock[errorMethod].mock.calls[0]).toMatchSnapshot();
       });
@@ -117,8 +117,8 @@ describe("ResultHandler", () => {
           response: responseMock as Response,
           logger: loggerMock,
         });
-        expect(loggerMock.error).toBeCalledTimes(0);
-        expect(responseMock.status).toBeCalledWith(404);
+        expect(loggerMock.error).toHaveBeenCalledTimes(0);
+        expect(responseMock.status).toHaveBeenCalledWith(404);
         expect(responseMock[errorMethod]).toHaveBeenCalledTimes(1);
         expect(responseMock[errorMethod].mock.calls[0]).toMatchSnapshot();
       });
@@ -136,8 +136,8 @@ describe("ResultHandler", () => {
           response: responseMock as Response,
           logger: loggerMock,
         });
-        expect(loggerMock.error).toBeCalledTimes(0);
-        expect(responseMock.status).toBeCalledWith(200);
+        expect(loggerMock.error).toHaveBeenCalledTimes(0);
+        expect(responseMock.status).toHaveBeenCalledWith(200);
         expect(responseMock.json).toHaveBeenCalledTimes(1);
         expect(responseMock.json.mock.calls[0]).toMatchSnapshot();
       });
@@ -183,8 +183,8 @@ describe("ResultHandler", () => {
       response: responseMock as Response,
       logger: loggerMock,
     });
-    expect(loggerMock.error).toBeCalledTimes(0);
-    expect(responseMock.status).toBeCalledWith(500);
+    expect(loggerMock.error).toHaveBeenCalledTimes(0);
+    expect(responseMock.status).toHaveBeenCalledWith(500);
     expect(responseMock.send).toHaveBeenCalledTimes(1);
     expect(responseMock.send.mock.calls[0]).toMatchSnapshot();
   });

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -8,7 +8,7 @@ import {
   ServeStatic,
   defaultResultHandler,
 } from "../../src";
-import { CommonConfig } from "../../src/config-type";
+import { CommonConfig } from "../../src";
 import { mimeJson } from "../../src/mime";
 import { makeRequestMock, makeResponseMock } from "../../src/mock";
 import { initRouting } from "../../src/routing";
@@ -78,12 +78,12 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.get).toBeCalledTimes(2);
-      expect(appMock.post).toBeCalledTimes(2);
-      expect(appMock.put).toBeCalledTimes(0);
-      expect(appMock.delete).toBeCalledTimes(0);
-      expect(appMock.patch).toBeCalledTimes(0);
-      expect(appMock.options).toBeCalledTimes(3);
+      expect(appMock.get).toHaveBeenCalledTimes(2);
+      expect(appMock.post).toHaveBeenCalledTimes(2);
+      expect(appMock.put).toHaveBeenCalledTimes(0);
+      expect(appMock.delete).toHaveBeenCalledTimes(0);
+      expect(appMock.patch).toHaveBeenCalledTimes(0);
+      expect(appMock.options).toHaveBeenCalledTimes(3);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/get");
       expect(appMock.get.mock.calls[1][0]).toBe("/v1/user/universal");
       expect(appMock.post.mock.calls[0][0]).toBe("/v1/user/set");
@@ -153,12 +153,12 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.get).toBeCalledTimes(1);
-      expect(appMock.post).toBeCalledTimes(1);
-      expect(appMock.put).toBeCalledTimes(1);
-      expect(appMock.patch).toBeCalledTimes(1);
-      expect(appMock.delete).toBeCalledTimes(0);
-      expect(appMock.options).toBeCalledTimes(1);
+      expect(appMock.get).toHaveBeenCalledTimes(1);
+      expect(appMock.post).toHaveBeenCalledTimes(1);
+      expect(appMock.put).toHaveBeenCalledTimes(1);
+      expect(appMock.patch).toHaveBeenCalledTimes(1);
+      expect(appMock.delete).toHaveBeenCalledTimes(0);
+      expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user");
       expect(appMock.post.mock.calls[0][0]).toBe("/v1/user");
       expect(appMock.put.mock.calls[0][0]).toBe("/v1/user");
@@ -235,7 +235,7 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.options).toBeCalledTimes(1);
+      expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0][0]).toBe("/hello");
       const fn = appMock.options.mock.calls[0][1];
       expect(typeof fn).toBe("function"); // async (req, res) => void
@@ -272,7 +272,7 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.get).toBeCalledTimes(1);
+      expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/:id");
     });
 
@@ -301,7 +301,7 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.get).toBeCalledTimes(2);
+      expect(appMock.get).toHaveBeenCalledTimes(2);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/:id");
       expect(appMock.get.mock.calls[1][0]).toBe("/v1/user/:id/download");
     });
@@ -367,7 +367,7 @@ describe("Routing", () => {
         config: configMock as CommonConfig,
         routing,
       });
-      expect(appMock.post).toBeCalledTimes(1);
+      expect(appMock.post).toHaveBeenCalledTimes(1);
       const routeHandler = appMock.post.mock.calls[0][1] as RequestHandler;
       const requestMock = {
         method: "POST",
@@ -387,19 +387,19 @@ describe("Routing", () => {
         responseMock as unknown as Response,
         nextMock,
       );
-      expect(nextMock).toBeCalledTimes(0);
-      expect(handlerMock).toBeCalledTimes(1);
-      expect(loggerMock.info).toBeCalledWith("POST: /v1/user/set");
-      expect(loggerMock.error).toBeCalledTimes(0);
-      expect(handlerMock).toBeCalledWith({
+      expect(nextMock).toHaveBeenCalledTimes(0);
+      expect(handlerMock).toHaveBeenCalledTimes(1);
+      expect(loggerMock.info).toHaveBeenCalledWith("POST: /v1/user/set");
+      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(handlerMock).toHaveBeenCalledWith({
         input: {
           test: 123,
         },
         options: {},
         logger: loggerMock,
       });
-      expect(responseMock.status).toBeCalledWith(200);
-      expect(responseMock.json).toBeCalledWith({
+      expect(responseMock.status).toHaveBeenCalledWith(200);
+      expect(responseMock.json).toHaveBeenCalledWith({
         status: "success",
         data: {
           result: true,

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -69,15 +69,15 @@ describe("Server", () => {
       createServer(configMock, routingMock);
       expect(appMock).toBeTruthy();
       expect(appMock.disable).toHaveBeenCalledWith("x-powered-by");
-      expect(appMock.use).toBeCalledTimes(3);
+      expect(appMock.use).toHaveBeenCalledTimes(3);
       expect(appMock.use.mock.calls[0][0]).toBe(expressJsonMock);
-      expect(appMock.get).toBeCalledTimes(1);
+      expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.post).toBeCalledTimes(1);
+      expect(appMock.post).toHaveBeenCalledTimes(1);
       expect(appMock.post.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.options).toBeCalledTimes(1);
+      expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0][0]).toBe("/v1/test");
-      expect(httpListenSpy).toBeCalledTimes(1);
+      expect(httpListenSpy).toHaveBeenCalledTimes(1);
       expect(httpListenSpy).toHaveBeenCalledWith(port, expect.any(Function));
     });
 
@@ -118,18 +118,18 @@ describe("Server", () => {
       expect(logger).toEqual(customLogger);
       expect(app).toEqual(appMock);
       expect(appMock).toBeTruthy();
-      expect(appMock.use).toBeCalledTimes(3);
+      expect(appMock.use).toHaveBeenCalledTimes(3);
       expect(appMock.use.mock.calls[0][0]).toBe(configMock.server.jsonParser);
-      expect(configMock.errorHandler.handler).toBeCalledTimes(0);
-      expect(infoMethod).toBeCalledTimes(1);
-      expect(infoMethod).toBeCalledWith(`Listening`, { port });
-      expect(appMock.get).toBeCalledTimes(1);
+      expect(configMock.errorHandler.handler).toHaveBeenCalledTimes(0);
+      expect(infoMethod).toHaveBeenCalledTimes(1);
+      expect(infoMethod).toHaveBeenCalledWith(`Listening`, { port });
+      expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.post).toBeCalledTimes(1);
+      expect(appMock.post).toHaveBeenCalledTimes(1);
       expect(appMock.post.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.options).toBeCalledTimes(1);
+      expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0][0]).toBe("/v1/test");
-      expect(httpListenSpy).toBeCalledTimes(1);
+      expect(httpListenSpy).toHaveBeenCalledTimes(1);
       expect(httpListenSpy).toHaveBeenCalledWith(
         { port },
         expect.any(Function),
@@ -167,7 +167,7 @@ describe("Server", () => {
         configMock.https.options,
         appMock,
       );
-      expect(httpsListenSpy).toBeCalledTimes(1);
+      expect(httpsListenSpy).toHaveBeenCalledTimes(1);
       expect(httpsListenSpy).toHaveBeenCalledWith(
         configMock.https.listen,
         expect.any(Function),
@@ -393,14 +393,14 @@ describe("Server", () => {
       );
       expect(logger).toEqual(customLogger);
       expect(typeof notFoundHandler).toBe("function");
-      expect(appMock.use).toBeCalledTimes(0);
-      expect(configMock.errorHandler.handler).toBeCalledTimes(0);
-      expect(infoMethod).toBeCalledTimes(0);
-      expect(appMock.get).toBeCalledTimes(1);
+      expect(appMock.use).toHaveBeenCalledTimes(0);
+      expect(configMock.errorHandler.handler).toHaveBeenCalledTimes(0);
+      expect(infoMethod).toHaveBeenCalledTimes(0);
+      expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.post).toBeCalledTimes(1);
+      expect(appMock.post).toHaveBeenCalledTimes(1);
       expect(appMock.post.mock.calls[0][0]).toBe("/v1/test");
-      expect(appMock.options).toBeCalledTimes(1);
+      expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0][0]).toBe("/v1/test");
     });
   });

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -30,7 +30,7 @@ describe("ZodUpload", () => {
       const buffer = Buffer.from("something");
       const result = schema.safeParse({
         name: "avatar.jpg",
-        mv: async () => Promise.resolve(),
+        mv: jest.fn(async () => Promise.resolve()),
         encoding: "utf-8",
         mimetype: "image/jpeg",
         data: buffer,


### PR DESCRIPTION
In accordance with https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67143

There are also some warnings fixed in tests, that are reported by IDE, like unused variables.