### PR TITLE
Support connecting express router in app config.

### DIFF
--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -1,5 +1,5 @@
 import type compression from "compression";
-import { Express, Request, RequestHandler } from "express";
+import { IRouter, Request, RequestHandler } from "express";
 import type fileUpload from "express-fileupload";
 import { ServerOptions } from "node:https";
 import { AbstractEndpoint } from "./endpoint";
@@ -127,7 +127,7 @@ export interface ServerConfig<TAG extends string = string>
 export interface AppConfig<TAG extends string = string>
   extends CommonConfig<TAG> {
   /** @desc Your custom express app instead. */
-  app: Express;
+  app: IRouter;
 }
 
 export function createConfig<TAG extends string>(

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -126,7 +126,7 @@ export interface ServerConfig<TAG extends string = string>
 
 export interface AppConfig<TAG extends string = string>
   extends CommonConfig<TAG> {
-  /** @desc Your custom express app instead. */
+  /** @desc Your custom express app or express router instead. */
   app: IRouter;
 }
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import { IRouter } from "express";
 import { CommonConfig } from "./config-type";
 import { DependsOnMethod } from "./depends-on-method";
 import { AbstractEndpoint } from "./endpoint";
@@ -17,7 +17,7 @@ export const initRouting = ({
   config,
   routing,
 }: {
-  app: Express;
+  app: IRouter;
   logger: AbstractLogger;
   config: CommonConfig;
   routing: Routing;

--- a/tests/unit/config-type.spec.ts
+++ b/tests/unit/config-type.spec.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import { Express, IRouter } from "express";
 import { createConfig } from "../../src";
 import winston from "winston";
 import { describe, expect, test, vi } from "vitest";
@@ -20,6 +20,16 @@ describe("ConfigType", () => {
     test("should create a config with app", () => {
       const argument = {
         app: vi.fn() as unknown as Express,
+        cors: true,
+        logger: winston.createLogger({ silent: true }),
+      };
+      const config = createConfig(argument);
+      expect(config).toEqual(argument);
+    });
+
+    test("should create a config with router", () => {
+      const argument = {
+        app: vi.fn() as unknown as IRouter,
         cors: true,
         logger: winston.createLogger({ silent: true }),
       };

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import { IRouter } from "express";
 import { expectType } from "tsd";
 import { z } from "zod";
 import * as entrypoint from "../../src";
@@ -60,7 +60,7 @@ describe("Index Entrypoint", () => {
       expectType<ZodUploadDef>({ typeName: "ZodUpload" });
       expectType<CommonConfig>({ cors: true, logger: { level: "silent" } });
       expectType<AppConfig>({
-        app: {} as Express,
+        app: {} as IRouter,
         cors: true,
         logger: { level: "silent" },
       });

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -21,7 +21,7 @@ import {
   makeResponseMock,
 } from "../../src/testing";
 import { initRouting } from "../../src/routing";
-import type { Express, Request, RequestHandler, Response } from "express";
+import type { IRouter, Request, RequestHandler, Response } from "express";
 import {
   Mock,
   beforeAll,
@@ -77,7 +77,7 @@ describe("Routing", () => {
         },
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -106,7 +106,7 @@ describe("Routing", () => {
         startupLogo: false,
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -152,7 +152,7 @@ describe("Routing", () => {
         },
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -190,7 +190,7 @@ describe("Routing", () => {
       };
       expect(() =>
         initRouting({
-          app: appMock as unknown as Express,
+          app: appMock as unknown as IRouter,
           logger: winston.createLogger({ silent: true }),
           config: configMock as CommonConfig,
           routing,
@@ -234,7 +234,7 @@ describe("Routing", () => {
         }),
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -274,7 +274,7 @@ describe("Routing", () => {
         },
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -303,7 +303,7 @@ describe("Routing", () => {
         },
       };
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: winston.createLogger({ silent: true }),
         config: configMock as CommonConfig,
         routing,
@@ -324,7 +324,7 @@ describe("Routing", () => {
       });
       expect(() =>
         initRouting({
-          app: appMock as unknown as Express,
+          app: appMock as unknown as IRouter,
           logger: winston.createLogger({ silent: true }),
           config: configMock as CommonConfig,
           routing: {
@@ -336,7 +336,7 @@ describe("Routing", () => {
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
         initRouting({
-          app: appMock as unknown as Express,
+          app: appMock as unknown as IRouter,
           logger: winston.createLogger({ silent: true }),
           config: configMock as CommonConfig,
           routing: {
@@ -370,7 +370,7 @@ describe("Routing", () => {
       };
       const loggerMock = makeLoggerMock({ fnMethod: vi.fn });
       initRouting({
-        app: appMock as unknown as Express,
+        app: appMock as unknown as IRouter,
         logger: loggerMock,
         config: configMock as CommonConfig,
         routing,


### PR DESCRIPTION
Currently only an `Express` application can be connected with `createConfig`, however applications may use express `IRouter`s instead, e.g. for configuring routes on separate subdomains.

This change updates the expected type from `Express` to `IRouter` (which `Express` inherits from)