### PR TITLE
Feat: Multiple status codes

### DIFF
--- a/src/api-response.ts
+++ b/src/api-response.ts
@@ -5,8 +5,14 @@ export interface ApiResponse<S extends z.ZodTypeAny> {
   /**
    * @default 200 for a positive response
    * @default 400 for a negative response
+   * @override statusCodes
    * */
   statusCode?: number;
+  /**
+   * @default [200] for positive response
+   * @default [400] for negative response
+   * */
+  statusCodes?: [number, ...number[]];
   /**
    * @default "application/json"
    * @override mimeTypes

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -31,7 +31,7 @@ import {
 import { Security } from "./security";
 import { AbstractLogger } from "./logger";
 
-interface ProcessedResponse<S> {
+export interface ProcessedResponse<S> {
   schema: S;
   statusCodes: number[];
   mimeTypes: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type { ZodUploadDef } from "./upload-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
 export type { MiddlewareDefinition } from "./middleware";
 export type { ResultHandlerDefinition } from "./result-handler";
+export type { ProcessedResponse } from "./endpoint";
 export type {
   BasicSecurity,
   BearerSecurity,

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -38,8 +38,10 @@ export interface ResultHandlerDefinition<
   POS extends z.ZodTypeAny,
   NEG extends z.ZodTypeAny,
 > {
-  getPositiveResponse: (output: IOSchema) => POS | ApiResponse<POS>;
-  getNegativeResponse: () => NEG | ApiResponse<NEG>;
+  getPositiveResponse: (
+    output: IOSchema,
+  ) => POS | ApiResponse<POS> | ApiResponse<POS>[];
+  getNegativeResponse: () => NEG | ApiResponse<NEG> | ApiResponse<NEG>[];
   handler: ResultHandler<z.output<POS> | z.output<NEG>>;
 }
 

--- a/tests/unit/__snapshots__/endpoint.spec.ts.snap
+++ b/tests/unit/__snapshots__/endpoint.spec.ts.snap
@@ -1,45 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Endpoint > .getNegativeResponseSchema() > should return the negative schema of the result handler 1`] = `
-{
-  "_type": "ZodObject",
-  "shape": {
-    "error": {
-      "_type": "ZodObject",
-      "shape": {
-        "message": {
-          "_type": "ZodString",
-        },
-      },
-    },
-    "status": {
-      "_type": "ZodLiteral",
-      "value": "error",
-    },
-  },
-}
-`;
-
-exports[`Endpoint > .getPositiveResponseSchema() > should return schema according to the result handler 1`] = `
-{
-  "_type": "ZodObject",
-  "shape": {
-    "data": {
-      "_type": "ZodObject",
-      "shape": {
-        "something": {
-          "_type": "ZodNumber",
-        },
-      },
-    },
-    "status": {
-      "_type": "ZodLiteral",
-      "value": "success",
-    },
-  },
-}
-`;
-
 exports[`Endpoint > .getResponses() > should return positive schema and mime types according to the result handler 1`] = `
 [
   {

--- a/tests/unit/__snapshots__/endpoint.spec.ts.snap
+++ b/tests/unit/__snapshots__/endpoint.spec.ts.snap
@@ -39,3 +39,47 @@ exports[`Endpoint > .getPositiveResponseSchema() > should return schema accordin
   },
 }
 `;
+
+exports[`Endpoint > .getResponses() > should return positive schema and mime types according to the result handler 1`] = `
+[
+  {
+    "_type": "ZodObject",
+    "shape": {
+      "data": {
+        "_type": "ZodObject",
+        "shape": {
+          "something": {
+            "_type": "ZodNumber",
+          },
+        },
+      },
+      "status": {
+        "_type": "ZodLiteral",
+        "value": "success",
+      },
+    },
+  },
+]
+`;
+
+exports[`Endpoint > .getResponses() > should return the negative schema of the result handler 1`] = `
+[
+  {
+    "_type": "ZodObject",
+    "shape": {
+      "error": {
+        "_type": "ZodObject",
+        "shape": {
+          "message": {
+            "_type": "ZodString",
+          },
+        },
+      },
+      "status": {
+        "_type": "ZodLiteral",
+        "value": "error",
+      },
+    },
+  },
+]
+`;

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -773,14 +773,9 @@ describe("Documentation helpers", () => {
     test("should depict query and path params", () => {
       expect(
         depictRequestParams({
-          endpoint: defaultEndpointsFactory.build({
-            methods: ["get", "put", "delete"],
-            input: z.object({
-              id: z.string(),
-              test: z.boolean(),
-            }),
-            output: z.object({}),
-            handler: vi.fn(),
+          schema: z.object({
+            id: z.string(),
+            test: z.boolean(),
           }),
           inputSources: ["query", "params"],
           composition: "inline",
@@ -792,14 +787,9 @@ describe("Documentation helpers", () => {
     test("should depict only path params if query is disabled", () => {
       expect(
         depictRequestParams({
-          endpoint: defaultEndpointsFactory.build({
-            methods: ["get", "put", "delete"],
-            input: z.object({
-              id: z.string(),
-              test: z.boolean(),
-            }),
-            output: z.object({}),
-            handler: vi.fn(),
+          schema: z.object({
+            id: z.string(),
+            test: z.boolean(),
           }),
           inputSources: ["body", "params"],
           composition: "inline",
@@ -811,14 +801,9 @@ describe("Documentation helpers", () => {
     test("should depict none if both query and params are disabled", () => {
       expect(
         depictRequestParams({
-          endpoint: defaultEndpointsFactory.build({
-            methods: ["get", "put", "delete"],
-            input: z.object({
-              id: z.string(),
-              test: z.boolean(),
-            }),
-            output: z.object({}),
-            handler: vi.fn(),
+          schema: z.object({
+            id: z.string(),
+            test: z.boolean(),
           }),
           inputSources: ["body"],
           composition: "inline",
@@ -830,15 +815,10 @@ describe("Documentation helpers", () => {
     test("Feature 1180: should depict header params when enabled", () => {
       expect(
         depictRequestParams({
-          endpoint: defaultEndpointsFactory.build({
-            method: "get",
-            input: z.object({
-              "x-request-id": z.string(),
-              id: z.string(),
-              test: z.boolean(),
-            }),
-            output: z.object({}),
-            handler: vi.fn(),
+          schema: z.object({
+            "x-request-id": z.string(),
+            id: z.string(),
+            test: z.boolean(),
           }),
           inputSources: ["query", "headers", "params"],
           composition: "inline",

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -3,12 +3,7 @@ import { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
 import { z } from "zod";
 import { defaultSerializer } from "../../src/common-helpers";
 import { IOSchemaError } from "../../src/errors";
-import {
-  DocumentationError,
-  defaultEndpointsFactory,
-  ez,
-  withMeta,
-} from "../../src";
+import { DocumentationError, ez, withMeta } from "../../src";
 import { getMeta } from "../../src/metadata";
 import {
   OpenAPIContext,

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -288,24 +288,8 @@ describe("Endpoint", () => {
     });
   });
 
-  describe(".getInputSchema()", () => {
-    test("should return input schema", () => {
-      const factory = new EndpointsFactory(defaultResultHandler);
-      const input = z.object({
-        something: z.number(),
-      });
-      const endpoint = factory.build({
-        method: "get",
-        input,
-        output: z.object({}),
-        handler: vi.fn(),
-      });
-      expect(endpoint.getSchema("input")).toEqual(input);
-    });
-  });
-
   describe(".getOperationId()", () => {
-    test("should return undefined if its not defined upon creaton", () => {
+    test("should return undefined if its not defined upon creation", () => {
       expect(
         new Endpoint({
           methods: ["get"],
@@ -318,8 +302,22 @@ describe("Endpoint", () => {
     });
   });
 
-  describe(".outputSchema", () => {
-    test("should be the output schema", () => {
+  describe(".getSchema()", () => {
+    test("should return the input schema", () => {
+      const factory = new EndpointsFactory(defaultResultHandler);
+      const input = z.object({
+        something: z.number(),
+      });
+      const endpoint = factory.build({
+        method: "get",
+        input,
+        output: z.object({}),
+        handler: vi.fn(),
+      });
+      expect(endpoint.getSchema("input")).toEqual(input);
+    });
+
+    test("should return the output schema", () => {
       const outputSchema = z.object({
         something: z.number(),
       });

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -334,8 +334,8 @@ describe("Endpoint", () => {
     });
   });
 
-  describe(".getPositiveResponseSchema()", () => {
-    test("should return schema according to the result handler", () => {
+  describe(".getResponses()", () => {
+    test("should return positive schema and mime types according to the result handler", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const output = z.object({
         something: z.number(),
@@ -347,12 +347,15 @@ describe("Endpoint", () => {
         handler: vi.fn(),
       });
       expect(
-        serializeSchemaForTest(endpoint.getSchema("positive")),
+        endpoint
+          .getResponses("positive")
+          .map(({ schema }) => serializeSchemaForTest(schema)),
       ).toMatchSnapshot();
+      expect(
+        endpoint.getResponses("positive").map(({ mimeTypes }) => mimeTypes),
+      ).toEqual([["application/json"]]);
     });
-  });
 
-  describe(".getNegativeResponseSchema()", () => {
     test("should return the negative schema of the result handler", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const output = z.object({
@@ -365,34 +368,13 @@ describe("Endpoint", () => {
         handler: vi.fn(),
       });
       expect(
-        serializeSchemaForTest(endpoint.getSchema("negative")),
+        endpoint
+          .getResponses("negative")
+          .map(({ schema }) => serializeSchemaForTest(schema)),
       ).toMatchSnapshot();
-    });
-  });
-
-  describe(".getPositiveMimeTypes()", () => {
-    test("should return an array according to the result handler", () => {
-      const factory = new EndpointsFactory(defaultResultHandler);
-      const endpoint = factory.build({
-        method: "get",
-        input: z.object({}),
-        output: z.object({}),
-        handler: vi.fn(),
-      });
-      expect(endpoint.getMimeTypes("positive")).toEqual(["application/json"]);
-    });
-  });
-
-  describe(".getNegativeMimeTypes()", () => {
-    test("should return an array according to the result handler", () => {
-      const factory = new EndpointsFactory(defaultResultHandler);
-      const endpoint = factory.build({
-        method: "get",
-        input: z.object({}),
-        output: z.object({}),
-        handler: vi.fn(),
-      });
-      expect(endpoint.getMimeTypes("negative")).toEqual(["application/json"]);
+      expect(
+        endpoint.getResponses("negative").map(({ mimeTypes }) => mimeTypes),
+      ).toEqual([["application/json"]]);
     });
   });
 


### PR DESCRIPTION
According to discussions #1193 , #1332 and #824

I'm trying here to enable consumers to declare slightly different schemas for various HTTP status codes.
So far, it used to be only one pair, but configurable (200 and 400 by default for positive and negative accordingly).