### PR TITLE
Ref: common starter for all servers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -123,21 +123,18 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
   initRouting({ app, routing, logger, config });
   app.use(notFoundHandler);
 
-  const starter = async <T extends http.Server | https.Server>(
+  const starter = <T extends http.Server | https.Server>(
     server: T,
     subject: typeof config.server.listen,
   ) =>
-    new Promise<T>((resolve) => {
-      server.listen(subject, () => {
-        logger.info("Listening", subject);
-        resolve(server);
-      });
-    });
+    server.listen(subject, () => {
+      logger.info("Listening", subject);
+    }) as T;
 
   const servers = {
-    httpServer: await starter(http.createServer(app), config.server.listen),
+    httpServer: starter(http.createServer(app), config.server.listen),
     httpsServer: config.https
-      ? await starter(
+      ? starter(
           https.createServer(config.https.options, app),
           config.https.listen,
         )


### PR DESCRIPTION
In v15 `createServer` becomes async (returns Promise).
~~I'd like to use that advantage to await for actual listening started before fulfilling the Promise.~~

After some considerations I decided to postpone that feature and limit the PR only to refactoring with a common starter.