### PR TITLE
Rev: avoid `safeParse()` in `hasMeta()`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -617,12 +617,7 @@ export const depictExamples = (
 ): ExamplesObject | undefined =>
   pipe(
     getExamples,
-    map(
-      when(
-        (example) => typeof example === "object" && !Array.isArray(example),
-        omit(omitProps),
-      ),
-    ),
+    map(when((subj) => z.object({}).safeParse(subj).success, omit(omitProps))),
     enumerateExamples,
   )({ schema, variant: isResponse ? "parsed" : "original", validate: true });
 

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -617,7 +617,12 @@ export const depictExamples = (
 ): ExamplesObject | undefined =>
   pipe(
     getExamples,
-    map(when((subj) => z.object({}).safeParse(subj).success, omit(omitProps))),
+    map(
+      when(
+        (example) => typeof example === "object" && !Array.isArray(example),
+        omit(omitProps),
+      ),
+    ),
     enumerateExamples,
   )({ schema, variant: isResponse ? "parsed" : "original", validate: true });
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -45,7 +45,9 @@ export const withMeta = <T extends z.ZodTypeAny>(schema: T): WithMeta<T> => {
 export const hasMeta = <T extends z.ZodTypeAny>(
   schema: T,
 ): schema is WithMeta<T> =>
-  z.object({ [metaProp]: z.object({}) }).safeParse(schema._def).success;
+  metaProp in schema._def &&
+  typeof schema._def[metaProp] === "object" &&
+  schema._def[metaProp] !== null;
 
 export const getMeta = <T extends z.ZodTypeAny, K extends keyof Metadata<T>>(
   schema: T,


### PR DESCRIPTION
Working on #1513 I found out that `safeParse` is much slower than a series of basic typescript checks.

This PR restores previous implementation without `safeParse` ~~in several places:~~

- Partially reverts #1456 for `hasMeta()`;
- ~~Partially reverts #1498 for `depictExamples()`.~~ (not taken, not critical)
