### PR TITLE
Ref: making `vitest` compatibility test an integration one

### DIFF
--- a/tests/vitest/compat.spec.ts
+++ b/tests/vitest/compat.spec.ts
@@ -1,9 +1,8 @@
-import { defaultEndpointsFactory } from "../../src";
+import { defaultEndpointsFactory, testEndpoint } from "express-zod-api";
 import { Mock, describe, expect, test } from "vitest";
 import { z } from "zod";
-import { testEndpoint } from "../../src";
 
-declare module "../../src" {
+declare module "express-zod-api" {
   interface MockOverrides extends Mock {}
 }
 

--- a/tests/vitest/package.json
+++ b/tests/vitest/package.json
@@ -6,6 +6,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "express-zod-api": "link:../..",
+    "express": "^4",
+    "http-errors": "^2",
+    "typescript": "^5",
+    "zod": "^3"
+  },
+  "devDependencies": {
     "vitest": "^1.0.0-beta.4"
   }
 }


### PR DESCRIPTION
For consistency and making more sense 