### PR TITLE
Clarification on ResultHandler used for upload failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Enabled `limits` option for `upload` feature in config;
   - See the [Busboy documentation](https://www.npmjs.com/package/busboy#exports) for details on `limits`;
   - Added `limitError` option to `upload` feature in config (optional);
-  - The error assigned to `limitError` is handled by ResultHandler (the negative response case);
+  - The error assigned to `limitError` is handled by `errorHandler` in config (the negative response case);
   - When the `limitError` is not set, the `truncated` property of the uploaded file reflects the issue;
   - Thanks to [@rottmann](https://github.com/rottmann) for his contribution.
 

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ const config = createConfig({
   server: {
     upload: {
       limits: { fileSize: 51200 }, // 50 KB
-      limitError: createHttpError(413, "The file is too large"), // handled by ResultHandler
+      limitError: createHttpError(413, "The file is too large"), // handled by errorHandler in config
     },
   },
 });

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -88,7 +88,7 @@ type UploadOptions = Pick<
   | "limits"
 > & {
   /**
-   * @desc The error to throw when file exceeds the configured limits (handled by ResultHandler).
+   * @desc The error to throw when the file exceeds the configured limits (handled by errorHandler).
    * @see limits
    * @override limitHandler
    * @example createHttpError(413, "The file is too large")


### PR DESCRIPTION
Clarifying that the ResultHandler is taken from errorHandler in config.