### PR TITLE
Ref: shortening `hasNestedSchema()`

### DIFF
--- a/src/deep-checks.ts
+++ b/src/deep-checks.ts
@@ -59,9 +59,8 @@ export const hasNestedSchema = ({
   maxDepth?: number;
   depth?: number;
 }): boolean => {
-  const early = condition(subject);
-  if (early) {
-    return early;
+  if (condition(subject)) {
+    return true;
   }
   const handler =
     depth < maxDepth


### PR DESCRIPTION
Making it simpler without loosing the speed.