### PR TITLE
Ref: Schema Walker: `next()` accepting only the schema argument

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -11,27 +11,26 @@ type Check<T extends z.ZodTypeAny> = SchemaHandler<T, boolean>;
 const onSomeUnion: Check<
   | z.ZodUnion<z.ZodUnionOptions>
   | z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
-> = ({ schema: { options }, next }) =>
-  options.some((schema) => next({ schema }));
+> = ({ schema: { options }, next }) => options.some(next);
 
 const onIntersection: Check<z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>> = ({
   schema: { _def },
   next,
-}) => [_def.left, _def.right].some((schema) => next({ schema }));
+}) => [_def.left, _def.right].some(next);
 
 const onObject: Check<z.ZodObject<z.ZodRawShape>> = ({ schema, next }) =>
-  Object.values(schema.shape).some((entry) => next({ schema: entry }));
+  Object.values(schema.shape).some(next);
 const onElective: Check<
   z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny>
-> = ({ schema, next }) => next({ schema: schema.unwrap() });
+> = ({ schema, next }) => next(schema.unwrap());
 const onEffects: Check<z.ZodEffects<z.ZodTypeAny>> = ({ schema, next }) =>
-  next({ schema: schema.innerType() });
+  next(schema.innerType());
 const onRecord: Check<z.ZodRecord> = ({ schema, next }) =>
-  next({ schema: schema.valueSchema });
+  next(schema.valueSchema);
 const onArray: Check<z.ZodArray<z.ZodTypeAny>> = ({ schema, next }) =>
-  next({ schema: schema.element });
+  next(schema.element);
 const onDefault: Check<z.ZodDefault<z.ZodTypeAny>> = ({ schema, next }) =>
