### PR TITLE
Fix: supporting primitive values for logging metadata

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -64,13 +64,17 @@ export const createWinstonLogger = async (
         meta = { ...meta, ...(message as object) };
         message = "[No message]";
       }
-      return (
-        `${timestamp} ${level}: ${message}` +
-        (durationMs === undefined ? "" : ` duration: ${durationMs}ms`) +
-        (Object.keys(meta).length === 0
-          ? ""
-          : " " + (isPretty ? prettyPrint(meta) : JSON.stringify(meta)))
-      );
+      const hasMetaProps = Object.keys(meta).length > 0;
+      const details = [];
+      if (durationMs) {
+        details.push("duration:", `${durationMs}ms`);
+      }
+      if (hasMetaProps) {
+        details.push(isPretty ? prettyPrint(meta) : JSON.stringify(meta));
+      } else {
+        details.push(...(meta?.[Symbol.for("splat")] || []));
+      }
+      return [timestamp, `${level}:`, message, ...details].join(" ");
     });
 
   const formats: Format[] = [useTimestamp()];

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,11 +136,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
         ? config.https!.listen
         : config.server.listen;
     server?.listen(listeningSubject, () => {
-      if (typeof listeningSubject === "object") {
-        logger.info("Listening", listeningSubject);
-      } else {
-        logger.info(`Listening ${listeningSubject}`);
-      }
+      logger.info("Listening", listeningSubject);
     });
   }
 

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -132,6 +132,25 @@ describe("Logger", () => {
       });
       expect(hasAnsi(params.level)).toBeTruthy();
     });
+
+    test.each(["debug", "warn"] as const)(
+      "Should handle non-object meta %#",
+      async (level) => {
+        const logger = await createWinstonLogger({ level, color: true });
+        const transform = jest.spyOn(logger.transports[0].format!, "transform");
+        logger.error("Code", 8090);
+        expect(transform).toHaveBeenCalled();
+        const params = transform.mock.calls[0][0];
+        expect(dropColorInObjectProps(params)).toEqual({
+          level: "error",
+          [LEVEL]: "error",
+          timestamp: "2022-01-01T00:00:00.000Z",
+          [SPLAT]: [8090],
+          message: "Code",
+          [MESSAGE]: `2022-01-01T00:00:00.000Z error: Code 8090`,
+        });
+      },
+    );
   });
 
   describe("isSimplifiedLoggerConfig()", () => {


### PR DESCRIPTION
```
logger.info("Listening", 8090)
```

will work in v15