### PR TITLE
Removing redundant condition in `combineContainers()`

### DIFF
--- a/src/logical-container.ts
+++ b/src/logical-container.ts
@@ -63,9 +63,6 @@ export const combineContainers = <T>(
   right: LogicalContainer<T>,
 ): LogicalContainer<T> => {
   if (isLogicalAnd(left)) {
-    if (isLogicalAnd(right)) {
-      return flattenAnds([left, right]);
-    }
     if (isLogicalOr(right)) {
       return combineContainers(andToOr(left), right);
     }


### PR DESCRIPTION
Excessive branch since `flattenAnds` can handle it later