### PR TITLE
Rev: avoiding `safeParse()` in the `ez.file()` implementation

### DIFF
--- a/src/schema-helpers.ts
+++ b/src/schema-helpers.ts
@@ -2,11 +2,13 @@ import { z } from "zod";
 
 export const isValidDate = (date: Date): boolean => !isNaN(date.getTime());
 
+/** @todo move to file schema in v17 */
 export const bufferSchema = z.custom<Buffer>(
   (subject) => Buffer.isBuffer(subject),
   { message: "Expected Buffer" },
 );
 
+/** @todo move to file schema in v17 */
 export const base64Regex =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 

--- a/src/upload-schema.ts
+++ b/src/upload-schema.ts
@@ -1,7 +1,6 @@
 import type { UploadedFile } from "express-fileupload";
 import { z } from "zod";
 import { proprietary } from "./metadata";
-import { bufferSchema } from "./schema-helpers";
 
 export const ezUploadKind = "Upload";
 
@@ -10,19 +9,26 @@ export const upload = () =>
     ezUploadKind,
     z.custom<UploadedFile>(
       (subject) =>
-        z
-          .object({
-            name: z.string(),
-            encoding: z.string(),
-            mimetype: z.string(),
-            data: bufferSchema,
-            tempFilePath: z.string(),
-            truncated: z.boolean(),
-            size: z.number(),
-            md5: z.string(),
-            mv: z.function(),
-          })
-          .safeParse(subject).success,
+        typeof subject === "object" &&
+        subject !== null &&
+        "name" in subject &&
+        "encoding" in subject &&
+        "mimetype" in subject &&
+        "data" in subject &&
+        "tempFilePath" in subject &&
+        "truncated" in subject &&
+        "size" in subject &&
+        "md5" in subject &&
+        "mv" in subject &&
+        typeof subject.name === "string" &&
+        typeof subject.encoding === "string" &&
+        typeof subject.mimetype === "string" &&
+        Buffer.isBuffer(subject.data) &&
+        typeof subject.tempFilePath === "string" &&
+        typeof subject.truncated === "boolean" &&
+        typeof subject.size === "number" &&
+        typeof subject.md5 === "string" &&
+        typeof subject.mv === "function",
       (input) => ({
         message: `Expected file upload, received ${typeof input}`,
       }),


### PR DESCRIPTION
Since v16.1.0
Partially reverts #1424, based on the performance impact investigation.

```
 ✓ tests/bench/experiment.bench.ts (2) 10490ms
   ✓ Experiment (2) 10487ms
     name             hz     min      max    mean     p75     p99    p995    p999     rme  samples
   · original  19,856.90  0.0361   6.9001  0.0504  0.0452  0.0936  0.1605  2.3311  ±1.59%    99285
   · featured  54,453.60  0.0107  10.9036  0.0184  0.0146  0.0285  0.0426  2.7442  ±2.67%   272406   fastest


 BENCH  Summary

  featured - tests/bench/experiment.bench.ts > Experiment
    2.74x faster than original
```