### PR TITLE
Regular handling for `writableEnded` prop

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -264,7 +264,7 @@ export class Endpoint<
           logger,
         }),
       );
-      isStreamClosed = "writableEnded" in response && response.writableEnded;
+      isStreamClosed = response.writableEnded;
       if (isStreamClosed) {
         logger.warn(
           `The middleware ${def.middleware.name} has closed the stream. Accumulated options:`,

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -240,7 +240,6 @@ export class Endpoint<
     logger: AbstractLogger;
   }) {
     const options = {} as OPT;
-    let isStreamClosed = false;
     for (const def of this.#middlewares) {
       if (method === "options" && def.type === "proprietary") {
         continue;
@@ -264,8 +263,7 @@ export class Endpoint<
           logger,
         }),
       );
-      isStreamClosed = response.writableEnded;
-      if (isStreamClosed) {
+      if (response.writableEnded) {
         logger.warn(
           `The middleware ${def.middleware.name} has closed the stream. Accumulated options:`,
           options,
@@ -273,7 +271,7 @@ export class Endpoint<
         break;
       }
     }
-    return { options, isStreamClosed };
+    return { options, isStreamClosed: response.writableEnded };
   }
 
   async #parseAndRunHandler({

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -271,7 +271,7 @@ export class Endpoint<
         break;
       }
     }
-    return { options, isStreamClosed: response.writableEnded };
+    return { options };
   }
 
   async #parseAndRunHandler({
@@ -366,14 +366,14 @@ export class Endpoint<
     }
     const input = getInput(request, config.inputSources);
     try {
-      const { options, isStreamClosed } = await this.#runMiddlewares({
+      const { options } = await this.#runMiddlewares({
         method,
         input,
         request,
         response,
         logger,
       });
-      if (isStreamClosed) {
+      if (response.writableEnded) {
         return;
       }
       if (method === "options") {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -271,7 +271,7 @@ export class Endpoint<
         break;
       }
     }
-    return { options };
+    return options;
   }
 
   async #parseAndRunHandler({
@@ -366,7 +366,7 @@ export class Endpoint<
     }
     const input = getInput(request, config.inputSources);
     try {
-      const { options } = await this.#runMiddlewares({
+      const options = await this.#runMiddlewares({
         method,
         input,
         request,


### PR DESCRIPTION
It's stable since Node 12.9, no need for a special handling.