### PR TITLE
Fixing the status code for upload failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 17
 
+### v17.1.1
+
+- Fixed wrong status code sending in case of upload failures when `limitError` is `HttpError`.
+  - The feature introduced in v17.1.0.
+  - The status code used to be always `400`.
+
 ### v17.1.0
 
 - Ability to configure upload limits and an error in case the uploaded file exceeds them:

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -2,7 +2,7 @@ import { AnyResultHandlerDefinition } from "./result-handler";
 import { AbstractLogger } from "./logger";
 import { CommonConfig } from "./config-type";
 import { ErrorRequestHandler, RequestHandler } from "express";
-import createHttpError from "http-errors";
+import createHttpError, { isHttpError } from "http-errors";
 import { lastResortHandler } from "./last-resort";
 import { ResultHandlerError } from "./errors";
 import { makeErrorFromAnything } from "./common-helpers";
@@ -24,7 +24,9 @@ export const createParserFailureHandler =
       return next();
     }
     errorHandler.handler({
-      error: createHttpError(400, makeErrorFromAnything(error).message),
+      error: isHttpError(error)
+        ? error
+        : createHttpError(400, makeErrorFromAnything(error).message),
       request,
       response,
       input: null,

--- a/tests/system/__snapshots__/example.spec.ts.snap
+++ b/tests/system/__snapshots__/example.spec.ts.snap
@@ -57,6 +57,15 @@ exports[`Example > Negative > PATCH request should fail on schema validation 1`]
 }
 `;
 
+exports[`Example > Negative > Should fail to upload if the file is too large 1`] = `
+{
+  "error": {
+    "message": "The file is too large",
+  },
+  "status": "error",
+}
+`;
+
 exports[`Example > Negative > Should respond with error to the missing static file request 1`] = `
 {
   "error": {

--- a/tests/system/example.spec.ts
+++ b/tests/system/example.spec.ts
@@ -376,6 +376,26 @@ describe("Example", async () => {
       );
       expect(await response.json()).toMatchSnapshot();
     });
+
+    test("Should fail to upload if the file is too large", async () => {
+      const filename = "dataflow.svg";
+      const logo = await readFile(filename, "utf-8");
+      const data = new FormData();
+      data.append("avatar", logo, { filename });
+      const response = await fetch(
+        `http://localhost:${port}/v1/avatar/upload`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": `${mimeMultipart}; boundary=${data.getBoundary()}`,
+          },
+          body: data.getBuffer().toString("utf8"),
+        },
+      );
+      expect(response.status).toBe(413);
+      const json = await response.json();
+      expect(json).toMatchSnapshot();
+    });
   });
 
   describe("Client", () => {


### PR DESCRIPTION
`createParserFailureHandler()` must just proxy the error in case it's HTTP Error