### PR TITLE
Ref: Avoiding `forEach`

### DIFF
--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -41,9 +41,9 @@ export const walkRouting = ({
       if (hasCors) {
         methods.push("options");
       }
-      methods.forEach((method) => {
+      for (const method of methods) {
         onEndpoint(element, path, method);
-      });
+      }
     } else if (element instanceof ServeStatic) {
       if (onStatic) {
         element.apply(path, onStatic);

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -26,8 +26,9 @@ export const walkRouting = ({
   parentPath,
   hasCors,
 }: RoutingWalkerParams) => {
-  Object.entries(routing).forEach(([segment, element]) => {
-    segment = segment.trim();
+  for (const [segment, element] of Object.entries(routing).map(
+    ([key, value]) => [key.trim(), value] as const,
+  )) {
     assert.doesNotMatch(
       segment,
       /\//,
@@ -75,5 +76,5 @@ export const walkRouting = ({
         parentPath: path,
       });
     }
-  });
+  }
 };

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -26,9 +26,10 @@ export const walkRouting = ({
   parentPath,
   hasCors,
 }: RoutingWalkerParams) => {
-  for (const [segment, element] of Object.entries(routing).map(
+  const pairs = Object.entries(routing).map(
     ([key, value]) => [key.trim(), value] as const,
-  )) {
+  );
+  for (const [segment, element] of pairs) {
     assert.doesNotMatch(
       segment,
       /\//,


### PR DESCRIPTION
`for..of` is faster because it does not create a new function for each entry.