### PR TITLE
Removing redundant variation in `depictParamExamples()`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -643,7 +643,6 @@ export const depictExamples = (
 
 export const depictParamExamples = (
   schema: z.ZodTypeAny,
-  isResponse: boolean,
   param: string,
 ): ExamplesObject | undefined => {
   const examples = pipe(
@@ -651,7 +650,7 @@ export const depictParamExamples = (
     filter<FlatObject>(has(param)),
     pluck(param),
     map(objOf("value")),
-  )({ schema, variant: isResponse ? "parsed" : "original", validate: true });
+  )({ schema, variant: "original", validate: true });
   if (examples.length === 0) {
     return undefined;
   }
@@ -743,7 +742,7 @@ export const depictRequestParams = ({
         required: !shape[name].isOptional(),
         description: depicted.description || description,
         schema: result,
-        examples: depictParamExamples(schema, false, name),
+        examples: depictParamExamples(schema, name),
       };
     });
 };

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -722,24 +722,13 @@ exports[`Documentation helpers > depictOptional() > should pass the next depicte
 }
 `;
 
-exports[`Documentation helpers > depictParamExamples() > should 'pass' examples in case of 'request' 1`] = `
+exports[`Documentation helpers > depictParamExamples() > should pass examples for the given parameter 1`] = `
 {
   "example1": {
     "value": 123,
   },
   "example2": {
     "value": 456,
-  },
-}
-`;
-
-exports[`Documentation helpers > depictParamExamples() > should 'transform' examples in case of 'response' 1`] = `
-{
-  "example1": {
-    "value": "123",
-  },
-  "example2": {
-    "value": "456",
   },
 }
 `;

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -758,10 +758,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictParamExamples()", () => {
-    test.each<{ isResponse: boolean } & Record<"case" | "action", string>>([
-      { isResponse: false, case: "request", action: "pass" },
-      { isResponse: true, case: "response", action: "transform" },
-    ])("should $action examples in case of $case", ({ isResponse }) => {
+    test("should pass examples for the given parameter", () => {
       expect(
         depictParamExamples(
           withMeta(
@@ -781,7 +778,6 @@ describe("Documentation helpers", () => {
               two: 456,
               three: false,
             }),
-          isResponse,
           "two",
         ),
       ).toMatchSnapshot();


### PR DESCRIPTION
Parameters can not be in response