### PR TITLE
Fix logging arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Version 16
 
+### v16.7.1
+
+- Fixed logging arrays by the default `winston` logger.
+
+```typescript
+// before: Items { '0': 123 }
+// after:  Items [ 123 ]
+logger.debug("Items", [123]);
+```
+
 ### v16.7.0
 
 - Introducing the `beforeRouting` feature for the `ServerConfig`:

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import type { Format, TransformableInfo } from "logform";
+import type { Format } from "logform";
 import type Winston from "winston";
 import type Transport from "winston-transport";
 import { isObject } from "./common-helpers";
@@ -48,15 +48,8 @@ export const createLogger = ({
 }: SimplifiedWinstonConfig & {
   winston: typeof Winston;
 }): Winston.Logger => {
-  const prettyPrint = (meta: Omit<TransformableInfo, "level" | "message">) => {
-    const {
-      [Symbol.for("level")]: noLevel,
-      [Symbol.for("message")]: noMessage,
-      [Symbol.for("splat")]: noSplat,
-      ...rest
-    } = meta;
-    return inspect(rest, false, 1, config.color);
-  };
+  const prettyPrint = (value: unknown) =>
+    inspect(value, false, 1, config.color);
 
   const getOutputFormat = (isPretty?: boolean) =>
     printf(({ timestamp, message, level, durationMs, ...meta }) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -61,14 +61,10 @@ export const createLogger = ({
       if (durationMs) {
         details.push("duration:", `${durationMs}ms`);
       }
-      const objectHandler = isPretty ? prettyPrint : JSON.stringify;
+      const serializer = isPretty ? prettyPrint : JSON.stringify;
       const splat = meta?.[Symbol.for("splat")];
       if (Array.isArray(splat)) {
-        details.push(
-          ...splat.map((entry) =>
-            typeof entry === "object" ? objectHandler(entry) : entry,
-          ),
-        );
+        details.push(...splat.map((entry) => serializer(entry)));
       }
       return [timestamp, `${level}:`, message, ...details].join(" ");
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -61,26 +61,21 @@ export const createLogger = ({
   const getOutputFormat = (isPretty?: boolean) =>
     printf(({ timestamp, message, level, durationMs, ...meta }) => {
       if (typeof message === "object") {
-        meta = { ...meta, ...(message as object) };
+        meta[Symbol.for("splat")] = [message];
         message = "[No message]";
       }
-      const hasMetaProps = Object.keys(meta).length > 0;
       const details = [];
       if (durationMs) {
         details.push("duration:", `${durationMs}ms`);
       }
       const objectHandler = isPretty ? prettyPrint : JSON.stringify;
-      if (hasMetaProps) {
-        details.push(objectHandler(meta));
-      } else {
-        const splat = meta?.[Symbol.for("splat")];
-        if (Array.isArray(splat)) {
-          details.push(
-            ...splat.map((entry) =>
-              typeof entry === "object" ? objectHandler(entry) : entry,
-            ),
-          );
-        }
+      const splat = meta?.[Symbol.for("splat")];
+      if (Array.isArray(splat)) {
+        details.push(
+          ...splat.map((entry) =>
+            typeof entry === "object" ? objectHandler(entry) : entry,
+          ),
+        );
       }
       return [timestamp, `${level}:`, message, ...details].join(" ");
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,9 +52,9 @@ export const createLogger = ({
     inspect(value, false, 1, config.color);
 
   const getOutputFormat = (isPretty?: boolean) =>
-    printf(({ timestamp, message, level, durationMs, ...meta }) => {
+    printf(({ timestamp, message, level, durationMs, ...rest }) => {
       if (typeof message === "object") {
-        meta[Symbol.for("splat")] = [message];
+        rest[Symbol.for("splat")] = [message];
         message = "[No message]";
       }
       const details = [];
@@ -62,7 +62,7 @@ export const createLogger = ({
         details.push("duration:", `${durationMs}ms`);
       }
       const serializer = isPretty ? prettyPrint : JSON.stringify;
-      const splat = meta?.[Symbol.for("splat")];
+      const splat = rest?.[Symbol.for("splat")];
       if (Array.isArray(splat)) {
         details.push(...splat.map((entry) => serializer(entry)));
       }

--- a/tests/cjs/quick-start.spec.ts
+++ b/tests/cjs/quick-start.spec.ts
@@ -13,7 +13,7 @@ describe("CJS Test", async () => {
   quickStart.stdout.on("data", listener);
   quickStart.stderr.on("data", listener);
   const port = givePort("example");
-  await waitFor(() => out.indexOf(`Listening ${port}`) > -1);
+  await waitFor(() => out.indexOf(`Listening`) > -1);
 
   afterAll(async () => {
     quickStart.stdout.removeListener("data", listener);

--- a/tests/esm/quick-start.spec.ts
+++ b/tests/esm/quick-start.spec.ts
@@ -11,7 +11,7 @@ describe("ESM Test", async () => {
   quickStart.stdout.on("data", listener);
   quickStart.stderr.on("data", listener);
   const port = givePort("example");
-  await waitFor(() => out.indexOf(`Listening ${port}`) > -1);
+  await waitFor(() => out.indexOf(`Listening`) > -1);
 
   afterAll(async () => {
     quickStart.stdout.removeListener("data", listener);

--- a/tests/system/example.spec.ts
+++ b/tests/system/example.spec.ts
@@ -21,7 +21,7 @@ describe("Example", async () => {
   const example = spawn("tsx", ["example/index.ts"]);
   example.stdout.on("data", listener);
   const port = givePort("example");
-  await waitFor(() => out.indexOf(`Listening ${port}`) > -1);
+  await waitFor(() => out.indexOf(`Listening`) > -1);
 
   afterAll(async () => {
     example.stdout.removeListener("data", listener);

--- a/tests/unit/__snapshots__/logger.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger.spec.ts.snap
@@ -42,6 +42,48 @@ exports[`Logger > createWinstonLogger() > Should create warn logger 1`] = `
 ]
 `;
 
+exports[`Logger > createWinstonLogger() > Should handle array 0 1`] = `
+[
+  [
+    {
+      "0": "test",
+      "level": "[31merror[39m",
+      "message": "Array",
+      "timestamp": "2022-01-01T00:00:00.000Z",
+      Symbol(level): "error",
+      Symbol(splat): [
+        [
+          "test",
+        ],
+      ],
+      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array { [32m'0'[39m: [32m'test'[39m }",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`Logger > createWinstonLogger() > Should handle array 1 1`] = `
+[
+  [
+    {
+      "0": "test",
+      "level": "[31merror[39m",
+      "message": "Array",
+      "timestamp": "2022-01-01T00:00:00.000Z",
+      Symbol(level): "error",
+      Symbol(splat): [
+        [
+          "test",
+        ],
+      ],
+      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array ["test"]",
+    },
+    [Function],
+  ],
+]
+`;
+
 exports[`Logger > createWinstonLogger() > Should handle empty message 1`] = `
 [
   [

--- a/tests/unit/__snapshots__/logger.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger.spec.ts.snap
@@ -56,7 +56,7 @@ exports[`Logger > createWinstonLogger() > Should handle array 0 1`] = `
           "test",
         ],
       ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array { [32m'0'[39m: [32m'test'[39m }",
+      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array [ [32m'test'[39m ]",
     },
     [Function],
   ],

--- a/tests/unit/__snapshots__/logger.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger.spec.ts.snap
@@ -137,6 +137,31 @@ exports[`Logger > createWinstonLogger() > Should handle empty object meta 1 1`] 
 ]
 `;
 
+exports[`Logger > createWinstonLogger() > Should handle excessive arguments 1`] = `
+[
+  [
+    {
+      "level": "debug",
+      "message": "Test",
+      "some": "value",
+      "timestamp": "2022-01-01T00:00:00.000Z",
+      Symbol(level): "debug",
+      Symbol(splat): [
+        {
+          "some": "value",
+        },
+        [
+          123,
+        ],
+        456,
+      ],
+      Symbol(message): "2022-01-01T00:00:00.000Z debug: Test { some: 'value' } [ 123 ] 456",
+    },
+    [Function],
+  ],
+]
+`;
+
 exports[`Logger > createWinstonLogger() > Should handle non-object meta 0 1`] = `
 [
   [

--- a/tests/unit/__snapshots__/logger.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger.spec.ts.snap
@@ -148,7 +148,7 @@ exports[`Logger > createWinstonLogger() > Should handle non-object meta 0 1`] = 
       Symbol(splat): [
         8090,
       ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Code 8090",
+      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
     },
     [Function],
   ],

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -99,6 +99,12 @@ describe("Logger", () => {
         expect(logSpy.mock.calls).toMatchSnapshot();
       },
     );
+
+    test.each(["debug", "warn"] as const)("Should handle array %#", (level) => {
+      const { logger, logSpy } = makeLogger({ level, color: true });
+      logger.error("Array", ["test"]);
+      expect(logSpy.mock.calls).toMatchSnapshot();
+    });
   });
 
   describe("isSimplifiedLoggerConfig()", () => {

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -105,6 +105,12 @@ describe("Logger", () => {
       logger.error("Array", ["test"]);
       expect(logSpy.mock.calls).toMatchSnapshot();
     });
+
+    test("Should handle excessive arguments", () => {
+      const { logger, logSpy } = makeLogger({ level: "debug", color: false });
+      logger.debug("Test", { some: "value" }, [123], 456);
+      expect(logSpy.mock.calls).toMatchSnapshot();
+    });
   });
 
   describe("isSimplifiedLoggerConfig()", () => {


### PR DESCRIPTION
Arrays are logged as objects with numeric keys now by the default `winston` logger.
Time to fix it.