### PR TITLE
Remove `copyMeta` from `extractObjectSchema`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -39,7 +39,6 @@ import {
   andToOr,
   mapLogicalContainer,
 } from "./logical-container";
-import { copyMeta } from "./metadata";
 import { Method } from "./method";
 import { RawSchema, ezRawKind } from "./raw-schema";
 import { isoDateRegex } from "./schema-helpers";
@@ -680,7 +679,7 @@ export const extractObjectSchema = (
       extractObjectSchema(subject._def.right, ctx),
     );
   }
-  return copyMeta(subject, objectSchema);
+  return objectSchema;
 };
 
 export const depictRequestParams = ({

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -650,16 +650,15 @@ export const depictParamExamples = (
 export const extractObjectSchema = (
   subject: IOSchema,
   ctx: Pick<OpenAPIContext, "path" | "method" | "isResponse">,
-) => {
+): z.ZodObject<z.ZodRawShape> => {
   if (subject instanceof z.ZodObject) {
     return subject;
   }
-  let objectSchema: z.AnyZodObject;
   if (
     subject instanceof z.ZodUnion ||
     subject instanceof z.ZodDiscriminatedUnion
   ) {
-    objectSchema = Array.from(subject.options.values())
+    return Array.from(subject.options.values())
       .map((option) => extractObjectSchema(option, ctx))
       .reduce((acc, option) => acc.merge(option.partial()), z.object({}));
   } else if (subject instanceof z.ZodEffects) {
@@ -672,14 +671,11 @@ export const extractObjectSchema = (
         ...ctx,
       }),
     );
-    objectSchema = extractObjectSchema(subject._def.schema, ctx); // object refinement
-  } else {
-    // intersection
-    objectSchema = extractObjectSchema(subject._def.left, ctx).merge(
-      extractObjectSchema(subject._def.right, ctx),
-    );
-  }
-  return objectSchema;
+    return extractObjectSchema(subject._def.schema, ctx); // object refinement
+  } // intersection left
+  return extractObjectSchema(subject._def.left, ctx).merge(
+    extractObjectSchema(subject._def.right, ctx),
+  );
 };
 
 export const depictRequestParams = ({

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { defaultSerializer } from "../../src/common-helpers";
 import { IOSchemaError } from "../../src/errors";
 import { DocumentationError, ez, withMeta } from "../../src";
-import { getMeta } from "../../src/metadata";
 import {
   OpenAPIContext,
   depictAny,
@@ -157,41 +156,6 @@ describe("Documentation helpers", () => {
       );
       expect(subject).toBeInstanceOf(z.ZodObject);
       expect(serializeSchemaForTest(subject)).toMatchSnapshot();
-    });
-
-    test("should preserve examples", () => {
-      const objectSchema = withMeta(z.object({ one: z.string() })).example({
-        one: "test",
-      });
-      expect(
-        getMeta(extractObjectSchema(objectSchema, requestCtx), "examples"),
-      ).toEqual([{ one: "test" }]);
-
-      const refinedObjSchema = withMeta(
-        z.object({ one: z.string() }).refine(() => true),
-      ).example({ one: "test" });
-      expect(
-        getMeta(extractObjectSchema(refinedObjSchema, requestCtx), "examples"),
-      ).toEqual([{ one: "test" }]);
-
-      const unionSchema = withMeta(
-        z.object({ one: z.string() }).or(z.object({ two: z.number() })),
-      )
-        .example({ one: "test1" })
-        .example({ two: 123 });
-      expect(
-        getMeta(extractObjectSchema(unionSchema, requestCtx), "examples"),
-      ).toEqual([{ one: "test1" }, { two: 123 }]);
-
-      const intersectionSchema = withMeta(
-        z.object({ one: z.string() }).and(z.object({ two: z.number() })),
-      ).example({ one: "test1", two: 123 });
-      expect(
-        getMeta(
-          extractObjectSchema(intersectionSchema, requestCtx),
-          "examples",
-        ),
-      ).toEqual([{ one: "test1", two: 123 }]);
     });
 
     describe("Feature #600: Top level refinements", () => {


### PR DESCRIPTION
Turned out to be redundant, no longer used.