### PR TITLE
CI: Moving build step after unit tests.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,8 +35,6 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
     - name: Install dependencies
       run: yarn install
-    - name: Build
-      run: yarn build
     - name: Lint
       run: yarn lint
     - name: Test
@@ -48,6 +46,8 @@ jobs:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ matrix.node-version }}
         parallel: true
+    - name: Build
+      run: yarn build
     - name: Vitest compatibility
       run: yarn test:vi
     - name: Integration test


### PR DESCRIPTION
Previous improvements on making stable integration tests in #1355 and #1354 made it possible