### PR TITLE
Restoring `createLogger` in v15

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export {
   getMessageFromError,
   getStatusCodeFromError,
 } from "./common-helpers";
-export { LoggerOverrides } from "./logger";
+export { createLogger, LoggerOverrides } from "./logger";
 export { createMiddleware } from "./middleware";
 export {
   createResultHandler,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -35,7 +35,7 @@ export const isSimplifiedWinstonConfig = (
 /**
  * @desc a helper for creating a winston logger easier
  * @requires winston
- * @example createWinstonLogger({ winston, level: "debug", color: true })
+ * @example createLogger({ winston, level: "debug", color: true })
  * */
 export const createLogger = ({
   winston: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,10 +69,7 @@ export const createNotFoundHandler =
 
 const makeCommonEntities = async (config: CommonConfig) => {
   const logger: AbstractLogger = isSimplifiedWinstonConfig(config.logger)
-    ? createLogger({
-        ...config.logger,
-        winston: await loadPeer("winston"),
-      })
+    ? createLogger({ ...config.logger, winston: await loadPeer("winston") })
     : config.logger;
   const errorHandler = config.errorHandler || defaultResultHandler;
   const notFoundHandler = createNotFoundHandler(errorHandler, logger);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import https from "node:https";
 import { AppConfig, CommonConfig, ServerConfig } from "./config-type";
 import {
   AbstractLogger,
-  createWinstonLogger,
+  createLogger,
   isSimplifiedWinstonConfig,
 } from "./logger";
 import { ResultHandlerError } from "./errors";
@@ -69,7 +69,10 @@ export const createNotFoundHandler =
 
 const makeCommonEntities = async (config: CommonConfig) => {
   const logger: AbstractLogger = isSimplifiedWinstonConfig(config.logger)
-    ? await createWinstonLogger(config.logger)
+    ? createLogger({
+        ...config.logger,
+        winston: await loadPeer("winston"),
+      })
     : config.logger;
   const errorHandler = config.errorHandler || defaultResultHandler;
   const notFoundHandler = createNotFoundHandler(errorHandler, logger);

--- a/tests/unit/__snapshots__/index.spec.ts.snap
+++ b/tests/unit/__snapshots__/index.spec.ts.snap
@@ -46,6 +46,8 @@ exports[`Index Entrypoint exports attachRouting should have certain value 1`] = 
 
 exports[`Index Entrypoint exports createConfig should have certain value 1`] = `[Function]`;
 
+exports[`Index Entrypoint exports createLogger should have certain value 1`] = `[Function]`;
+
 exports[`Index Entrypoint exports createMiddleware should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint exports createResultHandler should have certain value 1`] = `[Function]`;
@@ -111,6 +113,7 @@ exports[`Index Entrypoint exports should have certain entities exposed 1`] = `
   "arrayResultHandler",
   "attachRouting",
   "createConfig",
+  "createLogger",
   "createMiddleware",
   "createResultHandler",
   "createServer",

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -2,10 +2,8 @@ import { LEVEL, MESSAGE, SPLAT } from "triple-beam";
 import MockDate from "mockdate";
 import stripAnsi from "strip-ansi";
 import hasAnsi from "has-ansi";
-import {
-  createWinstonLogger,
-  isSimplifiedWinstonConfig,
-} from "../../src/logger";
+import { createLogger, isSimplifiedWinstonConfig } from "../../src/logger";
+import winston from "winston";
 
 describe("Logger", () => {
   beforeEach(() => {
@@ -29,8 +27,8 @@ describe("Logger", () => {
   };
 
   describe("createWinstonLogger()", () => {
-    test("Should create silent logger", async () => {
-      const logger = await createWinstonLogger({ level: "silent" });
+    test("Should create silent logger", () => {
+      const logger = createLogger({ winston, level: "silent" });
       const transform = jest.spyOn(logger.transports[0].format!, "transform");
       expect(logger.silent).toBeTruthy();
       expect(logger.isErrorEnabled()).toBeTruthy();
@@ -43,8 +41,8 @@ describe("Logger", () => {
       expect(transform).toHaveBeenCalledTimes(0);
     });
 
-    test("Should create warn logger", async () => {
-      const logger = await createWinstonLogger({ level: "warn" });
+    test("Should create warn logger", () => {
+      const logger = createLogger({ winston, level: "warn" });
       const transform = jest.spyOn(logger.transports[0].format!, "transform");
       expect(logger.isErrorEnabled()).toBeTruthy();
       expect(logger.isWarnEnabled()).toBeTruthy();
@@ -68,8 +66,8 @@ describe("Logger", () => {
       expect(hasAnsi(params.level)).toBeFalsy();
     });
 
-    test("Should create debug logger", async () => {
-      const logger = await createWinstonLogger({ level: "debug", color: true });
+    test("Should create debug logger", () => {
+      const logger = createLogger({ winston, level: "debug", color: true });
       const transform = jest.spyOn(logger.transports[0].format!, "transform");
       expect(logger.isErrorEnabled()).toBeTruthy();
       expect(logger.isWarnEnabled()).toBeTruthy();
@@ -92,8 +90,8 @@ describe("Logger", () => {
       expect(hasAnsi(params.level)).toBeTruthy();
     });
 
-    test("Should manage profiling", async () => {
-      const logger = await createWinstonLogger({ level: "debug", color: true });
+    test("Should manage profiling", () => {
+      const logger = createLogger({ winston, level: "debug", color: true });
       const transform = jest.spyOn(logger.transports[0].format!, "transform");
       logger.profile("long-test");
       MockDate.set("2022-01-01T00:00:00.554Z");
@@ -111,8 +109,8 @@ describe("Logger", () => {
       expect(hasAnsi(params.level)).toBeTruthy();
     });
 
-    test("Should handle empty message", async () => {
-      const logger = await createWinstonLogger({ level: "debug", color: true });
+    test("Should handle empty message", () => {
+      const logger = createLogger({ winston, level: "debug", color: true });
       const transform = jest.spyOn(logger.transports[0].format!, "transform");
       expect(logger.isErrorEnabled()).toBeTruthy();
       expect(logger.isWarnEnabled()).toBeTruthy();
@@ -135,8 +133,8 @@ describe("Logger", () => {
 
     test.each(["debug", "warn"] as const)(
       "Should handle non-object meta %#",
-      async (level) => {
-        const logger = await createWinstonLogger({ level, color: true });
+      (level) => {
+        const logger = createLogger({ winston, level, color: true });
         const transform = jest.spyOn(logger.transports[0].format!, "transform");
         logger.error("Code", 8090);
         expect(transform).toHaveBeenCalled();
@@ -169,7 +167,6 @@ describe("Logger", () => {
       { level: null },
       { level: "wrong" },
       { level: "debug", color: null },
-      createWinstonLogger({ level: "debug" }),
     ])("should invalidate config %#", (sample) => {
       expect(isSimplifiedWinstonConfig(sample)).toBeFalsy();
     });


### PR DESCRIPTION
I decided to restore `createLogger` exposition sync, but with `winston` argument.
Thus, all async `loadPeer` are concentrated in `server.ts` file and there are less breaking changes.