### PR TITLE
Experiment: Metadata in description

### DIFF
--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -146,7 +146,7 @@ export const getExamples = <
    * */
   validate?: boolean;
 }): ReadonlyArray<V extends "parsed" ? z.output<T> : z.input<T>> => {
-  const examples = getMeta(schema, "examples") || [];
+  const examples = getMeta(schema, "examples");
   if (!validate && variant === "original") {
     return examples;
   }

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -40,7 +40,7 @@ import {
   andToOr,
   mapLogicalContainer,
 } from "./logical-container";
-import { copyMeta } from "./metadata";
+import { copyMeta, getMeta } from "./metadata";
 import { Method } from "./method";
 import {
   HandlingRules,
@@ -780,7 +780,7 @@ export const onEach: Depicter<z.ZodTypeAny, "each"> = ({
   if (isReferenceObject(prev)) {
     return {};
   }
-  const { description } = schema;
+  const description = getMeta(schema, "description");
   const shouldAvoidParsing = schema instanceof z.ZodLazy;
   const hasTypePropertyInDepiction = prev.type !== undefined;
   const isResponseHavingCoercion = isResponse && hasCoercion(schema);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -46,10 +46,9 @@ export const withMeta = <T extends z.ZodTypeAny>(subject: T) =>
     get: (target, prop) => {
       if (prop === "example") {
         const setter: ExampleSetter<T> = (value) => {
-          const current = unpack(target);
-          const { examples } = current;
-          examples.push(value); // instead of concat, for handling array examples
-          return withMeta(pack(target, { ...current, examples }));
+          const data = unpack(target);
+          data.examples.push(value); // instead of concat, for handling array examples
+          return withMeta(pack(target, data));
         };
         return setter;
       }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -31,13 +31,12 @@ const validate = <T extends z.ZodTypeAny>(
   fallback: Metadata<T>,
 ): Metadata<T> => {
   if (!description) {
-    return fallback;
+    return initialData;
   }
   try {
     const json = JSON.parse(description, reviver);
-    return metaSchema.safeParse(json).success
-      ? (json as Metadata<T>)
-      : fallback;
+    metaSchema.parse(json);
+    return json as Metadata<T>;
   } catch {
     return fallback;
   }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -68,8 +68,7 @@ const internal = <T extends z.ZodTypeAny>(subject: T): WithMeta<T> =>
           data.examples.push(value); // instead of concat, for handling array examples
           return internal(pack(target, data));
         }) satisfies ExampleSetter<T>;
-      }
-      if (prop === "describe") {
+      } else if (prop === "describe") {
         return ((description: string) => {
           const fallback = { ...unpack(target), description };
           return internal(pack(target, validate(description, fallback)));

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -20,10 +20,22 @@ const validate = <T extends z.ZodTypeAny>(
 ): Metadata<T> =>
   metaSchema.safeParse(meta).success ? (meta as Metadata<T>) : fallback;
 
+const reviver = ({}: string, value: string) => {
+  const parsed = z
+    .string()
+    .datetime()
+    .transform((str) => new Date(str))
+    .safeParse(value);
+  if (parsed.success) {
+    return parsed.data;
+  }
+  return value;
+};
+
 const unpack = <T extends z.ZodTypeAny>(subject: T): Metadata<T> => {
   try {
     return subject.description
-      ? validate(JSON.parse(subject.description), initialData)
+      ? validate(JSON.parse(subject.description, reviver), initialData)
       : initialData;
   } catch {
     return { ...initialData, description: subject.description };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -47,12 +47,9 @@ export const withMeta = <T extends z.ZodTypeAny>(subject: T) =>
       if (prop === "example") {
         const setter: ExampleSetter<T> = (value) => {
           const current = unpack(target);
-          return withMeta(
-            pack(target, {
-              ...current,
-              examples: current.examples.concat(value),
-            }),
-          );
+          const { examples } = current;
+          examples.push(value); // instead of concat, for handling array examples
+          return withMeta(pack(target, { ...current, examples }));
         };
         return setter;
       }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -91,12 +91,12 @@ export const copyMeta = <A extends z.ZodTypeAny, B extends z.ZodTypeAny>(
   src: A,
   dest: B,
 ): WithMeta<B> => {
-  const destExamples = getMeta(dest, "examples");
+  const { examples: destExamples, ...restMeta } = unpack(dest);
   const srcExamples = getMeta(src, "examples");
   const merge = ([destExample, srcExample]: [unknown, unknown]) =>
     typeof destExample === "object" && typeof srcExample === "object"
       ? mergeDeepRight({ ...destExample }, { ...srcExample })
       : srcExample; // not supposed to be called on non-object schemas
   const examples = combinations(destExamples, srcExamples, merge);
-  return withMeta(pack(dest, { ...unpack(dest), examples }));
+  return withMeta(pack(dest, { ...restMeta, examples }));
 };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -74,10 +74,10 @@ const internal = <T extends z.ZodTypeAny>(subject: T): WithMeta<T> =>
           return internal(pack(target, validate(description, fallback)));
         }) satisfies T["describe"];
       }
-      return Reflect.get(target, prop, target);
+      return Reflect.get(target, prop);
     },
     has: (target, prop: string) =>
-      prop === "example" ? true : Reflect.has(target, prop),
+      prop === "example" || Reflect.has(target, prop),
   });
 
 export const withMeta = <T extends z.ZodTypeAny>(subject: T) =>

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -30,11 +30,8 @@ const validate = <T extends z.ZodTypeAny>(
   description: string | undefined,
   fallback: Metadata<T>,
 ): Metadata<T> => {
-  if (!description) {
-    return initialData;
-  }
   try {
-    const json = JSON.parse(description, reviver);
+    const json = JSON.parse(description || "", reviver);
     metaSchema.parse(json);
     return json as Metadata<T>;
   } catch {

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { z } from "zod";
 import { hasCoercion, tryToTransform } from "./common-helpers";
 import { ZodFile } from "./file-schema";
+import { getMeta } from "./metadata";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   LiteralType,
@@ -55,8 +56,9 @@ const onObject: Producer<z.ZodObject<z.ZodRawShape>> = ({
         : undefined,
       next({ schema: value }),
     );
-    if (value.description) {
-      addJsDocComment(propertySignature, value.description);
+    const description = getMeta(value, "description");
+    if (description) {
+      addJsDocComment(propertySignature, description);
     }
     return propertySignature;
   });

--- a/tests/unit/__snapshots__/result-handler.spec.ts.snap
+++ b/tests/unit/__snapshots__/result-handler.spec.ts.snap
@@ -29,23 +29,17 @@ exports[`ResultHandler > 'arrayResultHandler' > Should handle schema error 1`] =
 `;
 
 exports[`ResultHandler > 'arrayResultHandler' > should forward output schema examples 1`] = `
-{
-  "examples": [
-    [
-      "One",
-      "Two",
-      "Three",
-    ],
-  ],
-}
+[
+  "One",
+  "Two",
+  "Three",
+]
 `;
 
 exports[`ResultHandler > 'arrayResultHandler' > should generate negative response example 1`] = `
-{
-  "examples": [
-    "Sample error message",
-  ],
-}
+[
+  "Sample error message",
+]
 `;
 
 exports[`ResultHandler > 'defaultResultHandler' > Should handle HTTP error 1`] = `
@@ -98,34 +92,30 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`]
 `;
 
 exports[`ResultHandler > 'defaultResultHandler' > should forward output schema examples 1`] = `
-{
-  "examples": [
-    {
-      "data": {
-        "items": [
-          "One",
-          "Two",
-          "Three",
-        ],
-        "str": "test",
-      },
-      "status": "success",
+[
+  {
+    "data": {
+      "items": [
+        "One",
+        "Two",
+        "Three",
+      ],
+      "str": "test",
     },
-  ],
-}
+    "status": "success",
+  },
+]
 `;
 
 exports[`ResultHandler > 'defaultResultHandler' > should generate negative response example 1`] = `
-{
-  "examples": [
-    {
-      "error": {
-        "message": "Sample error message",
-      },
-      "status": "error",
+[
+  {
+    "error": {
+      "message": "Sample error message",
     },
-  ],
-}
+    "status": "error",
+  },
+]
 `;
 
 exports[`ResultHandler > arrayResultHandler should fail when there is no items prop in the output 1`] = `

--- a/tests/unit/__snapshots__/result-handler.spec.ts.snap
+++ b/tests/unit/__snapshots__/result-handler.spec.ts.snap
@@ -30,9 +30,11 @@ exports[`ResultHandler > 'arrayResultHandler' > Should handle schema error 1`] =
 
 exports[`ResultHandler > 'arrayResultHandler' > should forward output schema examples 1`] = `
 [
-  "One",
-  "Two",
-  "Three",
+  [
+    "One",
+    "Two",
+    "Three",
+  ],
 ]
 `;
 

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -298,7 +298,7 @@ describe("Endpoint", () => {
           something: z.number(),
         });
         const output = z.object({
-          something: z.number(),
+          anything: z.number(),
         });
         const endpoint = factory.build({
           method: "get",
@@ -306,9 +306,11 @@ describe("Endpoint", () => {
           output,
           handler: vi.fn(),
         });
-        expect((endpoint as AbstractEndpoint).getSchema(variant)).toEqual(
-          variant === "input" ? input : output,
-        );
+        expect(
+          serializeSchemaForTest(
+            (endpoint as AbstractEndpoint).getSchema(variant),
+          ),
+        ).toEqual(serializeSchemaForTest(variant === "input" ? input : output));
       },
     );
 

--- a/tests/unit/metadata.spec.ts
+++ b/tests/unit/metadata.spec.ts
@@ -117,31 +117,13 @@ describe("Metadata", () => {
     });
 
     test("should merge the meta from src to dest (deep merge)", () => {
-      const src = withMeta(
-        z.object({
-          a: z.string(),
-        }),
-      )
-        .example({
-          a: "some",
-        })
-        .example({
-          a: "another",
-        });
-      const dest = withMeta(
-        z.object({
-          b: z.number(),
-        }),
-      )
-        .example({
-          b: 123,
-        })
-        .example({
-          b: 456,
-        })
-        .example({
-          b: 789,
-        });
+      const src = withMeta(z.object({ a: z.string() }))
+        .example({ a: "some" })
+        .example({ a: "another" });
+      const dest = withMeta(z.object({ b: z.number() }))
+        .example({ b: 123 })
+        .example({ b: 456 })
+        .example({ b: 789 });
       const result = copyMeta(src, dest);
       expect(getMeta(result, "examples")).toEqual([
         { a: "some", b: 123 },

--- a/tests/unit/metadata.spec.ts
+++ b/tests/unit/metadata.spec.ts
@@ -67,6 +67,7 @@ describe("Metadata", () => {
       expect(describedSchema.description).toBe(
         '{"examples":["test"],"description":"some string"}',
       );
+      expect(describedSchema).toHaveProperty("example"); // and also remain being proxy
     });
   });
 

--- a/tests/unit/metadata.spec.ts
+++ b/tests/unit/metadata.spec.ts
@@ -59,6 +59,15 @@ describe("Metadata", () => {
         '{"examples":["test","another"]}',
       );
     });
+
+    test("metadata should withstand calling describe() by consumer", () => {
+      const schema = withMeta(z.string()).example("test");
+      const describedSchema = schema.describe("some string");
+      expect(schema.description).toBe('{"examples":["test"]}');
+      expect(describedSchema.description).toBe(
+        '{"examples":["test"],"description":"some string"}',
+      );
+    });
   });
 
   describe("getMeta()", () => {

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -10,8 +10,8 @@ import {
   withMeta,
 } from "../../src";
 import { ApiResponse } from "../../src/api-response";
-import { metaProp } from "../../src/metadata";
 import { describe, expect, test, vi } from "vitest";
+import { getMeta } from "../../src/metadata";
 import {
   makeLoggerMock,
   makeRequestMock,
@@ -145,7 +145,7 @@ describe("ResultHandler", () => {
         if (!(apiResponse instanceof z.ZodType)) {
           expect.fail("should not be here");
         }
-        expect(apiResponse._def[metaProp]).toMatchSnapshot();
+        expect(getMeta(apiResponse, "examples")).toMatchSnapshot();
       });
 
       test("should generate negative response example", () => {
@@ -153,7 +153,7 @@ describe("ResultHandler", () => {
         if (!(apiResponse instanceof z.ZodType)) {
           expect.fail("should not be here");
         }
-        expect(apiResponse._def[metaProp]).toMatchSnapshot();
+        expect(getMeta(apiResponse, "examples")).toMatchSnapshot();
       });
     },
   );


### PR DESCRIPTION
- Instead of #1450 
- Accompanies #1442

Probably a less hacky way to store metadata.