### PR TITLE
Ref: shortening `getRoutePathParams()`

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -119,13 +119,8 @@ const samples = {
 /** @see https://expressjs.com/en/guide/routing.html */
 const routePathParamsRegex = /:([A-Za-z0-9_]+)/g;
 
-export const getRoutePathParams = (path: string): string[] => {
-  const match = path.match(routePathParamsRegex);
-  if (!match) {
-    return [];
-  }
-  return match.map((param) => param.slice(1));
-};
+export const getRoutePathParams = (path: string): string[] =>
+  path.match(routePathParamsRegex)?.map((param) => param.slice(1)) || [];
 
 export const reformatParamsInPath = (path: string) =>
   path.replace(routePathParamsRegex, (param) => `{${param.slice(1)}}`);


### PR DESCRIPTION
```
 ✓ tests/bench/experiment.bench.ts (2) 11867ms
   ✓ Experiment (2) 11865ms
     name                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · original  3,587,176.25  0.0002  1.6251  0.0003  0.0003  0.0004  0.0005  0.0015  ±0.39%  7174353
   · featured  3,685,180.91  0.0002  0.4668  0.0003  0.0003  0.0003  0.0004  0.0008  ±0.32%  7370362   fastest


 BENCH  Summary

  featured - tests/bench/experiment.bench.ts > Experiment
    1.03x faster than original
```