### PR TITLE
Shortening the `ensureShortDescription()`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -1052,9 +1052,7 @@ export const depictTags = <TAG extends string>(
     return result;
   });
 
-export const ensureShortDescription = (description: string) => {
-  if (description.length <= shortDescriptionLimit) {
-    return description;
-  }
-  return description.slice(0, shortDescriptionLimit - 1) + "…";
-};
+export const ensureShortDescription = (description: string) =>
+  description.length <= shortDescriptionLimit
+    ? description
+    : description.slice(0, shortDescriptionLimit - 1) + "…";


### PR DESCRIPTION
```
 ✓ tests/bench/experiment.bench.ts (2) 10805ms
   ✓ Experiment (2) 10803ms
     name                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · original  8,494,663.88  0.0001  0.9349  0.0001  0.0001  0.0002  0.0002  0.0003  ±0.31%  8494664
   · featured  9,627,306.83  0.0001  0.3401  0.0001  0.0001  0.0001  0.0001  0.0003  ±0.21%  9627307   fastest
```