### PR TITLE
Proprietary schemas using native zod methods and Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Version 16
 
+### 16.3.0
+
+- Switching to using native `zod` methods for proprietary schemas instead of custom classes (`ez` namespace):
+  - Each proprietary schema now relies on internal Metadata;
+  - Validation errors for `ez.file()` are changed slightly;
+  - The following refinements of `ez.file()` are deprecated and will be removed later:
+    - ~~`ez.file().string()`~~ — use `ez.file("string")` instead,
+    - ~~`ez.file().buffer()`~~ — use `ez.file("buffer")` instead,
+    - ~~`ez.file().base64()`~~ — use `ez.file("base64")` instead,
+    - ~~`ez.file().binary()`~~ — use `ez.file("binary")` instead.
+
 ### 16.2.2
 
 - Fixed issue #1458 reported by [@elee1766](https://github.com/elee1766):

--- a/README.md
+++ b/README.md
@@ -708,14 +708,14 @@ You can find two approaches to `EndpointsFactory` and `ResultHandler` implementa
 [in this example](https://github.com/RobinTail/express-zod-api/blob/master/example/factories.ts).
 One of them implements file streaming, in this case the endpoint just has to provide the filename.
 The response schema generally may be just `z.string()`, but I made more specific `ez.file()` that also supports
-`.binary()` and `.base64()` refinements which are reflected in the
+`ez.file("binary")` and `ez.file("base64")` variants which are reflected in the
 [generated documentation](#creating-a-documentation).
 
 ```typescript
 const fileStreamingEndpointsFactory = new EndpointsFactory(
   createResultHandler({
     getPositiveResponse: () => ({
-      schema: ez.file().buffer(),
+      schema: ez.file("buffer"),
       mimeType: "image/*",
     }),
     getNegativeResponse: () => ({ schema: z.string(), mimeType: "text/plain" }),
@@ -899,7 +899,7 @@ Some APIs may require an endpoint to be able to accept and process raw data, suc
 file as an entire body of request. In order to enable this feature you need to set the `rawParser` config feature to
 `express.raw()`. See also its options [in Express.js documentation](https://expressjs.com/en/4x/api.html#express.raw).
 The raw data is placed into `request.body.raw` property, having type `Buffer`. Then use the proprietary `ez.raw()`
-schema (which is an alias for `z.object({ raw: ez.file().buffer() })`) as the input schema of your endpoint.
+schema (which is an alias for `z.object({ raw: ez.file("buffer") })`) as the input schema of your endpoint.
 
 ```typescript
 import express from "express";

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Example API
-  version: 16.2.2
+  version: 16.3.0-beta1
 paths:
   /v1/user/retrieve:
     get:

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -52,7 +52,7 @@ export const fileStreamingEndpointsFactory = new EndpointsFactory({
   config,
   resultHandler: createResultHandler({
     getPositiveResponse: () => ({
-      schema: ez.file().buffer(),
+      schema: ez.file("buffer"), // .buffer(),
       mimeType: "image/*",
     }),
     getNegativeResponse: () => ({

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -52,7 +52,7 @@ export const fileStreamingEndpointsFactory = new EndpointsFactory({
   config,
   resultHandler: createResultHandler({
     getPositiveResponse: () => ({
-      schema: ez.file("buffer"), // .buffer(),
+      schema: ez.file("buffer"),
       mimeType: "image/*",
     }),
     getNegativeResponse: () => ({

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -52,7 +52,7 @@ export const fileStreamingEndpointsFactory = new EndpointsFactory({
   config,
   resultHandler: createResultHandler({
     getPositiveResponse: () => ({
-      schema: ez.file().buffer(),
+      schema: ez.file("buffer"),
       mimeType: "image/*",
     }),
     getNegativeResponse: () => ({

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -52,7 +52,7 @@ export const fileStreamingEndpointsFactory = new EndpointsFactory({
   config,
   resultHandler: createResultHandler({
     getPositiveResponse: () => ({
-      schema: ez.file("buffer"),
+      schema: ez.file().buffer(),
       mimeType: "image/*",
     }),
     getNegativeResponse: () => ({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-zod-api",
-  "version": "16.2.2",
+  "version": "16.3.0-beta1",
   "description": "A Typescript library to help you get an API server up and running with I/O schema validation and custom middlewares in minutes.",
   "license": "MIT",
   "repository": {

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -5,12 +5,12 @@ import { xprod } from "ramda";
 import { z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { InputValidationError, OutputValidationError } from "./errors";
-import { zodFileKind } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import { AbstractLogger } from "./logger";
 import { getMeta, isProprietary } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { mimeMultipart } from "./mime";
+import { zodRawKind } from "./raw-schema";
 import { zodUploadKind } from "./upload-schema";
 
 export type FlatObject = Record<string, unknown>;
@@ -235,11 +235,7 @@ export const hasUpload = (subject: IOSchema) =>
 export const hasRaw = (subject: IOSchema) =>
   hasNestedSchema({
     subject,
-    condition: (schema) =>
-      schema instanceof z.ZodObject &&
-      "raw" in schema.shape &&
-      isProprietary(schema.shape.raw, zodFileKind) &&
-      !(schema.shape.raw instanceof z.ZodString),
+    condition: (schema) => isProprietary(schema, zodRawKind),
   });
 
 /**

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -10,8 +10,8 @@ import { AbstractLogger } from "./logger";
 import { getMeta, isProprietary } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { mimeMultipart } from "./mime";
-import { zodRawKind } from "./raw-schema";
-import { zodUploadKind } from "./upload-schema";
+import { ezRawKind } from "./raw-schema";
+import { ezUploadKind } from "./upload-schema";
 
 export type FlatObject = Record<string, unknown>;
 
@@ -229,13 +229,13 @@ export const hasNestedSchema = ({
 export const hasUpload = (subject: IOSchema) =>
   hasNestedSchema({
     subject,
-    condition: (schema) => isProprietary(schema, zodUploadKind),
+    condition: (schema) => isProprietary(schema, ezUploadKind),
   });
 
 export const hasRaw = (subject: IOSchema) =>
   hasNestedSchema({
     subject,
-    condition: (schema) => isProprietary(schema, zodRawKind),
+    condition: (schema) => isProprietary(schema, ezRawKind),
   });
 
 /**

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -8,7 +8,7 @@ import { InputValidationError, OutputValidationError } from "./errors";
 import { zodFileKind } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import { AbstractLogger } from "./logger";
-import { getMeta, hasMeta } from "./metadata";
+import { getMeta } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { mimeMultipart } from "./mime";
 import { zodUploadKind } from "./upload-schema";
@@ -236,7 +236,7 @@ export const hasNestedSchema = ({
 };
 
 export const isProprietary = (schema: z.ZodTypeAny, kind: string) =>
-  hasMeta(schema) && getMeta(schema, "proprietaryKind") === kind;
+  getMeta(schema, "proprietaryKind") === kind;
 
 export const hasUpload = (subject: IOSchema) =>
   hasNestedSchema({

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -255,11 +255,13 @@ export const hasNestedSchema = ({
   return false;
 };
 
+export const isProprietary = (schema: z.ZodTypeAny, kind: string) =>
+  hasMeta(schema) && getMeta(schema, "proprietaryKind") === kind;
+
 export const hasUpload = (subject: IOSchema) =>
   hasNestedSchema({
     subject,
-    condition: (schema) =>
-      hasMeta(schema) && getMeta(schema, "proprietaryKind") === zodUploadKind, // @todo extract into a helper
+    condition: (schema) => isProprietary(schema, zodUploadKind),
   });
 
 export const hasRaw = (subject: IOSchema) =>

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -8,7 +8,7 @@ import { InputValidationError, OutputValidationError } from "./errors";
 import { zodFileKind } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import { AbstractLogger } from "./logger";
-import { getMeta } from "./metadata";
+import { getMeta, isProprietary } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { mimeMultipart } from "./mime";
 import { zodUploadKind } from "./upload-schema";
@@ -225,9 +225,6 @@ export const hasNestedSchema = ({
   }
   return false;
 };
-
-export const isProprietary = (schema: z.ZodTypeAny, kind: string) =>
-  getMeta(schema, "proprietaryKind") === kind;
 
 export const hasUpload = (subject: IOSchema) =>
   hasNestedSchema({

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import { z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { InputValidationError, OutputValidationError } from "./errors";
-import { ZodFile } from "./file-schema";
+import { zodFileKind } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import { AbstractLogger } from "./logger";
 import { getMeta, hasMeta } from "./metadata";
@@ -267,7 +267,8 @@ export const hasUpload = (subject: IOSchema) =>
 export const hasRaw = (subject: IOSchema) =>
   hasNestedSchema({
     subject,
-    condition: (schema) => schema instanceof ZodFile,
+    condition: (schema) =>
+      isProprietary(schema, zodFileKind) && !(schema instanceof z.ZodString), // @todo can simplify?
     maxDepth: 3,
   });
 

--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -1,15 +1,6 @@
 import { z } from "zod";
 import { proprietary } from "./metadata";
-import { isValidDate } from "./schema-helpers";
-
-// simple regex for ISO date, supports the following formats:
-// 2021-01-01T00:00:00.000Z
-// 2021-01-01T00:00:00.0Z
-// 2021-01-01T00:00:00Z
-// 2021-01-01T00:00:00
-// 2021-01-01
-export const isoDateRegex =
-  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)?Z?$/;
+import { isValidDate, isoDateRegex } from "./schema-helpers";
 
 export const zodDateInKind = "ZodDateIn";
 

--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import { proprietary } from "./metadata";
 import { isValidDate, isoDateRegex } from "./schema-helpers";
 
-export const zodDateInKind = "ZodDateIn";
+export const ezDateInKind = "DateIn";
 
 export const dateIn = () =>
   proprietary(
-    zodDateInKind,
+    ezDateInKind,
     z
       .string()
       .regex(isoDateRegex)

--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -1,13 +1,5 @@
-import {
-  INVALID,
-  ParseInput,
-  ParseReturnType,
-  ZodIssueCode,
-  ZodParsedType,
-  ZodType,
-  ZodTypeDef,
-  addIssueToContext,
-} from "zod";
+import { z } from "zod";
+import { metaProp, withMeta } from "./metadata";
 import { isValidDate } from "./schema-helpers";
 
 // simple regex for ISO date, supports the following formats:
@@ -19,46 +11,16 @@ import { isValidDate } from "./schema-helpers";
 export const isoDateRegex =
   /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)?Z?$/;
 
-const zodDateInKind = "ZodDateIn";
+export const zodDateInKind = "ZodDateIn";
 
-export interface ZodDateInDef extends ZodTypeDef {
-  typeName: typeof zodDateInKind;
-}
-
-export class ZodDateIn extends ZodType<Date, ZodDateInDef, string> {
-  _parse(input: ParseInput): ParseReturnType<Date> {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType.string) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.string,
-        received: ctx.parsedType,
-      });
-      return INVALID;
-    }
-
-    if (!isoDateRegex.test(ctx.data as string)) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_string,
-        validation: "regex",
-      });
-      status.dirty();
-    }
-
-    const date = new Date(ctx.data);
-
-    if (!isValidDate(date)) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_date,
-      });
-      return INVALID;
-    }
-
-    return { status: status.value, value: date };
-  }
-
-  static create = () =>
-    new ZodDateIn({
-      typeName: zodDateInKind,
-    });
-}
+export const dateIn = () => {
+  const schema = withMeta(
+    z
+      .string()
+      .regex(isoDateRegex)
+      .transform((str) => new Date(str))
+      .pipe(z.date().refine(isValidDate)),
+  );
+  schema._def[metaProp].proprietaryKind = zodDateInKind;
+  return schema;
+};

--- a/src/date-in-schema.ts
+++ b/src/date-in-schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { metaProp, withMeta } from "./metadata";
+import { proprietary } from "./metadata";
 import { isValidDate } from "./schema-helpers";
 
 // simple regex for ISO date, supports the following formats:
@@ -13,14 +13,12 @@ export const isoDateRegex =
 
 export const zodDateInKind = "ZodDateIn";
 
-export const dateIn = () => {
-  const schema = withMeta(
+export const dateIn = () =>
+  proprietary(
+    zodDateInKind,
     z
       .string()
       .regex(isoDateRegex)
       .transform((str) => new Date(str))
       .pipe(z.date().refine(isValidDate)),
   );
-  schema._def[metaProp].proprietaryKind = zodDateInKind;
-  return schema;
-};

--- a/src/date-out-schema.ts
+++ b/src/date-out-schema.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import { proprietary } from "./metadata";
 import { isValidDate } from "./schema-helpers";
 
-export const zodDateOutKind = "ZodDateOut";
+export const ezDateOutKind = "DateOut";
 
 export const dateOut = () =>
   proprietary(
-    zodDateOutKind,
+    ezDateOutKind,
     z
       .date()
       .refine(isValidDate)

--- a/src/date-out-schema.ts
+++ b/src/date-out-schema.ts
@@ -1,16 +1,14 @@
 import { z } from "zod";
-import { metaProp, withMeta } from "./metadata";
+import { proprietary } from "./metadata";
 import { isValidDate } from "./schema-helpers";
 
 export const zodDateOutKind = "ZodDateOut";
 
-export const dateOut = () => {
-  const schema = withMeta(
+export const dateOut = () =>
+  proprietary(
+    zodDateOutKind,
     z
       .date()
       .refine(isValidDate)
       .transform((date) => date.toISOString()),
   );
-  schema._def[metaProp].proprietaryKind = zodDateOutKind;
-  return schema;
-};

--- a/src/date-out-schema.ts
+++ b/src/date-out-schema.ts
@@ -1,45 +1,16 @@
-import {
-  INVALID,
-  ParseInput,
-  ParseReturnType,
-  ZodIssueCode,
-  ZodParsedType,
-  ZodType,
-  ZodTypeDef,
-  addIssueToContext,
-} from "zod";
+import { z } from "zod";
+import { metaProp, withMeta } from "./metadata";
 import { isValidDate } from "./schema-helpers";
 
-const zodDateOutKind = "ZodDateOut";
+export const zodDateOutKind = "ZodDateOut";
 
-export interface ZodDateOutDef extends ZodTypeDef {
-  typeName: typeof zodDateOutKind;
-}
-
-export class ZodDateOut extends ZodType<string, ZodDateOutDef, Date> {
-  _parse(input: ParseInput): ParseReturnType<string> {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType.date) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.date,
-        received: ctx.parsedType,
-      });
-      return INVALID;
-    }
-
-    if (!isValidDate(ctx.data)) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_date,
-      });
-      return INVALID;
-    }
-
-    return { status: status.value, value: (ctx.data as Date).toISOString() };
-  }
-
-  static create = () =>
-    new ZodDateOut({
-      typeName: zodDateOutKind,
-    });
-}
+export const dateOut = () => {
+  const schema = withMeta(
+    z
+      .date()
+      .refine(isValidDate)
+      .transform((date) => date.toISOString()),
+  );
+  schema._def[metaProp].proprietaryKind = zodDateOutKind;
+  return schema;
+};

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -39,7 +39,7 @@ import {
 } from "./logical-container";
 import { copyMeta } from "./metadata";
 import { Method } from "./method";
-import * as ez from "./proprietary-schemas";
+import { ez } from "./proprietary-schemas";
 import { isoDateRegex } from "./schema-helpers";
 import {
   HandlingRules,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -767,10 +767,10 @@ export const depicters: HandlingRules<
   ZodPipeline: depictPipeline,
   ZodLazy: depictLazy,
   ZodReadonly: depictReadonly,
-  ZodFile: depictFile,
-  ZodUpload: depictUpload,
-  ZodDateOut: depictDateOut,
-  ZodDateIn: depictDateIn,
+  File: depictFile,
+  Upload: depictUpload,
+  DateOut: depictDateOut,
+  DateIn: depictDateIn,
 };
 
 export const onEach: Depicter<z.ZodTypeAny, "each"> = ({

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -32,7 +32,7 @@ import {
 } from "./common-helpers";
 import { InputSource, TagsConfig } from "./config-type";
 import { isoDateRegex, zodDateInKind } from "./date-in-schema";
-import { ZodDateOut } from "./date-out-schema";
+import { zodDateOutKind } from "./date-out-schema";
 import { DocumentationError } from "./errors";
 import { ZodFile } from "./file-schema";
 import { IOSchema } from "./io-schema";
@@ -265,7 +265,7 @@ export const depictDateIn: Depicter<z.ZodType> = (ctx) => {
   };
 };
 
-export const depictDateOut: Depicter<ZodDateOut> = (ctx) => {
+export const depictDateOut: Depicter<z.ZodType> = (ctx) => {
   assert(
     ctx.isResponse,
     new DocumentationError({
@@ -543,6 +543,9 @@ export const depictEffect: Depicter<z.ZodEffects<z.ZodTypeAny>> = ({
   if (isProprietary(schema, zodUploadKind)) {
     return depictUpload({ schema, isResponse, next, ...ctx });
   }
+  if (isProprietary(schema, zodDateOutKind)) {
+    return depictDateOut({ schema, isResponse, next, ...ctx });
+  }
   const input = next({ schema: schema.innerType() });
   const { effect } = schema._def;
   if (isResponse && effect.type === "transform" && !isReferenceObject(input)) {
@@ -755,7 +758,6 @@ export const depicters: HandlingRules<
   ZodNumber: depictNumber,
   ZodBigInt: depictBigInt,
   ZodBoolean: depictBoolean,
-  ZodDateOut: depictDateOut,
   ZodNull: depictNull,
   ZodArray: depictArray,
   ZodTuple: depictTuple,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -29,7 +29,10 @@ import {
   ucFirst,
 } from "./common-helpers";
 import { InputSource, TagsConfig } from "./config-type";
+import { ezDateInKind } from "./date-in-schema";
+import { ezDateOutKind } from "./date-out-schema";
 import { DocumentationError } from "./errors";
+import { ezFileKind } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import {
   LogicalContainer,
@@ -39,6 +42,7 @@ import {
 import { copyMeta } from "./metadata";
 import { Method } from "./method";
 import { ez } from "./proprietary-schemas";
+import { ezRawKind } from "./raw-schema";
 import { isoDateRegex } from "./schema-helpers";
 import {
   HandlingRules,
@@ -47,6 +51,7 @@ import {
   walkSchema,
 } from "./schema-walker";
 import { Security } from "./security";
+import { ezUploadKind } from "./upload-schema";
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
@@ -769,11 +774,11 @@ export const depicters: HandlingRules<
   ZodPipeline: depictPipeline,
   ZodLazy: depictLazy,
   ZodReadonly: depictReadonly,
-  File: depictFile,
-  Upload: depictUpload,
-  DateOut: depictDateOut,
-  DateIn: depictDateIn,
-  Raw: depictRaw,
+  [ezFileKind]: depictFile,
+  [ezUploadKind]: depictUpload,
+  [ezDateOutKind]: depictDateOut,
+  [ezDateInKind]: depictDateIn,
+  [ezRawKind]: depictRaw,
 };
 
 export const onEach: Depicter<z.ZodTypeAny, "each"> = ({

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -25,6 +25,7 @@ import {
   hasRaw,
   hasTopLevelTransformingEffect,
   isCustomHeader,
+  isProprietary,
   makeCleanId,
   tryToTransform,
   ucFirst,
@@ -40,7 +41,7 @@ import {
   andToOr,
   mapLogicalContainer,
 } from "./logical-container";
-import { copyMeta, getMeta, hasMeta } from "./metadata";
+import { copyMeta } from "./metadata";
 import { Method } from "./method";
 import {
   HandlingRules,
@@ -538,8 +539,8 @@ export const depictEffect: Depicter<z.ZodEffects<z.ZodTypeAny>> = ({
   next,
   ...ctx
 }) => {
-  // @todo reconsider
-  if (hasMeta(schema) && getMeta(schema, "proprietaryKind") === zodUploadKind) {
+  // @todo can move to walker?
+  if (isProprietary(schema, zodUploadKind)) {
     return depictUpload({ schema, isResponse, next, ...ctx });
   }
   const input = next({ schema: schema.innerType() });

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -30,7 +30,6 @@ import {
   ucFirst,
 } from "./common-helpers";
 import { InputSource, TagsConfig } from "./config-type";
-import { isoDateRegex } from "./date-in-schema";
 import { DocumentationError } from "./errors";
 import { IOSchema } from "./io-schema";
 import {
@@ -41,6 +40,7 @@ import {
 import { copyMeta } from "./metadata";
 import { Method } from "./method";
 import * as ez from "./proprietary-schemas";
+import { isoDateRegex } from "./schema-helpers";
 import {
   HandlingRules,
   HandlingVariant,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -41,8 +41,7 @@ import {
 } from "./logical-container";
 import { copyMeta } from "./metadata";
 import { Method } from "./method";
-import { ez } from "./proprietary-schemas";
-import { ezRawKind } from "./raw-schema";
+import { RawSchema, ezRawKind } from "./raw-schema";
 import { isoDateRegex } from "./schema-helpers";
 import {
   HandlingRules,
@@ -592,8 +591,8 @@ export const depictLazy: Depicter<z.ZodLazy<z.ZodTypeAny>> = ({
   );
 };
 
-export const depictRaw: Depicter<z.ZodType> = ({ next }) =>
-  next({ schema: ez.file("buffer") });
+export const depictRaw: Depicter<RawSchema> = ({ next, schema }) =>
+  next({ schema: schema.shape.raw });
 
 export const depictExamples = (
   schema: z.ZodTypeAny,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -22,7 +22,6 @@ import {
   FlatObject,
   getExamples,
   hasCoercion,
-  hasRaw,
   hasTopLevelTransformingEffect,
   isCustomHeader,
   makeCleanId,
@@ -588,6 +587,9 @@ export const depictLazy: Depicter<z.ZodLazy<z.ZodTypeAny>> = ({
   );
 };
 
+export const depictRaw: Depicter<z.ZodType> = ({ next }) =>
+  next({ schema: ez.file("buffer") });
+
 export const depictExamples = (
   schema: z.ZodTypeAny,
   isResponse: boolean,
@@ -771,6 +773,7 @@ export const depicters: HandlingRules<
   Upload: depictUpload,
   DateOut: depictDateOut,
   DateIn: depictDateIn,
+  Raw: depictRaw,
 };
 
 export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
@@ -1049,7 +1052,7 @@ export const depictRequest = ({
   const bodyDepiction = excludeExamplesFromDepiction(
     excludeParamsFromDepiction(
       walkSchema({
-        schema: hasRaw(schema) ? ez.file("buffer") : schema,
+        schema,
         isResponse: false,
         rules: depicters,
         onEach,

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -18,7 +18,7 @@ interface DeprecatedMethods extends Record<Narrowing, () => z.ZodType> {
   /** @deprecated use ez.file("base64") instead */
   base64: () => z.ZodString;
   /** @deprecated use ez.file("binary") instead */
-  binary: () => z.ZodString | z.ZodType<Buffer>;
+  binary: () => z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]>;
 }
 
 export const file = (type?: Narrowing) => {

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -1,110 +1,27 @@
-import {
-  INVALID,
-  ParseInput,
-  ParseReturnType,
-  ZodIssueCode,
-  ZodParsedType,
-  ZodType,
-  ZodTypeDef,
-  addIssueToContext,
-} from "zod";
-import { ErrMessage, errToObj } from "./schema-helpers";
+import { z } from "zod";
+import { metaProp, withMeta } from "./metadata";
+import { bufferSchema } from "./schema-helpers";
 
-const zodFileKind = "ZodFile";
-
-export interface ZodFileDef<T extends string | Buffer = string | Buffer>
-  extends ZodTypeDef {
-  typeName: typeof zodFileKind;
-  type: T;
-  encoding?: "binary" | "base64";
-  message?: string;
-}
+export const zodFileKind = "ZodFile";
 
 const base64Regex =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-export class ZodFile<
-  T extends string | Buffer = string | Buffer,
-> extends ZodType<T, ZodFileDef<T>, T> {
-  _parse(input: ParseInput): ParseReturnType<T> {
-    const { status, ctx } = this._processInputParams(input);
+export const file = (
+  ...features: Array<"string" | "buffer" | "base64" | "binary">
+) => {
+  const schema = withMeta(
+    features.includes("buffer")
+      ? bufferSchema
+      : features.includes("base64")
+        ? z
+            .string()
+            .regex(base64Regex, { message: "Does not match base64 encoding" })
+        : z.string(),
+  );
+  schema._def[metaProp].proprietaryKind = zodFileKind;
+  return schema;
+};
 
-    const isParsedString =
-      ctx.parsedType === ZodParsedType.string && typeof ctx.data === "string";
-
-    if (this.isString && !isParsedString) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.string,
-        received: ctx.parsedType,
-      });
-      return INVALID;
-    }
-
-    const isParsedBuffer =
-      ctx.parsedType === ZodParsedType.object && Buffer.isBuffer(ctx.data);
-
-    if (this.isBuffer && !isParsedBuffer) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.object,
-        received: ctx.parsedType,
-        message: "Expected Buffer",
-      });
-      return INVALID;
-    }
-
-    if (isParsedString && this.isBase64 && !base64Regex.test(ctx.data)) {
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.custom,
-        message: this._def.message || "Does not match base64 encoding",
-      });
-      status.dirty();
-    }
-
-    return { status: status.value, value: ctx.data as T };
-  }
-
-  string = (message?: ErrMessage) =>
-    new ZodFile<string>({ ...this._def, ...errToObj(message), type: "" });
-
-  buffer = (message?: ErrMessage) =>
-    new ZodFile({
-      ...this._def,
-      ...errToObj(message),
-      type: Buffer.from([]),
-    });
-
-  binary = (message?: ErrMessage) =>
-    new ZodFile<T>({
-      ...this._def,
-      ...errToObj(message),
-      encoding: "binary",
-    });
-
-  base64 = (message?: ErrMessage) =>
-    new ZodFile<T>({
-      ...this._def,
-      ...errToObj(message),
-      encoding: "base64",
-    });
-
-  get isBinary() {
-    return this._def.encoding === "binary";
-  }
-
-  get isBase64() {
-    return this._def.encoding === "base64";
-  }
-
-  get isString() {
-    return typeof this._def.type === "string";
-  }
-
-  get isBuffer() {
-    return Buffer.isBuffer(this._def.type);
-  }
-
-  static create = () =>
-    new ZodFile<string>({ typeName: zodFileKind, type: "" });
-}
+/** Shorthand for z.object({ raw: z.file().buffer() }) */
+export const raw = () => z.object({ raw: file("buffer") });

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -12,16 +12,34 @@ type Narrowing = "string" | "buffer" | "base64" | "binary";
 /** @todo remove in v17 */
 interface DeprecatedMethods extends Record<Narrowing, () => z.ZodType> {
   /** @deprecated use ez.file("buffer") instead */
-  buffer: () => z.ZodType<Buffer>;
+  buffer: () => z.ZodType<Buffer> & DeprecatedMethods;
   /** @deprecated use ez.file("string") instead */
-  string: () => z.ZodString;
+  string: () => z.ZodString & DeprecatedMethods;
   /** @deprecated use ez.file("base64") instead */
-  base64: () => z.ZodString;
+  base64: () => z.ZodString & DeprecatedMethods;
   /** @deprecated use ez.file("binary") instead */
-  binary: () => z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]>;
+  binary: () => z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]> &
+    DeprecatedMethods;
 }
 
-export const file = (type?: Narrowing) => {
+export function file(
+  type?: "string" | "base64",
+): z.ZodString & DeprecatedMethods;
+
+export function file(
+  type: "binary",
+): z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]> & DeprecatedMethods;
+
+export function file(type: "buffer"): z.ZodType<Buffer> & DeprecatedMethods;
+
+export function file(
+  type?: Narrowing,
+): (
+  | z.ZodString
+  | z.ZodType<Buffer>
+  | z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]>
+) &
+  DeprecatedMethods {
   const justString = z.string();
   const base64String = justString.regex(base64Regex, {
     message: "Does not match base64 encoding",
@@ -42,7 +60,7 @@ export const file = (type?: Narrowing) => {
   (schema as any).base64 = () => file("base64");
   (schema as any).binary = () => file("binary");
   return schema as typeof schema & DeprecatedMethods;
-};
+}
 
 /** Shorthand for z.object({ raw: ez.file("buffer") }) */
 export const raw = () => z.object({ raw: file("buffer") });

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -51,6 +51,3 @@ export function file(
   }
   return schema as typeof schema & typeof deprecatedMethods;
 }
-
-/** Shorthand for z.object({ raw: ez.file("buffer") }) */
-export const raw = () => z.object({ raw: file("buffer") });

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -16,9 +16,13 @@ const wrap = <T extends z.ZodTypeAny>(
   ) as ReturnType<typeof proprietary<T>> & Narrowings;
 
 const narrowings = {
+  /** @deprecated use ez.file("buffer") instead */
   buffer: () => wrap(bufferSchema),
+  /** @deprecated use ez.file("string") instead */
   string: () => wrap(z.string()),
+  /** @deprecated use ez.file("binary") instead */
   binary: () => wrap(bufferSchema.or(z.string())),
+  /** @deprecated use ez.file("base64") instead */
   base64: () =>
     wrap(z.string().regex(base64Regex, "Does not match base64 encoding")),
 };

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -35,15 +35,12 @@ export function file(
   | z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]>
 ) &
   typeof deprecatedMethods {
-  const base64String = z.string().regex(base64Regex, {
-    message: "Does not match base64 encoding",
-  });
   const schema = proprietary(
     zodFileKind,
     type === "buffer"
       ? bufferSchema
       : type === "base64"
-        ? base64String
+        ? z.string().regex(base64Regex, "Does not match base64 encoding")
         : type === "binary"
           ? bufferSchema.or(z.string())
           : z.string(),

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -7,36 +7,41 @@ export const zodFileKind = "ZodFile";
 const base64Regex =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-export const file = (type?: "string" | "buffer" | "base64" | "binary") => {
+type Narrowing = "string" | "buffer" | "base64" | "binary";
+
+/** @todo remove in v17 */
+interface DeprecatedMethods extends Record<Narrowing, () => z.ZodType> {
+  /** @deprecated use ez.file("buffer") instead */
+  buffer: () => z.ZodType<Buffer>;
+  /** @deprecated use ez.file("string") instead */
+  string: () => z.ZodString;
+  /** @deprecated use ez.file("base64") instead */
+  base64: () => z.ZodString;
+  /** @deprecated use ez.file("binary") instead */
+  binary: () => z.ZodString | z.ZodType<Buffer>;
+}
+
+export const file = (type?: Narrowing) => {
   const justString = z.string();
+  const base64String = justString.regex(base64Regex, {
+    message: "Does not match base64 encoding",
+  });
   const schema = withMeta(
     type === "buffer"
       ? bufferSchema
       : type === "base64"
-        ? justString.regex(base64Regex, {
-            message: "Does not match base64 encoding",
-          })
+        ? base64String
         : type === "binary"
           ? bufferSchema.or(justString)
           : justString,
   );
   schema._def[metaProp].proprietaryKind = zodFileKind;
-  /** @todo remove in v17 */
+  /** @todo remove this hack in v17 */
   (schema as any).buffer = () => file("buffer");
   (schema as any).string = () => file("string");
   (schema as any).base64 = () => file("base64");
   (schema as any).binary = () => file("binary");
-  /** @todo remove extra methods in v17 */
-  return schema as typeof schema & {
-    /** @deprecated use ez.file("buffer") instead */
-    buffer: () => z.ZodType<Buffer>;
-    /** @deprecated use ez.file("string") instead */
-    string: () => z.ZodString;
-    /** @deprecated use ez.file("base64") instead */
-    base64: () => z.ZodString;
-    /** @deprecated use ez.file("binary") instead */
-    binary: () => z.ZodString | z.ZodType<Buffer>;
-  };
+  return schema as typeof schema & DeprecatedMethods;
 };
 
 /** Shorthand for z.object({ raw: ez.file("buffer") }) */

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -5,13 +5,15 @@ import { base64Regex, bufferSchema } from "./schema-helpers";
 export const ezFileKind = "File";
 
 // @todo remove this in v17
-const wrap = <T extends z.ZodTypeAny>(schema: T): T & Narrowings =>
+const wrap = <T extends z.ZodTypeAny>(
+  schema: T,
+): ReturnType<typeof proprietary<T>> & Narrowings =>
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   Object.entries(narrowings).reduce(
     (agg, [method, handler]) =>
       Object.defineProperty(agg, method, { get: () => handler }),
     proprietary(ezFileKind, schema),
-  ) as unknown as T & Narrowings;
+  ) as ReturnType<typeof proprietary<T>> & Narrowings;
 
 const narrowings = {
   buffer: () => wrap(bufferSchema),

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -47,7 +47,7 @@ export function file(
   );
   /** @todo remove this hack in v17 */
   for (const [method, handler] of Object.entries(deprecatedMethods)) {
-    (schema as any)[method] = handler;
+    Object.defineProperty(schema, method, { get: () => handler });
   }
   return schema as typeof schema & typeof deprecatedMethods;
 }

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -7,22 +7,37 @@ export const zodFileKind = "ZodFile";
 const base64Regex =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-export const file = (
-  ...features: Array<"string" | "buffer" | "base64" | "binary">
-) => {
+export const file = (type?: "string" | "buffer" | "base64" | "binary") => {
   const justString = z.string();
   const schema = withMeta(
-    features.includes("buffer")
+    type === "buffer"
       ? bufferSchema
-      : features.includes("base64")
+      : type === "base64"
         ? justString.regex(base64Regex, {
             message: "Does not match base64 encoding",
           })
-        : justString,
+        : type === "binary"
+          ? bufferSchema.or(justString)
+          : justString,
   );
   schema._def[metaProp].proprietaryKind = zodFileKind;
-  return schema;
+  /** @todo remove in v17 */
+  (schema as any).buffer = () => file("buffer");
+  (schema as any).string = () => file("string");
+  (schema as any).base64 = () => file("base64");
+  (schema as any).binary = () => file("binary");
+  /** @todo remove extra methods in v17 */
+  return schema as typeof schema & {
+    /** @deprecated use ez.file("buffer") instead */
+    buffer: () => z.ZodType<Buffer>;
+    /** @deprecated use ez.file("string") instead */
+    string: () => z.ZodString;
+    /** @deprecated use ez.file("base64") instead */
+    base64: () => z.ZodString;
+    /** @deprecated use ez.file("binary") instead */
+    binary: () => z.ZodString | z.ZodType<Buffer>;
+  };
 };
 
-/** Shorthand for z.object({ raw: z.file().buffer() }) */
+/** Shorthand for z.object({ raw: ez.file("buffer") }) */
 export const raw = () => z.object({ raw: file("buffer") });

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -15,15 +15,16 @@ const wrap = <T extends z.ZodTypeAny>(
     proprietary(ezFileKind, schema),
   ) as ReturnType<typeof proprietary<T>> & Variants;
 
+// @todo remove arguments from the methods in v17
 const variants = {
   /** @deprecated use ez.file("buffer") instead */
-  buffer: () => wrap(bufferSchema),
+  buffer: ({}: string | object = {}) => wrap(bufferSchema),
   /** @deprecated use ez.file("string") instead */
-  string: () => wrap(z.string()),
+  string: ({}: string | object = {}) => wrap(z.string()),
   /** @deprecated use ez.file("binary") instead */
-  binary: () => wrap(bufferSchema.or(z.string())),
+  binary: ({}: string | object = {}) => wrap(bufferSchema.or(z.string())),
   /** @deprecated use ez.file("base64") instead */
-  base64: () =>
+  base64: ({}: string | object = {}) =>
     wrap(z.string().regex(base64Regex, "Does not match base64 encoding")),
 };
 

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -10,14 +10,15 @@ const base64Regex =
 export const file = (
   ...features: Array<"string" | "buffer" | "base64" | "binary">
 ) => {
+  const justString = z.string();
   const schema = withMeta(
     features.includes("buffer")
       ? bufferSchema
       : features.includes("base64")
-        ? z
-            .string()
-            .regex(base64Regex, { message: "Does not match base64 encoding" })
-        : z.string(),
+        ? justString.regex(base64Regex, {
+            message: "Does not match base64 encoding",
+          })
+        : justString,
   );
   schema._def[metaProp].proprietaryKind = zodFileKind;
   return schema;

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -1,11 +1,8 @@
 import { z } from "zod";
 import { proprietary } from "./metadata";
-import { bufferSchema } from "./schema-helpers";
+import { base64Regex, bufferSchema } from "./schema-helpers";
 
 export const zodFileKind = "ZodFile";
-
-const base64Regex =
-  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 type Narrowing = "string" | "buffer" | "base64" | "binary";
 

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { proprietary } from "./metadata";
 import { base64Regex, bufferSchema } from "./schema-helpers";
 
-export const zodFileKind = "ZodFile";
+export const ezFileKind = "File";
 
 type Narrowing = "string" | "buffer" | "base64" | "binary";
 
@@ -36,7 +36,7 @@ export function file(
 ) &
   typeof deprecatedMethods {
   const schema = proprietary(
-    zodFileKind,
+    ezFileKind,
     type === "buffer"
       ? bufferSchema
       : type === "base64"

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { metaProp, withMeta } from "./metadata";
+import { proprietary } from "./metadata";
 import { bufferSchema } from "./schema-helpers";
 
 export const zodFileKind = "ZodFile";
@@ -44,7 +44,8 @@ export function file(
   const base64String = justString.regex(base64Regex, {
     message: "Does not match base64 encoding",
   });
-  const schema = withMeta(
+  const schema = proprietary(
+    zodFileKind,
     type === "buffer"
       ? bufferSchema
       : type === "base64"
@@ -53,7 +54,6 @@ export function file(
           ? bufferSchema.or(justString)
           : justString,
   );
-  schema._def[metaProp].proprietaryKind = zodFileKind;
   /** @todo remove this hack in v17 */
   (schema as any).buffer = () => file("buffer");
   (schema as any).string = () => file("string");

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -35,8 +35,7 @@ export function file(
   | z.ZodUnion<[z.ZodType<Buffer>, z.ZodString]>
 ) &
   typeof deprecatedMethods {
-  const justString = z.string();
-  const base64String = justString.regex(base64Regex, {
+  const base64String = z.string().regex(base64Regex, {
     message: "Does not match base64 encoding",
   });
   const schema = proprietary(
@@ -46,8 +45,8 @@ export function file(
       : type === "base64"
         ? base64String
         : type === "binary"
-          ? bufferSchema.or(justString)
-          : justString,
+          ? bufferSchema.or(z.string())
+          : z.string(),
   );
   /** @todo remove this hack in v17 */
   for (const [method, handler] of Object.entries(deprecatedMethods)) {

--- a/src/file-schema.ts
+++ b/src/file-schema.ts
@@ -7,15 +7,15 @@ export const ezFileKind = "File";
 // @todo remove this in v17
 const wrap = <T extends z.ZodTypeAny>(
   schema: T,
-): ReturnType<typeof proprietary<T>> & Narrowings =>
+): ReturnType<typeof proprietary<T>> & Variants =>
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  Object.entries(narrowings).reduce(
+  Object.entries(variants).reduce(
     (agg, [method, handler]) =>
       Object.defineProperty(agg, method, { get: () => handler }),
     proprietary(ezFileKind, schema),
-  ) as ReturnType<typeof proprietary<T>> & Narrowings;
+  ) as ReturnType<typeof proprietary<T>> & Variants;
 
-const narrowings = {
+const variants = {
   /** @deprecated use ez.file("buffer") instead */
   buffer: () => wrap(bufferSchema),
   /** @deprecated use ez.file("string") instead */
@@ -27,11 +27,11 @@ const narrowings = {
     wrap(z.string().regex(base64Regex, "Does not match base64 encoding")),
 };
 
-type Narrowings = typeof narrowings;
-type Narrowing = keyof Narrowings;
+type Variants = typeof variants;
+type Variant = keyof Variants;
 
-export function file(): ReturnType<Narrowings["string"]>;
-export function file<K extends Narrowing>(type: K): ReturnType<Narrowings[K]>;
-export function file<K extends Narrowing>(type?: K) {
-  return narrowings[type || "string"]();
+export function file(): ReturnType<Variants["string"]>;
+export function file<K extends Variant>(variant: K): ReturnType<Variants[K]>;
+export function file<K extends Variant>(variant?: K) {
+  return variants[variant || "string"]();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
 export type { IOSchema } from "./io-schema";
 export type { Metadata } from "./metadata";
-export type { ZodDateOutDef } from "./date-out-schema";
 export type { ZodFileDef } from "./file-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
 export type { MiddlewareDefinition } from "./middleware";

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
 export type { IOSchema } from "./io-schema";
 export type { Metadata } from "./metadata";
-export type { ZodFileDef } from "./file-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
 export type { MiddlewareDefinition } from "./middleware";
 export type { ResultHandlerDefinition } from "./result-handler";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { withMeta } from "./metadata";
 export { testEndpoint } from "./testing";
 export { Integration } from "./integration";
 
-export * as ez from "./proprietary-schemas";
+export { ez } from "./proprietary-schemas";
 
 // Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
 export type { MockOverrides } from "./testing";

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
 export type { IOSchema } from "./io-schema";
 export type { Metadata } from "./metadata";
-export type { ZodDateInDef } from "./date-in-schema";
 export type { ZodDateOutDef } from "./date-out-schema";
 export type { ZodFileDef } from "./file-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,6 +1,5 @@
 import ts from "typescript";
 import { z } from "zod";
-import { ZodFile } from "./file-schema";
 import {
   emptyHeading,
   emptyTail,
@@ -33,6 +32,7 @@ import { mimeJson } from "./mime";
 import { loadPeer } from "./peer-helpers";
 import { Routing } from "./routing";
 import { walkRouting } from "./routing-walker";
+import * as ez from "./proprietary-schemas";
 import { zodToTs } from "./zts";
 import { createTypeAlias, printNode } from "./zts-helpers";
 import type Prettier from "prettier";
@@ -159,7 +159,7 @@ export class Integration {
         const inputId = makeCleanId(method, path, "input");
         const input = zodToTs({
           ...commons,
-          schema: hasRaw(inputSchema) ? ZodFile.create().buffer() : inputSchema,
+          schema: hasRaw(inputSchema) ? ez.file("buffer") : inputSchema,
           isResponse: false,
         });
         const positiveResponseId = splitResponse

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -26,13 +26,12 @@ import {
   protectedReadonlyModifier,
   spacingMiddle,
 } from "./integration-helpers";
-import { defaultSerializer, hasRaw, makeCleanId } from "./common-helpers";
+import { defaultSerializer, makeCleanId } from "./common-helpers";
 import { Method, methods } from "./method";
 import { mimeJson } from "./mime";
 import { loadPeer } from "./peer-helpers";
 import { Routing } from "./routing";
 import { walkRouting } from "./routing-walker";
-import { ez } from "./proprietary-schemas";
 import { zodToTs } from "./zts";
 import { createTypeAlias, printNode } from "./zts-helpers";
 import type Prettier from "prettier";
@@ -159,7 +158,7 @@ export class Integration {
         const inputId = makeCleanId(method, path, "input");
         const input = zodToTs({
           ...commons,
-          schema: hasRaw(inputSchema) ? ez.file("buffer") : inputSchema,
+          schema: inputSchema,
           isResponse: false,
         });
         const positiveResponseId = splitResponse

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -32,7 +32,7 @@ import { mimeJson } from "./mime";
 import { loadPeer } from "./peer-helpers";
 import { Routing } from "./routing";
 import { walkRouting } from "./routing-walker";
-import * as ez from "./proprietary-schemas";
+import { ez } from "./proprietary-schemas";
 import { zodToTs } from "./zts";
 import { createTypeAlias, printNode } from "./zts-helpers";
 import type Prettier from "prettier";

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -154,11 +154,10 @@ export class Integration {
           makeAlias: this.makeAlias.bind(this),
           optionalPropStyle,
         };
-        const inputSchema = endpoint.getSchema("input");
         const inputId = makeCleanId(method, path, "input");
         const input = zodToTs({
           ...commons,
-          schema: inputSchema,
+          schema: endpoint.getSchema("input"),
           isResponse: false,
         });
         const positiveResponseId = splitResponse

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -8,7 +8,7 @@ export interface Metadata<T extends z.ZodTypeAny> {
    * @todo if the following PR merged, use native branding instead:
    * @link https://github.com/colinhacks/zod/pull/2860
    * */
-  proprietaryKind?: ProprietaryKind;
+  kind?: ProprietaryKind;
   examples: z.input<T>[];
 }
 
@@ -77,9 +77,9 @@ export const proprietary = <T extends z.ZodTypeAny>(
   subject: T,
 ) => {
   const schema = withMeta(subject);
-  schema._def[metaProp].proprietaryKind = kind;
+  schema._def[metaProp].kind = kind;
   return schema;
 };
 
 export const isProprietary = (schema: z.ZodTypeAny, kind: ProprietaryKind) =>
-  getMeta(schema, "proprietaryKind") === kind;
+  getMeta(schema, "kind") === kind;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,6 +1,6 @@
-import { clone, mergeDeepRight } from "ramda";
-import { z } from "zod";
 import { combinations } from "./common-helpers";
+import { z } from "zod";
+import { clone, mergeDeepRight } from "ramda";
 
 export interface Metadata<T extends z.ZodTypeAny> {
   examples: z.input<T>[];

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -4,8 +4,12 @@ import { clone, mergeDeepRight } from "ramda";
 import { ProprietaryKind } from "./proprietary-schemas";
 
 export interface Metadata<T extends z.ZodTypeAny> {
-  examples: z.input<T>[];
+  /**
+   * @todo if the following PR merged, use native branding instead:
+   * @link https://github.com/colinhacks/zod/pull/2860
+   * */
   proprietaryKind?: ProprietaryKind;
+  examples: z.input<T>[];
 }
 
 export const metaProp = "expressZodApiMeta";

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,6 +1,6 @@
-import { combinations } from "./common-helpers";
-import { z } from "zod";
 import { clone, mergeDeepRight } from "ramda";
+import { z } from "zod";
+import { combinations } from "./common-helpers";
 
 export interface Metadata<T extends z.ZodTypeAny> {
   examples: z.input<T>[];
@@ -78,3 +78,15 @@ export const copyMeta = <A extends z.ZodTypeAny, B extends z.ZodTypeAny>(
   );
   return result;
 };
+
+export const proprietary = <T extends z.ZodTypeAny>(
+  kind: string,
+  subject: T,
+) => {
+  const schema = withMeta(subject);
+  schema._def[metaProp].proprietaryKind = kind;
+  return schema;
+};
+
+export const isProprietary = (schema: z.ZodTypeAny, kind: string) =>
+  getMeta(schema, "proprietaryKind") === kind;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,10 +1,11 @@
 import { combinations } from "./common-helpers";
 import { z } from "zod";
 import { clone, mergeDeepRight } from "ramda";
+import { ProprietaryKind } from "./proprietary-schemas";
 
 export interface Metadata<T extends z.ZodTypeAny> {
   examples: z.input<T>[];
-  proprietaryKind?: string;
+  proprietaryKind?: ProprietaryKind;
 }
 
 export const metaProp = "expressZodApiMeta";
@@ -68,7 +69,7 @@ export const copyMeta = <A extends z.ZodTypeAny, B extends z.ZodTypeAny>(
 };
 
 export const proprietary = <T extends z.ZodTypeAny>(
-  kind: string,
+  kind: ProprietaryKind,
   subject: T,
 ) => {
   const schema = withMeta(subject);
@@ -76,5 +77,5 @@ export const proprietary = <T extends z.ZodTypeAny>(
   return schema;
 };
 
-export const isProprietary = (schema: z.ZodTypeAny, kind: string) =>
+export const isProprietary = (schema: z.ZodTypeAny, kind: ProprietaryKind) =>
   getMeta(schema, "proprietaryKind") === kind;

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 export { dateIn } from "./date-in-schema";
-import { ZodDateOut } from "./date-out-schema";
+export { dateOut } from "./date-out-schema";
 import { ZodFile } from "./file-schema";
 export { upload } from "./upload-schema";
 
 export const file = ZodFile.create;
-export const dateOut = ZodDateOut.create;
 
 /** Shorthand for z.object({ raw: z.file().buffer() }) */
 export const raw = () => z.object({ raw: ZodFile.create().buffer() });

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
-import { ZodDateIn } from "./date-in-schema";
+export { dateIn } from "./date-in-schema";
 import { ZodDateOut } from "./date-out-schema";
 import { ZodFile } from "./file-schema";
 export { upload } from "./upload-schema";
 
 export const file = ZodFile.create;
-export const dateIn = ZodDateIn.create;
 export const dateOut = ZodDateOut.create;
 
 /** Shorthand for z.object({ raw: z.file().buffer() }) */

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -1,5 +1,14 @@
-export { dateIn } from "./date-in-schema";
-export { dateOut } from "./date-out-schema";
-export { file } from "./file-schema";
-export { upload } from "./upload-schema";
-export { raw } from "./raw-schema";
+import { dateIn, ezDateInKind } from "./date-in-schema";
+import { dateOut, ezDateOutKind } from "./date-out-schema";
+import { ezFileKind, file } from "./file-schema";
+import { ezRawKind, raw } from "./raw-schema";
+import { ezUploadKind, upload } from "./upload-schema";
+
+export const ez = { dateIn, dateOut, file, upload, raw };
+
+export type ProprietaryKinds =
+  | typeof ezFileKind
+  | typeof ezDateInKind
+  | typeof ezDateOutKind
+  | typeof ezUploadKind
+  | typeof ezRawKind;

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -6,7 +6,7 @@ import { ezUploadKind, upload } from "./upload-schema";
 
 export const ez = { dateIn, dateOut, file, upload, raw };
 
-export type ProprietaryKinds =
+export type ProprietaryKind =
   | typeof ezFileKind
   | typeof ezDateInKind
   | typeof ezDateOutKind

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -2,16 +2,10 @@ import { z } from "zod";
 import { ZodDateIn } from "./date-in-schema";
 import { ZodDateOut } from "./date-out-schema";
 import { ZodFile } from "./file-schema";
-import { metaProp, withMeta } from "./metadata";
-import { getUploadSchema, zodUploadKind } from "./upload-schema";
+import { getUploadSchema } from "./upload-schema";
 
 export const file = ZodFile.create;
-// @todo reconsider location
-export const upload = () => {
-  const schema = withMeta(getUploadSchema());
-  schema._def[metaProp].proprietaryKind = zodUploadKind;
-  return schema;
-};
+export const upload = getUploadSchema;
 export const dateIn = ZodDateIn.create;
 export const dateOut = ZodDateOut.create;
 

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -1,10 +1,4 @@
-import { z } from "zod";
 export { dateIn } from "./date-in-schema";
 export { dateOut } from "./date-out-schema";
-import { ZodFile } from "./file-schema";
+export { file, raw } from "./file-schema";
 export { upload } from "./upload-schema";
-
-export const file = ZodFile.create;
-
-/** Shorthand for z.object({ raw: z.file().buffer() }) */
-export const raw = () => z.object({ raw: ZodFile.create().buffer() });

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -2,10 +2,9 @@ import { z } from "zod";
 import { ZodDateIn } from "./date-in-schema";
 import { ZodDateOut } from "./date-out-schema";
 import { ZodFile } from "./file-schema";
-import { getUploadSchema } from "./upload-schema";
+export { upload } from "./upload-schema";
 
 export const file = ZodFile.create;
-export const upload = getUploadSchema;
 export const dateIn = ZodDateIn.create;
 export const dateOut = ZodDateOut.create;
 

--- a/src/proprietary-schemas.ts
+++ b/src/proprietary-schemas.ts
@@ -1,4 +1,5 @@
 export { dateIn } from "./date-in-schema";
 export { dateOut } from "./date-out-schema";
-export { file, raw } from "./file-schema";
+export { file } from "./file-schema";
 export { upload } from "./upload-schema";
+export { raw } from "./raw-schema";

--- a/src/raw-schema.ts
+++ b/src/raw-schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { file } from "./file-schema";
+import { proprietary } from "./metadata";
+
+export const zodRawKind = "ZodRaw";
+
+/** Shorthand for z.object({ raw: ez.file("buffer") }) */
+export const raw = () =>
+  proprietary(zodRawKind, z.object({ raw: file("buffer") }));

--- a/src/raw-schema.ts
+++ b/src/raw-schema.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { file } from "./file-schema";
 import { proprietary } from "./metadata";
 
-export const zodRawKind = "ZodRaw";
+export const ezRawKind = "Raw";
 
 /** Shorthand for z.object({ raw: ez.file("buffer") }) */
 export const raw = () =>
-  proprietary(zodRawKind, z.object({ raw: file("buffer") }));
+  proprietary(ezRawKind, z.object({ raw: file("buffer") }));

--- a/src/raw-schema.ts
+++ b/src/raw-schema.ts
@@ -7,3 +7,5 @@ export const ezRawKind = "Raw";
 /** Shorthand for z.object({ raw: ez.file("buffer") }) */
 export const raw = () =>
   proprietary(ezRawKind, z.object({ raw: file("buffer") }));
+
+export type RawSchema = ReturnType<typeof raw>;

--- a/src/schema-helpers.ts
+++ b/src/schema-helpers.ts
@@ -6,3 +6,16 @@ export const bufferSchema = z.custom<Buffer>(
   (subject) => Buffer.isBuffer(subject),
   { message: "Expected Buffer" },
 );
+
+export const base64Regex =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/**
+ * @example 2021-01-01T00:00:00.000Z
+ * @example 2021-01-01T00:00:00.0Z
+ * @example 2021-01-01T00:00:00Z
+ * @example 2021-01-01T00:00:00
+ * @example 2021-01-01
+ */
+export const isoDateRegex =
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)?Z?$/;

--- a/src/schema-helpers.ts
+++ b/src/schema-helpers.ts
@@ -1,17 +1,8 @@
 import { z } from "zod";
 
-// obtaining the private helper type from Zod
-export type ErrMessage = Exclude<
-  Parameters<typeof z.ZodString.prototype.email>[0],
-  undefined
->;
-
-// the copy of the private Zod errorUtil.errToObj
-export const errToObj = (message: ErrMessage | undefined) =>
-  typeof message === "string" ? { message } : message || {};
-
 export const isValidDate = (date: Date): boolean => !isNaN(date.getTime());
 
-export const bufferSchema = z.custom<Buffer>((subject) =>
-  Buffer.isBuffer(subject),
+export const bufferSchema = z.custom<Buffer>(
+  (subject) => Buffer.isBuffer(subject),
+  { message: "Expected Buffer" },
 );

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -50,11 +50,8 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
   rules: HandlingRules<U, Context>;
   onMissing: SchemaHandler<z.ZodTypeAny, U, Context, "last">;
 }): U => {
-  const handler =
-    rules[getMeta(schema, "proprietaryKind") as keyof typeof rules] ||
-    ("typeName" in schema._def
-      ? rules[schema._def.typeName as keyof typeof rules]
-      : undefined);
+  const kind = getMeta(schema, "proprietaryKind") || schema._def.typeName;
+  const handler = kind ? rules[kind as keyof typeof rules] : undefined;
   const ctx = rest as unknown as Context;
   const next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> = (params) =>
     walkSchema({ ...params, ...ctx, onEach, rules: rules, onMissing });

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { FlatObject } from "./common-helpers";
 import { getMeta } from "./metadata";
-import { ProprietaryKinds } from "./proprietary-schemas";
+import { ProprietaryKind } from "./proprietary-schemas";
 
 export type HandlingVariant = "last" | "regular" | "each";
 
@@ -33,7 +33,7 @@ export type SchemaHandler<
 
 export type HandlingRules<U, Context extends FlatObject = {}> = Partial<
   Record<
-    z.ZodFirstPartyTypeKind | ProprietaryKinds,
+    z.ZodFirstPartyTypeKind | ProprietaryKind,
     SchemaHandler<any, U, Context> // keeping "any" here in order to avoid excessive complexity
   >
 >;

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import type { FlatObject } from "./common-helpers";
-import { zodDateInKind } from "./date-in-schema";
-import { zodDateOutKind } from "./date-out-schema";
-import { zodFileKind } from "./file-schema";
+import { ezDateInKind } from "./date-in-schema";
+import { ezDateOutKind } from "./date-out-schema";
+import { ezFileKind } from "./file-schema";
 import { getMeta } from "./metadata";
-import { zodUploadKind } from "./upload-schema";
+import { ezUploadKind } from "./upload-schema";
 
 export type HandlingVariant = "last" | "regular" | "each";
 
@@ -35,10 +35,10 @@ export type SchemaHandler<
 > = (params: SchemaHandlingProps<T, U, Context, Variant>) => U;
 
 type ProprietaryKinds =
-  | typeof zodFileKind
-  | typeof zodDateInKind
-  | typeof zodDateOutKind
-  | typeof zodUploadKind;
+  | typeof ezFileKind
+  | typeof ezDateInKind
+  | typeof ezDateOutKind
+  | typeof ezUploadKind;
 
 export type HandlingRules<U, Context extends FlatObject = {}> = Partial<
   Record<

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -50,7 +50,7 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
   rules: HandlingRules<U, Context>;
   onMissing: SchemaHandler<z.ZodTypeAny, U, Context, "last">;
 }): U => {
-  const kind = getMeta(schema, "proprietaryKind") || schema._def.typeName;
+  const kind = getMeta(schema, "kind") || schema._def.typeName;
   const handler = kind ? rules[kind as keyof typeof rules] : undefined;
   const ctx = rest as unknown as Context;
   const next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> = (params) =>

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type { FlatObject } from "./common-helpers";
-import type { ZodDateOutDef } from "./date-out-schema";
 import type { ZodFileDef } from "./file-schema";
 
 export type HandlingVariant = "last" | "regular" | "each";
@@ -31,9 +30,7 @@ export type SchemaHandler<
   Variant extends HandlingVariant = "regular",
 > = (params: SchemaHandlingProps<T, U, Context, Variant>) => U;
 
-export type ProprietaryKinds =
-  | ZodFileDef["typeName"]
-  | ZodDateOutDef["typeName"];
+export type ProprietaryKinds = ZodFileDef["typeName"];
 
 export type HandlingRules<U, Context extends FlatObject = {}> = Partial<
   Record<

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type { FlatObject } from "./common-helpers";
-import type { ZodDateInDef } from "./date-in-schema";
 import type { ZodDateOutDef } from "./date-out-schema";
 import type { ZodFileDef } from "./file-schema";
 
@@ -34,7 +33,6 @@ export type SchemaHandler<
 
 export type ProprietaryKinds =
   | ZodFileDef["typeName"]
-  | ZodDateInDef["typeName"]
   | ZodDateOutDef["typeName"];
 
 export type HandlingRules<U, Context extends FlatObject = {}> = Partial<

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 import type { FlatObject } from "./common-helpers";
-import { ezDateInKind } from "./date-in-schema";
-import { ezDateOutKind } from "./date-out-schema";
-import { ezFileKind } from "./file-schema";
 import { getMeta } from "./metadata";
-import { ezUploadKind } from "./upload-schema";
+import { ProprietaryKinds } from "./proprietary-schemas";
 
 export type HandlingVariant = "last" | "regular" | "each";
 
@@ -33,12 +30,6 @@ export type SchemaHandler<
   Context extends FlatObject = {},
   Variant extends HandlingVariant = "regular",
 > = (params: SchemaHandlingProps<T, U, Context, Variant>) => U;
-
-type ProprietaryKinds =
-  | typeof ezFileKind
-  | typeof ezDateInKind
-  | typeof ezDateOutKind
-  | typeof ezUploadKind;
 
 export type HandlingRules<U, Context extends FlatObject = {}> = Partial<
   Record<

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 import { proprietary } from "./metadata";
 import { bufferSchema } from "./schema-helpers";
 
-export const zodUploadKind = "ZodUpload";
+export const ezUploadKind = "Upload";
 
 export const upload = () =>
   proprietary(
-    zodUploadKind,
+    ezUploadKind,
     z.custom<UploadedFile>(
       (subject) =>
         z

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -1,12 +1,13 @@
 import type { UploadedFile } from "express-fileupload";
 import { z } from "zod";
-import { metaProp, withMeta } from "./metadata";
+import { proprietary } from "./metadata";
 import { bufferSchema } from "./schema-helpers";
 
 export const zodUploadKind = "ZodUpload";
 
-export const upload = () => {
-  const schema = withMeta(
+export const upload = () =>
+  proprietary(
+    zodUploadKind,
     z.custom<UploadedFile>(
       (subject) =>
         z
@@ -27,6 +28,3 @@ export const upload = () => {
       }),
     ),
   );
-  schema._def[metaProp].proprietaryKind = zodUploadKind;
-  return schema;
-};

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -5,8 +5,7 @@ import { bufferSchema } from "./schema-helpers";
 
 export const zodUploadKind = "ZodUpload";
 
-// @todo naming?
-export const getUploadSchema = () => {
+export const upload = () => {
   const schema = withMeta(
     z.custom<UploadedFile>(
       (subject) =>

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -1,25 +1,33 @@
 import type { UploadedFile } from "express-fileupload";
 import { z } from "zod";
+import { metaProp, withMeta } from "./metadata";
 import { bufferSchema } from "./schema-helpers";
 
 export const zodUploadKind = "ZodUpload";
 
-// @todo simplify all that
-export const getUploadSchema = () =>
-  z.custom<UploadedFile>(
-    (subject) =>
-      z
-        .object({
-          name: z.string(),
-          encoding: z.string(),
-          mimetype: z.string(),
-          data: bufferSchema,
-          tempFilePath: z.string(),
-          truncated: z.boolean(),
-          size: z.number(),
-          md5: z.string(),
-          mv: z.function(),
-        })
-        .safeParse(subject).success,
-    (input) => ({ message: `Expected file upload, received ${typeof input}` }),
+// @todo naming?
+export const getUploadSchema = () => {
+  const schema = withMeta(
+    z.custom<UploadedFile>(
+      (subject) =>
+        z
+          .object({
+            name: z.string(),
+            encoding: z.string(),
+            mimetype: z.string(),
+            data: bufferSchema,
+            tempFilePath: z.string(),
+            truncated: z.boolean(),
+            size: z.number(),
+            md5: z.string(),
+            mv: z.function(),
+          })
+          .safeParse(subject).success,
+      (input) => ({
+        message: `Expected file upload, received ${typeof input}`,
+      }),
+    ),
   );
+  schema._def[metaProp].proprietaryKind = zodUploadKind;
+  return schema;
+};

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -211,10 +211,16 @@ const onLazy: Producer<z.ZodLazy<z.ZodTypeAny>> = ({
   );
 };
 
-const onFile: Producer<z.ZodType> = ({ schema }) =>
-  schema instanceof z.ZodString
-    ? f.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
-    : f.createTypeReferenceNode("Buffer");
+const onFile: Producer<z.ZodType> = ({ schema }) => {
+  const stringType = f.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+  const bufferType = f.createTypeReferenceNode("Buffer");
+  const unionType = f.createUnionTypeNode([stringType, bufferType]);
+  return schema instanceof z.ZodString
+    ? stringType
+    : schema instanceof z.ZodUnion
+      ? unionType
+      : bufferType;
+};
 
 const onRaw: Producer<RawSchema> = ({ next, schema }) =>
   next({ schema: schema.shape.raw });

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -218,7 +218,6 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodNumber: onPrimitive(ts.SyntaxKind.NumberKeyword),
   ZodBigInt: onPrimitive(ts.SyntaxKind.BigIntKeyword),
   ZodBoolean: onPrimitive(ts.SyntaxKind.BooleanKeyword),
-  ZodDateIn: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodDateOut: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodNull: onNull,
   ZodArray: onArray,

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -217,8 +217,9 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodNumber: onPrimitive(ts.SyntaxKind.NumberKeyword),
   ZodBigInt: onPrimitive(ts.SyntaxKind.BigIntKeyword),
   ZodBoolean: onPrimitive(ts.SyntaxKind.BooleanKeyword),
-  ZodDateIn: onPrimitive(ts.SyntaxKind.StringKeyword),
-  ZodDateOut: onPrimitive(ts.SyntaxKind.StringKeyword),
+  ZodAny: onPrimitive(ts.SyntaxKind.AnyKeyword),
+  DateIn: onPrimitive(ts.SyntaxKind.StringKeyword),
+  DateOut: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodNull: onNull,
   ZodArray: onArray,
   ZodTuple: onTuple,
@@ -227,7 +228,6 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodLiteral: onLiteral,
   ZodIntersection: onIntersection,
   ZodUnion: onSomeUnion,
-  ZodAny: onPrimitive(ts.SyntaxKind.AnyKeyword),
   ZodDefault: onDefault,
   ZodEnum: onEnum,
   ZodNativeEnum: onNativeEnum,
@@ -240,7 +240,7 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodPipeline: onPipeline,
   ZodLazy: onLazy,
   ZodReadonly: onReadonly,
-  ZodFile: onFile,
+  File: onFile,
 };
 
 export const zodToTs = ({

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -1,7 +1,11 @@
 import ts from "typescript";
 import { z } from "zod";
 import { hasCoercion, tryToTransform } from "./common-helpers";
+import { ezDateInKind } from "./date-in-schema";
+import { ezDateOutKind } from "./date-out-schema";
+import { ezFileKind } from "./file-schema";
 import { ez } from "./proprietary-schemas";
+import { ezRawKind } from "./raw-schema";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   LiteralType,
@@ -222,8 +226,8 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodBigInt: onPrimitive(ts.SyntaxKind.BigIntKeyword),
   ZodBoolean: onPrimitive(ts.SyntaxKind.BooleanKeyword),
   ZodAny: onPrimitive(ts.SyntaxKind.AnyKeyword),
-  DateIn: onPrimitive(ts.SyntaxKind.StringKeyword),
-  DateOut: onPrimitive(ts.SyntaxKind.StringKeyword),
+  [ezDateInKind]: onPrimitive(ts.SyntaxKind.StringKeyword),
+  [ezDateOutKind]: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodNull: onNull,
   ZodArray: onArray,
   ZodTuple: onTuple,
@@ -244,8 +248,8 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodPipeline: onPipeline,
   ZodLazy: onLazy,
   ZodReadonly: onReadonly,
-  File: onFile,
-  Raw: onRaw,
+  [ezFileKind]: onFile,
+  [ezRawKind]: onRaw,
 };
 
 export const zodToTs = ({

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -83,11 +83,6 @@ const onSomeUnion: Producer<
 > = ({ schema: { options }, next }) =>
   f.createUnionTypeNode(options.map((option) => next({ schema: option })));
 
-const onPrimitive =
-  (syntaxKind: ts.KeywordTypeSyntaxKind): Producer<z.ZodTypeAny> =>
-  () =>
-    f.createKeywordTypeNode(syntaxKind);
-
 const makeSample = (produced: ts.TypeNode) =>
   samples?.[produced.kind as keyof typeof samples];
 
@@ -171,6 +166,11 @@ const onIntersection: Producer<
 
 const onDefault: Producer<z.ZodDefault<z.ZodTypeAny>> = ({ next, schema }) =>
   next({ schema: schema._def.innerType });
+
+const onPrimitive =
+  (syntaxKind: ts.KeywordTypeSyntaxKind): Producer<z.ZodTypeAny> =>
+  () =>
+    f.createKeywordTypeNode(syntaxKind);
 
 const onBranded: Producer<
   z.ZodBranded<z.ZodTypeAny, string | number | symbol>

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -1,7 +1,6 @@
 import ts from "typescript";
 import { z } from "zod";
-import { hasCoercion, isProprietary, tryToTransform } from "./common-helpers";
-import { zodDateOutKind } from "./date-out-schema";
+import { hasCoercion, tryToTransform } from "./common-helpers";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   LiteralType,
@@ -95,17 +94,7 @@ const onEffects: Producer<z.ZodEffects<z.ZodTypeAny>> = ({
   schema,
   next,
   isResponse,
-  ...ctx
 }) => {
-  // @todo move to walker somehow
-  if (isProprietary(schema, zodDateOutKind)) {
-    return onPrimitive(ts.SyntaxKind.StringKeyword)({
-      schema,
-      next,
-      isResponse,
-      ...ctx,
-    });
-  }
   const input = next({ schema: schema.innerType() });
   const effect = schema._def.effect;
   if (isResponse && effect.type === "transform") {
@@ -228,6 +217,8 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodNumber: onPrimitive(ts.SyntaxKind.NumberKeyword),
   ZodBigInt: onPrimitive(ts.SyntaxKind.BigIntKeyword),
   ZodBoolean: onPrimitive(ts.SyntaxKind.BooleanKeyword),
+  ZodDateIn: onPrimitive(ts.SyntaxKind.StringKeyword),
+  ZodDateOut: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodNull: onNull,
   ZodArray: onArray,
   ZodTuple: onTuple,

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { z } from "zod";
 import { hasCoercion, tryToTransform } from "./common-helpers";
+import { ez } from "./proprietary-schemas";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   LiteralType,
@@ -212,6 +213,9 @@ const onFile: Producer<z.ZodType> = ({ schema }) =>
     ? f.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
     : f.createTypeReferenceNode("Buffer");
 
+const onRaw: Producer<z.ZodType> = ({ next }) =>
+  next({ schema: ez.file("buffer") });
+
 const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodString: onPrimitive(ts.SyntaxKind.StringKeyword),
   ZodNumber: onPrimitive(ts.SyntaxKind.NumberKeyword),
@@ -241,6 +245,7 @@ const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodLazy: onLazy,
   ZodReadonly: onReadonly,
   File: onFile,
+  Raw: onRaw,
 };
 
 export const zodToTs = ({

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -4,8 +4,7 @@ import { hasCoercion, tryToTransform } from "./common-helpers";
 import { ezDateInKind } from "./date-in-schema";
 import { ezDateOutKind } from "./date-out-schema";
 import { ezFileKind } from "./file-schema";
-import { ez } from "./proprietary-schemas";
-import { ezRawKind } from "./raw-schema";
+import { RawSchema, ezRawKind } from "./raw-schema";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   LiteralType,
@@ -217,8 +216,8 @@ const onFile: Producer<z.ZodType> = ({ schema }) =>
     ? f.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
     : f.createTypeReferenceNode("Buffer");
 
-const onRaw: Producer<z.ZodType> = ({ next }) =>
-  next({ schema: ez.file("buffer") });
+const onRaw: Producer<RawSchema> = ({ next, schema }) =>
+  next({ schema: schema.shape.raw });
 
 const producers: HandlingRules<ts.TypeNode, ZTSContext> = {
   ZodString: onPrimitive(ts.SyntaxKind.StringKeyword),

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -98,7 +98,7 @@ const onEffects: Producer<z.ZodEffects<z.ZodTypeAny>> = ({
   isResponse,
   ...ctx
 }) => {
-  // @todo why effects depicter does not work well here?
+  // @todo move to walker somehow
   if (isProprietary(schema, zodDateOutKind)) {
     return onPrimitive(ts.SyntaxKind.StringKeyword)({
       schema,

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -263,6 +263,20 @@ exports[`Documentation helpers > depictFile() > should set type:string and forma
 }
 `;
 
+exports[`Documentation helpers > depictFile() > should set type:string and format accordingly 3 1`] = `
+{
+  "format": "file",
+  "type": "string",
+}
+`;
+
+exports[`Documentation helpers > depictFile() > should set type:string and format accordingly 4 1`] = `
+{
+  "format": "binary",
+  "type": "string",
+}
+`;
+
 exports[`Documentation helpers > depictIntersection() > should wrap next depicters in allOf property 1`] = `
 {
   "allOf": [

--- a/tests/unit/__snapshots__/upload-schema.spec.ts.snap
+++ b/tests/unit/__snapshots__/upload-schema.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ZodUpload > _parse() > should accept UploadedFile 0 1`] = `
+exports[`ez.upload() > parsing > should accept UploadedFile 0 1`] = `
 {
   "data": {
     "data": {
@@ -30,7 +30,7 @@ exports[`ZodUpload > _parse() > should accept UploadedFile 0 1`] = `
 }
 `;
 
-exports[`ZodUpload > _parse() > should accept UploadedFile 1 1`] = `
+exports[`ez.upload() > parsing > should accept UploadedFile 1 1`] = `
 {
   "data": {
     "data": {

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -13,13 +13,13 @@ import {
   hasNestedSchema,
   hasTopLevelTransformingEffect,
   isCustomHeader,
+  isProprietary,
   makeCleanId,
   makeErrorFromAnything,
 } from "../../src/common-helpers";
 import { InputValidationError, ez, withMeta } from "../../src";
 import { Request } from "express";
 import { z } from "zod";
-import { getMeta, hasMeta } from "../../src/metadata";
 import { zodUploadKind } from "../../src/upload-schema";
 import { describe, expect, test } from "vitest";
 
@@ -396,9 +396,7 @@ describe("Common Helpers", () => {
       expect(
         hasNestedSchema({
           subject: ez.upload(),
-          condition: (subject) =>
-            hasMeta(subject) &&
-            getMeta(subject, "proprietaryKind") === zodUploadKind,
+          condition: (subject) => isProprietary(subject, zodUploadKind),
         }),
       ).toBeTruthy();
     });
@@ -416,9 +414,7 @@ describe("Common Helpers", () => {
       expect(
         hasNestedSchema({
           subject,
-          condition: (entry) =>
-            hasMeta(entry) &&
-            getMeta(entry, "proprietaryKind") === zodUploadKind,
+          condition: (entry) => isProprietary(entry, zodUploadKind),
         }),
       ).toBeTruthy();
     });
@@ -432,9 +428,7 @@ describe("Common Helpers", () => {
       expect(
         hasNestedSchema({
           subject,
-          condition: (entry) =>
-            hasMeta(entry) &&
-            getMeta(entry, "proprietaryKind") === zodUploadKind,
+          condition: (entry) => isProprietary(entry, zodUploadKind),
         }),
       ).toBeFalsy();
     });

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -20,7 +20,7 @@ import { InputValidationError, ez, withMeta } from "../../src";
 import { Request } from "express";
 import { z } from "zod";
 import { isProprietary } from "../../src/metadata";
-import { zodUploadKind } from "../../src/upload-schema";
+import { ezUploadKind } from "../../src/upload-schema";
 import { describe, expect, test } from "vitest";
 
 describe("Common Helpers", () => {
@@ -379,7 +379,7 @@ describe("Common Helpers", () => {
 
   describe("hasNestedSchema()", () => {
     const condition = (subject: z.ZodTypeAny) =>
-      isProprietary(subject, zodUploadKind);
+      isProprietary(subject, ezUploadKind);
     test("should return true for given argument satisfying condition", () => {
       expect(hasNestedSchema({ subject: ez.upload(), condition })).toBeTruthy();
     });

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -378,13 +378,10 @@ describe("Common Helpers", () => {
   });
 
   describe("hasNestedSchema()", () => {
+    const condition = (subject: z.ZodTypeAny) =>
+      isProprietary(subject, zodUploadKind);
     test("should return true for given argument satisfying condition", () => {
-      expect(
-        hasNestedSchema({
-          subject: ez.upload(),
-          condition: (subject) => isProprietary(subject, zodUploadKind),
-        }),
-      ).toBeTruthy();
+      expect(hasNestedSchema({ subject: ez.upload(), condition })).toBeTruthy();
     });
     test.each([
       z.object({ test: ez.upload() }),
@@ -397,12 +394,7 @@ describe("Common Helpers", () => {
       ez.upload().refine(() => true),
       z.array(ez.upload()),
     ])("should return true for wrapped needle %#", (subject) => {
-      expect(
-        hasNestedSchema({
-          subject,
-          condition: (entry) => isProprietary(entry, zodUploadKind),
-        }),
-      ).toBeTruthy();
+      expect(hasNestedSchema({ subject, condition })).toBeTruthy();
     });
     test.each([
       z.object({}),
@@ -411,12 +403,7 @@ describe("Common Helpers", () => {
       z.boolean().and(z.literal(true)),
       z.number().or(z.string()),
     ])("should return false in other cases %#", (subject) => {
-      expect(
-        hasNestedSchema({
-          subject,
-          condition: (entry) => isProprietary(entry, zodUploadKind),
-        }),
-      ).toBeFalsy();
+      expect(hasNestedSchema({ subject, condition })).toBeFalsy();
     });
   });
 

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -13,13 +13,13 @@ import {
   hasNestedSchema,
   hasTopLevelTransformingEffect,
   isCustomHeader,
-  isProprietary,
   makeCleanId,
   makeErrorFromAnything,
 } from "../../src/common-helpers";
 import { InputValidationError, ez, withMeta } from "../../src";
 import { Request } from "express";
 import { z } from "zod";
+import { isProprietary } from "../../src/metadata";
 import { zodUploadKind } from "../../src/upload-schema";
 import { describe, expect, test } from "vitest";
 

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getMeta } from "../../src/metadata";
-import * as ez from "../../src/proprietary-schemas";
+import { ez } from "../../src";
 import { describe, expect, test } from "vitest";
 
 describe("ez.dateIn()", () => {

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.dateIn()", () => {
     test("should create an instance", () => {
       const schema = ez.dateIn();
       expect(schema).toBeInstanceOf(z.ZodPipeline);
-      expect(getMeta(schema, "proprietaryKind")).toEqual("DateIn");
+      expect(getMeta(schema, "kind")).toEqual("DateIn");
     });
   });
 

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -3,9 +3,8 @@ import { getMeta } from "../../src/metadata";
 import * as ez from "../../src/proprietary-schemas";
 import { describe, expect, test } from "vitest";
 
-// @todo naming
-describe("ZodDateIn", () => {
-  describe("static::create()", () => {
+describe("ez.dateIn()", () => {
+  describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateIn();
       expect(schema).toBeInstanceOf(z.ZodPipeline);
@@ -13,7 +12,7 @@ describe("ZodDateIn", () => {
     });
   });
 
-  describe("_parse()", () => {
+  describe("parsing", () => {
     test("should handle wrong parsed type", () => {
       const schema = ez.dateIn();
       const result = schema.safeParse(123);

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.dateIn()", () => {
     test("should create an instance", () => {
       const schema = ez.dateIn();
       expect(schema).toBeInstanceOf(z.ZodPipeline);
-      expect(getMeta(schema, "proprietaryKind")).toEqual("ZodDateIn");
+      expect(getMeta(schema, "proprietaryKind")).toEqual("DateIn");
     });
   });
 

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -1,18 +1,21 @@
-import { ZodDateIn } from "../../src/date-in-schema";
+import { z } from "zod";
+import { getMeta } from "../../src/metadata";
+import * as ez from "../../src/proprietary-schemas";
 import { describe, expect, test } from "vitest";
 
+// @todo naming
 describe("ZodDateIn", () => {
   describe("static::create()", () => {
     test("should create an instance", () => {
-      const schema = ZodDateIn.create();
-      expect(schema).toBeInstanceOf(ZodDateIn);
-      expect(schema._def.typeName).toEqual("ZodDateIn");
+      const schema = ez.dateIn();
+      expect(schema).toBeInstanceOf(z.ZodPipeline);
+      expect(getMeta(schema, "proprietaryKind")).toEqual("ZodDateIn");
     });
   });
 
   describe("_parse()", () => {
     test("should handle wrong parsed type", () => {
-      const schema = ZodDateIn.create();
+      const schema = ez.dateIn();
       const result = schema.safeParse(123);
       expect(result.success).toBeFalsy();
       if (!result.success) {
@@ -29,7 +32,7 @@ describe("ZodDateIn", () => {
     });
 
     test("should accept valid date string", () => {
-      const schema = ZodDateIn.create();
+      const schema = ez.dateIn();
       const result = schema.safeParse("2022-12-31");
       expect(result).toEqual({
         success: true,
@@ -38,7 +41,7 @@ describe("ZodDateIn", () => {
     });
 
     test("should handle invalid date", () => {
-      const schema = ZodDateIn.create();
+      const schema = ez.dateIn();
       const result = schema.safeParse("2022-01-32");
       expect(result.success).toBeFalsy();
       if (!result.success) {
@@ -53,7 +56,7 @@ describe("ZodDateIn", () => {
     });
 
     test("should handle invalid format", () => {
-      const schema = ZodDateIn.create();
+      const schema = ez.dateIn();
       const result = schema.safeParse("12.01.2021");
       expect(result.success).toBeFalsy();
       if (!result.success) {

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.dateOut()", () => {
     test("should create an instance", () => {
       const schema = ez.dateOut();
       expect(schema).toBeInstanceOf(z.ZodEffects);
-      expect(getMeta(schema, "proprietaryKind")).toEqual("ZodDateOut");
+      expect(getMeta(schema, "proprietaryKind")).toEqual("DateOut");
     });
   });
 

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -1,18 +1,21 @@
-import { ZodDateOut } from "../../src/date-out-schema";
+import { z } from "zod";
+import { getMeta } from "../../src/metadata";
+import * as ez from "../../src/proprietary-schemas";
 import { describe, expect, test } from "vitest";
 
+// @todo naming
 describe("ZodDateOut", () => {
   describe("static::create()", () => {
     test("should create an instance", () => {
-      const schema = ZodDateOut.create();
-      expect(schema).toBeInstanceOf(ZodDateOut);
-      expect(schema._def.typeName).toEqual("ZodDateOut");
+      const schema = ez.dateOut();
+      expect(schema).toBeInstanceOf(z.ZodEffects);
+      expect(getMeta(schema, "proprietaryKind")).toEqual("ZodDateOut");
     });
   });
 
   describe("_parse()", () => {
     test("should handle wrong parsed type", () => {
-      const schema = ZodDateOut.create();
+      const schema = ez.dateOut();
       const result = schema.safeParse("12.01.2022");
       expect(result.success).toBeFalsy();
       if (!result.success) {
@@ -29,7 +32,7 @@ describe("ZodDateOut", () => {
     });
 
     test("should accept valid date", () => {
-      const schema = ZodDateOut.create();
+      const schema = ez.dateOut();
       const result = schema.safeParse(new Date("2022-12-31"));
       expect(result).toEqual({
         success: true,
@@ -38,7 +41,7 @@ describe("ZodDateOut", () => {
     });
 
     test("should handle invalid date", () => {
-      const schema = ZodDateOut.create();
+      const schema = ez.dateOut();
       const result = schema.safeParse(new Date("2022-01-32"));
       expect(result.success).toBeFalsy();
       if (!result.success) {

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -3,9 +3,8 @@ import { getMeta } from "../../src/metadata";
 import * as ez from "../../src/proprietary-schemas";
 import { describe, expect, test } from "vitest";
 
-// @todo naming
-describe("ZodDateOut", () => {
-  describe("static::create()", () => {
+describe("ez.dateOut()", () => {
+  describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateOut();
       expect(schema).toBeInstanceOf(z.ZodEffects);
@@ -13,7 +12,7 @@ describe("ZodDateOut", () => {
     });
   });
 
-  describe("_parse()", () => {
+  describe("parsing", () => {
     test("should handle wrong parsed type", () => {
       const schema = ez.dateOut();
       const result = schema.safeParse("12.01.2022");

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.dateOut()", () => {
     test("should create an instance", () => {
       const schema = ez.dateOut();
       expect(schema).toBeInstanceOf(z.ZodEffects);
-      expect(getMeta(schema, "proprietaryKind")).toEqual("DateOut");
+      expect(getMeta(schema, "kind")).toEqual("DateOut");
     });
   });
 

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getMeta } from "../../src/metadata";
-import * as ez from "../../src/proprietary-schemas";
+import { ez } from "../../src";
 import { describe, expect, test } from "vitest";
 
 describe("ez.dateOut()", () => {

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -318,7 +318,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictFile()", () => {
-    test.each([ez.file(), ez.file().binary(), ez.file().base64()])(
+    test.each([ez.file(), ez.file("buffer"), ez.file("base64")])(
       "should set type:string and format accordingly %#",
       (schema) => {
         expect(

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -318,18 +318,21 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictFile()", () => {
-    test.each([ez.file(), ez.file("buffer"), ez.file("base64")])(
-      "should set type:string and format accordingly %#",
-      (schema) => {
-        expect(
-          depictFile({
-            schema,
-            ...responseCtx,
-            next: makeNext(responseCtx),
-          }),
-        ).toMatchSnapshot();
-      },
-    );
+    test.each([
+      ez.file(),
+      ez.file("binary"),
+      ez.file("base64"),
+      ez.file("string"),
+      ez.file("buffer"),
+    ])("should set type:string and format accordingly %#", (schema) => {
+      expect(
+        depictFile({
+          schema,
+          ...responseCtx,
+          next: makeNext(responseCtx),
+        }),
+      ).toMatchSnapshot();
+    });
   });
 
   describe("depictUnion()", () => {

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -10,7 +10,7 @@ describe("ez.file()", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
-      expect(getMeta(schema, "proprietaryKind")).toBe("File");
+      expect(getMeta(schema, "kind")).toBe("File");
     });
 
     test.each([ez.file("string"), ez.file().string()])(

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getMeta } from "../../src/metadata";
-import * as ez from "../../src/proprietary-schemas";
+import { ez } from "../../src";
 import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "vitest";
 

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -12,25 +12,33 @@ describe("ez.file()", () => {
       expect(getMeta(schema, "proprietaryKind")).toBe("ZodFile");
     });
 
-    test("should create a string file", () => {
-      const schema = ez.file("string");
-      expect(schema).toBeInstanceOf(z.ZodString);
-    });
+    test.each([ez.file("string"), ez.file().string()])(
+      "should create a string file",
+      (schema) => {
+        expect(schema).toBeInstanceOf(z.ZodString);
+      },
+    );
 
-    test("should create a buffer file", () => {
-      const schema = ez.file("buffer");
-      expect(schema).toBeInstanceOf(z.ZodEffects);
-    });
+    test.each([ez.file("buffer"), ez.file().buffer()])(
+      "should create a buffer file",
+      (schema) => {
+        expect(schema).toBeInstanceOf(z.ZodEffects);
+      },
+    );
 
-    test("should create a binary file", () => {
-      const schema = ez.file("binary");
-      expect(schema).toBeInstanceOf(z.ZodString);
-    });
+    test.each([ez.file("binary"), ez.file().binary()])(
+      "should create a binary file",
+      (schema) => {
+        expect(schema).toBeInstanceOf(z.ZodUnion);
+      },
+    );
 
-    test("should create a base64 file", () => {
-      const schema = ez.file("base64");
-      expect(schema).toBeInstanceOf(z.ZodString);
-    });
+    test.each([ez.file("base64"), ez.file().base64()])(
+      "should create a base64 file",
+      (schema) => {
+        expect(schema).toBeInstanceOf(z.ZodString);
+      },
+    );
   });
 
   describe("parsing", () => {

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -9,7 +9,7 @@ describe("ez.file()", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
-      expect(getMeta(schema, "proprietaryKind")).toBe("ZodFile");
+      expect(getMeta(schema, "proprietaryKind")).toBe("File");
     });
 
     test.each([ez.file("string"), ez.file().string()])(

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -13,7 +13,7 @@ describe("ez.file()", () => {
       expect(getMeta(schema, "kind")).toBe("File");
     });
 
-    test.each([ez.file("string"), ez.file().string()])(
+    test.each([ez.file("string"), ez.file().string("deprecated message")])(
       "should create a string file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodString);
@@ -21,7 +21,7 @@ describe("ez.file()", () => {
       },
     );
 
-    test.each([ez.file("buffer"), ez.file().buffer()])(
+    test.each([ez.file("buffer"), ez.file().buffer("deprecated message")])(
       "should create a buffer file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodEffects);
@@ -29,7 +29,7 @@ describe("ez.file()", () => {
       },
     );
 
-    test.each([ez.file("binary"), ez.file().binary()])(
+    test.each([ez.file("binary"), ez.file().binary("deprecated message")])(
       "should create a binary file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodUnion);
@@ -37,7 +37,7 @@ describe("ez.file()", () => {
       },
     );
 
-    test.each([ez.file("base64"), ez.file().base64()])(
+    test.each([ez.file("base64"), ez.file().base64("deprecated message")])(
       "should create a base64 file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodString);

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -80,7 +80,7 @@ describe("ez.file()", () => {
     );
 
     test("should perform additional check for base64 file", () => {
-      const schema = ez.file("base64"); //.base64();
+      const schema = ez.file("base64");
       const result = schema.safeParse("~~~~");
       expect(result.success).toBeFalsy();
       if (!result.success) {
@@ -105,7 +105,7 @@ describe("ez.file()", () => {
     });
 
     test("should accept Buffer", () => {
-      const schema = ez.file("buffer"); //.buffer();
+      const schema = ez.file("buffer");
       const subject = Buffer.from("test", "utf-8");
       const result = schema.safeParse(subject);
       expect(result).toEqual({
@@ -115,7 +115,7 @@ describe("ez.file()", () => {
     });
 
     test("should accept binary read string", async () => {
-      const schema = ez.file("binary"); //.binary();
+      const schema = ez.file("binary");
       const data = await readFile("logo.svg", "binary");
       const result = schema.safeParse(data);
       expect(result).toEqual({

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -1,3 +1,4 @@
+import { expectType } from "tsd";
 import { z } from "zod";
 import { getMeta } from "../../src/metadata";
 import { ez } from "../../src";
@@ -16,6 +17,7 @@ describe("ez.file()", () => {
       "should create a string file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodString);
+        expectType<string>(schema._output);
       },
     );
 
@@ -23,6 +25,7 @@ describe("ez.file()", () => {
       "should create a buffer file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodEffects);
+        expectType<Buffer>(schema._output);
       },
     );
 
@@ -30,6 +33,7 @@ describe("ez.file()", () => {
       "should create a binary file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodUnion);
+        expectType<Buffer | string>(schema._output);
       },
     );
 
@@ -37,6 +41,7 @@ describe("ez.file()", () => {
       "should create a base64 file",
       (schema) => {
         expect(schema).toBeInstanceOf(z.ZodString);
+        expectType<string>(schema._output);
       },
     );
   });

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -9,57 +9,27 @@ describe("ez.file()", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
-      // expect(schema._def.encoding).toBeUndefined();
       expect(getMeta(schema, "proprietaryKind")).toBe("ZodFile");
-      /*
-      expect(schema.isBinary).toBeFalsy();
-      expect(schema.isBase64).toBeFalsy();
-      expect(schema.isString).toBeTruthy();
-      expect(schema.isBuffer).toBeFalsy();*/
     });
-  });
 
-  describe(".string()", () => {
     test("should create a string file", () => {
-      const schema = ez.file("string"); //.string();
+      const schema = ez.file("string");
       expect(schema).toBeInstanceOf(z.ZodString);
-      /*
-      expect(schema._def.encoding).toBeUndefined();
-      expect(schema.isString).toBeTruthy();
-      expect(schema.isBuffer).toBeFalsy();*/
     });
-  });
 
-  describe(".buffer()", () => {
     test("should create a buffer file", () => {
-      const schema = ez.file("buffer"); //.buffer();
+      const schema = ez.file("buffer");
       expect(schema).toBeInstanceOf(z.ZodEffects);
-      /*
-      expect(schema._def.encoding).toBeUndefined();
-      expect(schema.isBuffer).toBeTruthy();
-      expect(schema.isString).toBeFalsy();*/
     });
-  });
 
-  describe(".binary()", () => {
     test("should create a binary file", () => {
-      const schema = ez.file("binary"); //.binary("test message");
+      const schema = ez.file("binary");
       expect(schema).toBeInstanceOf(z.ZodString);
-      /*
-      expect(schema.isBinary).toBeTruthy();
-      expect(schema._def.encoding).toBe("binary");
-      expect(schema._def.message).toBe("test message");*/
     });
-  });
 
-  describe(".base64()", () => {
     test("should create a base64 file", () => {
-      const schema = ez.file("base64"); // .base64("test message");
+      const schema = ez.file("base64");
       expect(schema).toBeInstanceOf(z.ZodString);
-      /*
-      expect(schema.isBase64).toBeTruthy();
-      expect(schema._def.encoding).toBe("base64");
-      expect(schema._def.message).toBe("test message");*/
     });
   });
 
@@ -74,7 +44,7 @@ describe("ez.file()", () => {
         message: "Expected string, received number",
       },
       {
-        schema: ez.file("buffer"), // .buffer(),
+        schema: ez.file("buffer"),
         subject: "123",
         code: "custom",
         message: "Expected Buffer",
@@ -142,7 +112,7 @@ describe("ez.file()", () => {
     });
 
     test("should accept base64 read string", async () => {
-      const schema = ez.file("base64"); // .base64();
+      const schema = ez.file("base64");
       const data = await readFile("logo.svg", "base64");
       const result = schema.safeParse(data);
       expect(result).toEqual({

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -1,90 +1,95 @@
-import { ZodFile } from "../../src/file-schema";
+import { z } from "zod";
+import { getMeta } from "../../src/metadata";
+import * as ez from "../../src/proprietary-schemas";
 import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "vitest";
 
 describe("ZodFile", () => {
   describe("static::create()", () => {
     test("should create an instance being string by default", () => {
-      const schema = ZodFile.create();
-      expect(schema).toBeInstanceOf(ZodFile);
-      expect(schema._def.encoding).toBeUndefined();
-      expect(schema._def.typeName).toEqual("ZodFile");
+      const schema = ez.file();
+      expect(schema).toBeInstanceOf(z.ZodString);
+      // expect(schema._def.encoding).toBeUndefined();
+      expect(getMeta(schema, "proprietaryKind")).toBe("ZodFile");
+      /*
       expect(schema.isBinary).toBeFalsy();
       expect(schema.isBase64).toBeFalsy();
       expect(schema.isString).toBeTruthy();
-      expect(schema.isBuffer).toBeFalsy();
+      expect(schema.isBuffer).toBeFalsy();*/
     });
   });
 
   describe(".string()", () => {
     test("should create a string file", () => {
-      const schema = ZodFile.create().string();
-      expect(schema).toBeInstanceOf(ZodFile);
+      const schema = ez.file("string"); //.string();
+      expect(schema).toBeInstanceOf(z.ZodString);
+      /*
       expect(schema._def.encoding).toBeUndefined();
       expect(schema.isString).toBeTruthy();
-      expect(schema.isBuffer).toBeFalsy();
+      expect(schema.isBuffer).toBeFalsy();*/
     });
   });
 
   describe(".buffer()", () => {
     test("should create a buffer file", () => {
-      const schema = ZodFile.create().buffer();
-      expect(schema).toBeInstanceOf(ZodFile);
+      const schema = ez.file("buffer"); //.buffer();
+      expect(schema).toBeInstanceOf(z.ZodEffects);
+      /*
       expect(schema._def.encoding).toBeUndefined();
       expect(schema.isBuffer).toBeTruthy();
-      expect(schema.isString).toBeFalsy();
+      expect(schema.isString).toBeFalsy();*/
     });
   });
 
   describe(".binary()", () => {
     test("should create a binary file", () => {
-      const schema = ZodFile.create().binary("test message");
-      expect(schema).toBeInstanceOf(ZodFile);
+      const schema = ez.file("binary"); //.binary("test message");
+      expect(schema).toBeInstanceOf(z.ZodString);
+      /*
       expect(schema.isBinary).toBeTruthy();
       expect(schema._def.encoding).toBe("binary");
-      expect(schema._def.message).toBe("test message");
+      expect(schema._def.message).toBe("test message");*/
     });
   });
 
   describe(".base64()", () => {
     test("should create a base64 file", () => {
-      const schema = ZodFile.create().base64("test message");
-      expect(schema).toBeInstanceOf(ZodFile);
+      const schema = ez.file("base64"); // .base64("test message");
+      expect(schema).toBeInstanceOf(z.ZodString);
+      /*
       expect(schema.isBase64).toBeTruthy();
       expect(schema._def.encoding).toBe("base64");
-      expect(schema._def.message).toBe("test message");
+      expect(schema._def.message).toBe("test message");*/
     });
   });
 
   describe("_parse()", () => {
     test.each([
       {
-        schema: ZodFile.create(),
+        schema: ez.file(),
         subject: 123,
+        code: "invalid_type",
         expected: "string",
         received: "number",
         message: "Expected string, received number",
       },
       {
-        schema: ZodFile.create().buffer(),
+        schema: ez.file("buffer"), // .buffer(),
         subject: "123",
-        expected: "object",
-        received: "string",
+        code: "custom",
         message: "Expected Buffer",
+        fatal: true,
       },
     ])(
       "should invalidate wrong types",
-      ({ schema, subject, expected, received, message }) => {
+      ({ schema, subject, ...expectedError }) => {
         const result = schema.safeParse(subject);
         expect(result.success).toBeFalsy();
         if (!result.success) {
           expect(result.error.issues).toEqual([
             {
-              code: "invalid_type",
-              expected,
-              message,
+              ...expectedError,
               path: [],
-              received,
             },
           ]);
         }
@@ -92,14 +97,15 @@ describe("ZodFile", () => {
     );
 
     test("should perform additional check for base64 file", () => {
-      const schema = ZodFile.create().base64();
+      const schema = ez.file("base64"); //.base64();
       const result = schema.safeParse("~~~~");
       expect(result.success).toBeFalsy();
       if (!result.success) {
         expect(result.error.issues).toEqual([
           {
-            code: "custom",
+            code: "invalid_string",
             message: "Does not match base64 encoding",
+            validation: "regex",
             path: [],
           },
         ]);
@@ -107,7 +113,7 @@ describe("ZodFile", () => {
     });
 
     test("should accept string", () => {
-      const schema = ZodFile.create();
+      const schema = ez.file();
       const result = schema.safeParse("some string");
       expect(result).toEqual({
         success: true,
@@ -116,7 +122,7 @@ describe("ZodFile", () => {
     });
 
     test("should accept Buffer", () => {
-      const schema = ZodFile.create().buffer();
+      const schema = ez.file("buffer"); //.buffer();
       const subject = Buffer.from("test", "utf-8");
       const result = schema.safeParse(subject);
       expect(result).toEqual({
@@ -126,7 +132,7 @@ describe("ZodFile", () => {
     });
 
     test("should accept binary read string", async () => {
-      const schema = ZodFile.create().binary();
+      const schema = ez.file("binary"); //.binary();
       const data = await readFile("logo.svg", "binary");
       const result = schema.safeParse(data);
       expect(result).toEqual({
@@ -136,7 +142,7 @@ describe("ZodFile", () => {
     });
 
     test("should accept base64 read string", async () => {
-      const schema = ZodFile.create().base64();
+      const schema = ez.file("base64"); // .base64();
       const data = await readFile("logo.svg", "base64");
       const result = schema.safeParse(data);
       expect(result).toEqual({

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -4,8 +4,8 @@ import * as ez from "../../src/proprietary-schemas";
 import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "vitest";
 
-describe("ZodFile", () => {
-  describe("static::create()", () => {
+describe("ez.file()", () => {
+  describe("creation", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
@@ -63,7 +63,7 @@ describe("ZodFile", () => {
     });
   });
 
-  describe("_parse()", () => {
+  describe("parsing", () => {
     test.each([
       {
         schema: ez.file(),

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -23,7 +23,6 @@ import {
   ResultHandlerDefinition,
   Routing,
   ServerConfig,
-  ZodFileDef,
 } from "../../src";
 import { describe, expect, test, vi } from "vitest";
 
@@ -52,7 +51,6 @@ describe("Index Entrypoint", () => {
       expectType<LoggerOverrides>({});
       expectType<Routing>({});
       expectType<Metadata<z.ZodTypeAny>>({ examples: [] });
-      expectType<ZodFileDef>({ typeName: "ZodFile", type: "" });
       expectType<CommonConfig>({ cors: true, logger: { level: "silent" } });
       expectType<AppConfig>({
         app: {} as IRouter,

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -23,7 +23,6 @@ import {
   ResultHandlerDefinition,
   Routing,
   ServerConfig,
-  ZodDateOutDef,
   ZodFileDef,
 } from "../../src";
 import { describe, expect, test, vi } from "vitest";
@@ -53,7 +52,6 @@ describe("Index Entrypoint", () => {
       expectType<LoggerOverrides>({});
       expectType<Routing>({});
       expectType<Metadata<z.ZodTypeAny>>({ examples: [] });
-      expectType<ZodDateOutDef>({ typeName: "ZodDateOut" });
       expectType<ZodFileDef>({ typeName: "ZodFile", type: "" });
       expectType<CommonConfig>({ cors: true, logger: { level: "silent" } });
       expectType<AppConfig>({

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -23,7 +23,6 @@ import {
   ResultHandlerDefinition,
   Routing,
   ServerConfig,
-  ZodDateInDef,
   ZodDateOutDef,
   ZodFileDef,
 } from "../../src";
@@ -54,7 +53,6 @@ describe("Index Entrypoint", () => {
       expectType<LoggerOverrides>({});
       expectType<Routing>({});
       expectType<Metadata<z.ZodTypeAny>>({ examples: [] });
-      expectType<ZodDateInDef>({ typeName: "ZodDateIn" });
       expectType<ZodDateOutDef>({ typeName: "ZodDateOut" });
       expectType<ZodFileDef>({ typeName: "ZodFile", type: "" });
       expectType<CommonConfig>({ cors: true, logger: { level: "silent" } });

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -1,6 +1,6 @@
 import { getMeta } from "../../src/metadata";
 import { z } from "zod";
-import * as ez from "../../src/proprietary-schemas";
+import { ez } from "../../src";
 import { describe, expect, test, vi } from "vitest";
 
 describe("ez.upload()", () => {

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.upload()", () => {
     test("should create an instance", () => {
       const schema = ez.upload();
       expect(schema).toBeInstanceOf(z.ZodEffects);
-      expect(getMeta(schema, "proprietaryKind")).toBe("Upload");
+      expect(getMeta(schema, "kind")).toBe("Upload");
     });
   });
 

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -3,9 +3,8 @@ import { z } from "zod";
 import * as ez from "../../src/proprietary-schemas";
 import { describe, expect, test, vi } from "vitest";
 
-// @todo naming
-describe("ZodUpload", () => {
-  describe("static::create()", () => {
+describe("ez.upload()", () => {
+  describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.upload();
       expect(schema).toBeInstanceOf(z.ZodEffects);
@@ -13,7 +12,7 @@ describe("ZodUpload", () => {
     });
   });
 
-  describe("_parse()", () => {
+  describe("parsing", () => {
     test("should handle wrong parsed type", () => {
       const schema = ez.upload();
       const result = schema.safeParse(123);

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -8,7 +8,7 @@ describe("ez.upload()", () => {
     test("should create an instance", () => {
       const schema = ez.upload();
       expect(schema).toBeInstanceOf(z.ZodEffects);
-      expect(getMeta(schema, "proprietaryKind")).toBe("ZodUpload");
+      expect(getMeta(schema, "proprietaryKind")).toBe("Upload");
     });
   });
 


### PR DESCRIPTION
I was dreaming about it.
Unfortunately `zod` does not provide any way to make a custom or branded or third-party schema that can be identified as one programmatically. Developer of `zod` also does not want to make any method to store metadata in schemas, instead, recommends to wrap schemas in some other structures, which is not suitable for the purposes of `express-zod-api`. There are many small inconvenient things in making custom schema classes, that I'd like to replace into native methods, and use `withMeta` wrapper for storing proprietary identifier, so the generators and walkers could still handle it.

Related issues:

```
https://github.com/colinhacks/zod/issues/1718
https://github.com/colinhacks/zod/issues/2413
https://github.com/colinhacks/zod/issues/273
https://github.com/colinhacks/zod/issues/71
https://github.com/colinhacks/zod/issues/37
```

PR I've been waiting for months to merged (programmatically distinguishable branding):

```
https://github.com/colinhacks/zod/pull/2860
```