### PR TITLE
Ref: Drop `Endpoint::_setSiblingMethods()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v16.6.2
 
-- Internal method `Endpoint::_setSiblingMethods()` removed;
+- Internal method `Endpoint::_setSiblingMethods()` removed (since v8.4.1);
 - The public property `DependsOnMethod::endpoints` is deprecated and will be removed in v17.
 
 ### v16.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 16
 
+### v16.6.2
+
+- Internal method `Endpoint::_setSiblingMethods()` removed;
+- The public property `DependsOnMethod::endpoints` is deprecated and will be removed in v17.
+
 ### v16.6.1
 
 - Performance fix for uploads processing (since v16.1.0).

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -1,8 +1,24 @@
+import { head, tail, toPairs } from "ramda";
 import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
 
 export class DependsOnMethod {
+  public readonly pairs: [Method, AbstractEndpoint][];
+  public readonly firstEndpoint: AbstractEndpoint | undefined;
+  public readonly siblingMethods: Method[];
+
   constructor(
+    /**
+     * @deprecated use pairs instead
+     * @todo remove from public in v17
+     * */
     public readonly endpoints: Partial<Record<Method, AbstractEndpoint>>,
-  ) {}
+  ) {
+    this.pairs = toPairs(endpoints).filter(
+      (entry): entry is [Method, AbstractEndpoint] =>
+        Array.isArray(entry) && entry[1] instanceof AbstractEndpoint,
+    );
+    this.firstEndpoint = head(this.pairs)?.[1];
+    this.siblingMethods = tail(this.pairs).map(([method]) => method);
+  }
 }

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -1,4 +1,4 @@
-import { head, tail, toPairs } from "ramda";
+import { head, isNil, tail, toPairs } from "ramda";
 import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
 
@@ -16,7 +16,7 @@ export class DependsOnMethod {
   ) {
     this.pairs = toPairs(endpoints).filter(
       (entry): entry is [Method, AbstractEndpoint] =>
-        Array.isArray(entry) && entry[1] instanceof AbstractEndpoint,
+        !isNil(entry) && !isNil(entry[1]),
     );
     this.firstEndpoint = head(this.pairs)?.[1];
     this.siblingMethods = tail(this.pairs).map(([method]) => method);

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -1,4 +1,4 @@
-import { head, isNil, tail, toPairs } from "ramda";
+import { head, tail, toPairs } from "ramda";
 import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
 
@@ -15,8 +15,8 @@ export class DependsOnMethod {
     public readonly endpoints: Partial<Record<Method, AbstractEndpoint>>,
   ) {
     this.pairs = toPairs(endpoints).filter(
-      (entry): entry is [Method, AbstractEndpoint] =>
-        !isNil(entry) && !isNil(entry[1]),
+      (pair): pair is [Method, AbstractEndpoint] =>
+        pair !== undefined && pair[1] !== undefined,
     );
     this.firstEndpoint = head(this.pairs)?.[1];
     this.siblingMethods = tail(this.pairs).map(([method]) => method);

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -49,7 +49,7 @@ export const walkRouting = ({
         element.apply(path, onStatic);
       }
     } else if (element instanceof DependsOnMethod) {
-      element.pairs.forEach(([method, endpoint]) => {
+      for (const [method, endpoint] of element.pairs) {
         assert(
           endpoint.getMethods().includes(method),
           new RoutingError(
@@ -57,7 +57,7 @@ export const walkRouting = ({
           ),
         );
         onEndpoint(endpoint, path, method);
-      });
+      }
       if (hasCors && element.firstEndpoint) {
         onEndpoint(
           element.firstEndpoint,

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -12,6 +12,7 @@ export interface RoutingWalkerParams {
     endpoint: AbstractEndpoint,
     path: string,
     method: Method | AuxMethod,
+    siblingMethods?: Method[],
   ) => void;
   onStatic?: (path: string, handler: StaticHandler) => void;
   parentPath?: string;
@@ -57,13 +58,10 @@ export const walkRouting = ({
         );
         onEndpoint(endpoint, path, method as Method);
       });
-      if (hasCors && Object.keys(element.endpoints).length > 0) {
-        const [firstMethod, ...siblingMethods] = Object.keys(
-          element.endpoints,
-        ) as Method[];
-        const firstEndpoint = element.endpoints[firstMethod]!;
-        firstEndpoint._setSiblingMethods(siblingMethods);
-        onEndpoint(firstEndpoint, path, "options");
+      if (hasCors && Object.keys(element.endpoints).length) {
+        const [firstMethod, ...siblingMethods] = Object.keys(element.endpoints);
+        const firstEndpoint = element.endpoints[firstMethod as Method]!;
+        onEndpoint(firstEndpoint, path, "options", siblingMethods as Method[]);
       }
     } else {
       walkRouting({

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -49,19 +49,22 @@ export const walkRouting = ({
         element.apply(path, onStatic);
       }
     } else if (element instanceof DependsOnMethod) {
-      Object.entries(element.endpoints).forEach(([method, endpoint]) => {
+      element.pairs.forEach(([method, endpoint]) => {
         assert(
-          endpoint.getMethods().includes(method as Method),
+          endpoint.getMethods().includes(method),
           new RoutingError(
             `Endpoint assigned to ${method} method of ${path} must support ${method} method.`,
           ),
         );
-        onEndpoint(endpoint, path, method as Method);
+        onEndpoint(endpoint, path, method);
       });
-      if (hasCors && Object.keys(element.endpoints).length) {
-        const [firstMethod, ...siblingMethods] = Object.keys(element.endpoints);
-        const firstEndpoint = element.endpoints[firstMethod as Method]!;
-        onEndpoint(firstEndpoint, path, "options", siblingMethods as Method[]);
+      if (hasCors && element.firstEndpoint) {
+        onEndpoint(
+          element.firstEndpoint,
+          path,
+          "options",
+          element.siblingMethods,
+        );
       }
     } else {
       walkRouting({

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -29,13 +29,19 @@ export const initRouting = ({
   walkRouting({
     routing,
     hasCors: !!config.cors,
-    onEndpoint: (endpoint, path, method) => {
+    onEndpoint: (endpoint, path, method, siblingMethods) => {
       app[method](path, async (request, response) => {
         const logger = config.childLoggerProvider
           ? await config.childLoggerProvider({ request, parent: rootLogger })
           : rootLogger;
         logger.info(`${request.method}: ${path}`);
-        await endpoint.execute({ request, response, logger, config });
+        await endpoint.execute({
+          request,
+          response,
+          logger,
+          config,
+          siblingMethods,
+        });
       });
     },
     onStatic: (path, handler) => {

--- a/tests/unit/depends-on-method.spec.ts
+++ b/tests/unit/depends-on-method.spec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  AbstractEndpoint,
   DependsOnMethod,
   EndpointsFactory,
   defaultResultHandler,
@@ -11,6 +12,9 @@ describe("DependsOnMethod", () => {
     const instance = new DependsOnMethod({});
     expect(instance).toBeInstanceOf(DependsOnMethod);
     expect(instance.endpoints).toEqual({});
+    expect(instance.firstEndpoint).toBeUndefined();
+    expect(instance.siblingMethods).toEqual([]);
+    expect(instance.pairs).toEqual([]);
   });
 
   test("should accept an endpoint with a corresponding method", () => {
@@ -24,6 +28,9 @@ describe("DependsOnMethod", () => {
     });
     expect(instance).toBeInstanceOf(DependsOnMethod);
     expect(instance.endpoints).toHaveProperty("post");
+    expect(instance.firstEndpoint).toBeInstanceOf(AbstractEndpoint);
+    expect(instance.siblingMethods).toEqual([]);
+    expect(instance.pairs).toHaveLength(1);
   });
 
   test("should accept an endpoint with additional methods", () => {
@@ -40,5 +47,18 @@ describe("DependsOnMethod", () => {
     expect(instance).toBeInstanceOf(DependsOnMethod);
     expect(instance.endpoints).toHaveProperty("get");
     expect(instance.endpoints).toHaveProperty("post");
+    expect(instance.firstEndpoint).toBe(endpoint);
+    expect(instance.siblingMethods).toEqual(["post"]);
+    expect(instance.pairs).toHaveLength(2);
+  });
+
+  test("should reject empty assignments", () => {
+    const instance = new DependsOnMethod({
+      get: undefined,
+      post: undefined,
+    });
+    expect(instance.pairs).toEqual([]);
+    expect(instance.firstEndpoint).toBeUndefined();
+    expect(instance.siblingMethods).toEqual([]);
   });
 });

--- a/tests/unit/depends-on-method.spec.ts
+++ b/tests/unit/depends-on-method.spec.ts
@@ -11,7 +11,6 @@ describe("DependsOnMethod", () => {
   test("should accept empty object", () => {
     const instance = new DependsOnMethod({});
     expect(instance).toBeInstanceOf(DependsOnMethod);
-    expect(instance.endpoints).toEqual({});
     expect(instance.firstEndpoint).toBeUndefined();
     expect(instance.siblingMethods).toEqual([]);
     expect(instance.pairs).toEqual([]);
@@ -27,7 +26,6 @@ describe("DependsOnMethod", () => {
       }),
     });
     expect(instance).toBeInstanceOf(DependsOnMethod);
-    expect(instance.endpoints).toHaveProperty("post");
     expect(instance.firstEndpoint).toBeInstanceOf(AbstractEndpoint);
     expect(instance.siblingMethods).toEqual([]);
     expect(instance.pairs).toHaveLength(1);
@@ -45,8 +43,6 @@ describe("DependsOnMethod", () => {
       post: endpoint,
     });
     expect(instance).toBeInstanceOf(DependsOnMethod);
-    expect(instance.endpoints).toHaveProperty("get");
-    expect(instance.endpoints).toHaveProperty("post");
     expect(instance.firstEndpoint).toBe(endpoint);
     expect(instance.siblingMethods).toEqual(["post"]);
     expect(instance.pairs).toHaveLength(2);


### PR DESCRIPTION
Getting rid of some ugliness. 