### PR TITLE
Collapse empty allof declarations

### DIFF
--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -277,6 +277,20 @@ exports[`Documentation helpers > depictFile() > should set type:string and forma
 }
 `;
 
+exports[`Documentation helpers > depictIntersection() > should collapse empty schemas 1`] = `
+{
+  "properties": {
+    "a": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "a",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`Documentation helpers > depictIntersection() > should wrap next depicters in allOf property 1`] = `
 {
   "allOf": [

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -452,11 +452,8 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - type: object
-                  properties: {}
-                - type: object
-                  properties: {}
+              type: object
+              properties: {}
       security:
         - HTTP_1: []
           OAUTH2_1:
@@ -514,11 +511,8 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - type: object
-                  properties: {}
-                - type: object
-                  properties: {}
+              type: object
+              properties: {}
       security:
         - HTTP_2: []
 components:

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -377,6 +377,16 @@ describe("Documentation helpers", () => {
         }),
       ).toMatchSnapshot();
     });
+
+    test("should collapse empty schemas", () => {
+      expect(
+        depictIntersection({
+          schema: z.object({a: z.string()}).and(z.object({})),
+          ...requestCtx,
+          next: makeNext(requestCtx),
+        })
+      ).toMatchSnapshot();
+    })
   });
 
   describe("depictOptional()", () => {


### PR DESCRIPTION
This is perhaps a stylistic choice however I thought I'd fire a PR. I have a few layers of middleware which all have inputs by nature of requiring at least a `z.object({})`. This means I end up with many of my endpoints' types being something like (forgive pseudo-yaml)

```yaml
allOf:
  - allOf:
    - allOf:
      - type: object
        keys: ["a", "b"]
      - type: object
        keys: []
    - type: object
      keys: []
  - type: object
    keys: []
```

This PR changes the behaviour to collapse unions with empty objects such that we don't get such complicated types, as well as replacing allOfs with only a single item with just that single item.