-  next({ schema: schema._def.innerType });
+  next(schema._def.innerType);
 
 const checks: HandlingRules<boolean> = {
   ZodObject: onObject,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -132,10 +132,7 @@ export const depictDefault: Depicter<z.ZodDefault<z.ZodTypeAny>> = ({
     _def: { innerType, defaultValue },
   },
   next,
-}) => ({
-  ...next(innerType),
-  default: defaultValue(),
-});
+}) => ({ ...next(innerType), default: defaultValue() });
 
 export const depictCatch: Depicter<z.ZodCatch<z.ZodTypeAny>> = ({
   schema: {

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -4,7 +4,7 @@ import { getMeta } from "./metadata";
 import { ProprietaryKind } from "./proprietary-schemas";
 
 interface VariantDependingProps<U> {
-  regular: { next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> };
+  regular: { next: (schema: z.ZodTypeAny) => U };
   after: { prev: U };
   last: {};
 }
@@ -60,9 +60,9 @@ export const walkSchema = <U, Context extends FlatObject = {}>({
   const kind = getMeta(schema, "kind") || schema._def.typeName;
   const handler =
     kind && depth < maxDepth ? rules[kind as keyof typeof rules] : undefined;
-  const next: SchemaHandler<z.ZodTypeAny, U, {}, "last"> = (params) =>
+  const next = (subject: z.ZodTypeAny) =>
     walkSchema({
-      ...params,
+      schema: subject,
       ...ctx,
       beforeEach,
       afterEach,

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -152,10 +152,10 @@ const onRecord: Producer<z.ZodRecord> = ({
   next,
   schema: { keySchema, valueSchema },
 }) =>
-  f.createExpressionWithTypeArguments(f.createIdentifier("Record"), [
-    next(keySchema),
-    next(valueSchema),
-  ]);
+  f.createExpressionWithTypeArguments(
+    f.createIdentifier("Record"),
+    [keySchema, valueSchema].map(next),
+  );
 
 const onIntersection: Producer<
   z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,3 +1,4 @@
+import { map } from "ramda";
 import { z } from "zod";
 import { SchemaHandler, walkSchema } from "../src/schema-walker";
 
@@ -31,25 +32,22 @@ export const waitFor = async (cb: () => boolean) =>
   });
 
 export const serializeSchemaForTest = (
-  schema: z.ZodTypeAny,
+  subject: z.ZodTypeAny,
 ): Record<string, any> => {
   const onSomeUnion: SchemaHandler<
-    z.ZodUnion<any> | z.ZodDiscriminatedUnion<any, any>,
+    | z.ZodUnion<z.ZodUnionOptions>
+    | z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>,
     object
-  > = ({ schema: subject, next }) => ({
-    options: Array.from(subject.options.values()).map((option) =>
-      next({ schema: option as z.ZodTypeAny }),
-    ),
+  > = ({ schema, next }) => ({
+    options: Array.from(schema.options.values()).map(next),
   });
   const onOptionalOrNullable: SchemaHandler<
-    z.ZodOptional<any> | z.ZodNullable<any>,
+    z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny>,
     object
-  > = ({ schema: subject, next }) => ({
-    value: next({ schema: subject.unwrap() }),
-  });
+  > = ({ schema, next }) => ({ value: next(schema.unwrap()) });
   const onPrimitive = () => ({});
   return walkSchema({
-    schema,
+    schema: subject,
     rules: {
       ZodNull: onPrimitive,
       ZodNumber: onPrimitive,
@@ -59,48 +57,35 @@ export const serializeSchemaForTest = (
       ZodDiscriminatedUnion: onSomeUnion,
       ZodOptional: onOptionalOrNullable,
       ZodNullable: onOptionalOrNullable,
-      ZodIntersection: ({ schema: subject, next }) => ({
-        left: next({ schema: subject._def.left }),
-        right: next({ schema: subject._def.right }),
+      ZodIntersection: ({ schema, next }) => ({
+        left: next(schema._def.left),
+        right: next(schema._def.right),
       }),
-      ZodObject: ({ schema: subject, next }) => ({
-        shape: Object.keys(subject.shape).reduce(
-          (carry, key) => ({
-            ...carry,
-            [key]: next({ schema: subject.shape[key] }),
-          }),
-          {},
-        ),
+      ZodObject: ({ schema, next }) => ({ shape: map(next, schema.shape) }),
+      ZodEffects: ({ schema, next }) => ({ value: next(schema._def.schema) }),
+      ZodRecord: ({ schema, next }) => ({
+        keys: next(schema.keySchema),
+        values: next(schema.valueSchema),
       }),
-      ZodEffects: ({ schema: subject, next }) => ({
-        value: next({ schema: subject._def.schema }),
-      }),
-      ZodRecord: ({ schema: subject, next }) => ({
-        keys: next({ schema: subject.keySchema }),
-        values: next({ schema: subject.valueSchema }),
-      }),
-      ZodArray: ({ schema: subject, next }) => ({
-        items: next({ schema: subject.element }),
-      }),
-      ZodLiteral: ({ schema: subject }) => ({ value: subject.value }),
-      ZodDefault: ({ schema: subject, next }) => ({
-        value: next({ schema: subject._def.innerType }),
+      ZodArray: ({ schema, next }) => ({ items: next(schema.element) }),
+      ZodLiteral: ({ schema }) => ({ value: schema.value }),
+      ZodDefault: ({ schema, next }) => ({
+        value: next(schema._def.innerType),
         default: schema._def.defaultValue(),
       }),
-      ZodReadonly: ({ schema: subject, next }) =>
-        next({ schema: subject._def.innerType }),
-      ZodCatch: ({ schema: subject, next }) => ({
-        value: next({ schema: subject._def.innerType }),
+      ZodReadonly: ({ schema, next }) => next(schema._def.innerType),
+      ZodCatch: ({ schema, next }) => ({
+        value: next(schema._def.innerType),
         fallback: schema._def.defaultValue(),
       }),
-      ZodPipeline: ({ schema: subject, next }) => ({
-        from: next({ schema: subject._def.in }),
-        to: next({ schema: subject._def.out }),
+      ZodPipeline: ({ schema, next }) => ({
+        from: next(schema._def.in),
+        to: next(schema._def.out),
       }),
     },
-    afterEach: ({ schema: subject }) => ({ _type: subject._def.typeName }),
-    onMissing: ({ schema: subject }) => {
-      console.warn(`There is no serializer for ${subject._def.typeName}`);
+    afterEach: ({ schema }) => ({ _type: schema._def.typeName }),
+    onMissing: ({ schema }) => {
+      console.warn(`There is no serializer for ${schema._def.typeName}`);
       return {};
     },
   });

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -51,7 +51,7 @@ import {
   onMissing,
   reformatParamsInPath,
 } from "../../src/documentation-helpers";
-import { SchemaHandler, walkSchema } from "../../src/schema-walker";
+import { walkSchema } from "../../src/schema-walker";
 import { serializeSchemaForTest } from "../helpers";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -78,23 +78,14 @@ describe("Documentation helpers", () => {
     makeRef: makeRefMock,
     serializer: defaultSerializer,
   };
-  const makeNext =
-    (
-      ctx: OpenAPIContext,
-    ): SchemaHandler<
-      z.ZodTypeAny,
-      SchemaObject | ReferenceObject,
-      {},
-      "last"
-    > =>
-    ({ schema }) =>
-      walkSchema({
-        schema,
-        rules: depicters,
-        ...ctx,
-        afterEach,
-        onMissing,
-      });
+  const makeNext = (ctx: OpenAPIContext) => (schema: z.ZodTypeAny) =>
+    walkSchema({
+      schema,
+      rules: depicters,
+      ...ctx,
+      afterEach,
+      onMissing,
+    });
 
   beforeEach(() => {
     getRefMock.mockClear();


### PR DESCRIPTION
Impactful simplification.