### PR TITLE
Ref: overloads for `createConfig` method

### DIFF
--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -130,9 +130,12 @@ export interface AppConfig<TAG extends string = string>
   app: Express;
 }
 
-export const createConfig = <
-  TAG extends string,
-  T extends ServerConfig<TAG> | AppConfig<TAG>,
->(
-  config: T,
-): T => config;
+export function createConfig<TAG extends string>(
+  config: ServerConfig<TAG>,
+): ServerConfig<TAG>;
+export function createConfig<TAG extends string>(
+  config: AppConfig<TAG>,
+): AppConfig<TAG>;
+export function createConfig(config: AppConfig | ServerConfig) {
+  return config;
+}


### PR DESCRIPTION
This is a cherry-pick of 6355365 originally made in #1314, which I actually wanted to make in the current version.
It introduces more constraints on the argument of `createConfig` method, making it either `ServerConfig` OR `AppConfig`, forbidding to use both `app` and `server` properties.
The goal is to eliminate the confusion while writing the implementation.