### PR TITLE
Ensure using the dedicated `next()` for `limitHandler`

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
         ...derivedConfig,
         abortOnLimit: false,
         parseNested: true,
-        limitHandler: limitError && (({ next }) => next && next(limitError)),
+        limitHandler: limitError && (({}, {}, next) => next(limitError)),
       }),
     );
   }

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -232,7 +232,7 @@ describe("Server", () => {
       });
       // limitHandler and limitError test
       const nextMock = vi.fn();
-      fileUploadMock.mock.calls[0][0].limitHandler({ next: nextMock });
+      fileUploadMock.mock.calls[0][0].limitHandler({}, {}, nextMock);
       expect(nextMock).toHaveBeenCalledWith(new Error("Too heavy"));
     });
 


### PR DESCRIPTION
I found out that in some cases `req.next` may not be set and that may lead to issues.