### PR TITLE
Feat: Using the configured logger for debugging uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,21 @@ declare module "express-zod-api" {
 
 export const config = createConfig({
   server: {
+    listen: 8090,
     logger: { level: "debug" }, // simplified Winston config enabling debug level
     upload: { debug: true }, // writes messages using Winston::debug()
   },
 });
+```
+
+```text
+info: Listening 8090
+debug: Express-file-upload: New upload started avatar->file.svg, bytes:0
+debug: Express-file-upload: Uploading avatar->file.svg, bytes:1138...
+debug: Express-file-upload: Upload finished avatar->file.svg, bytes:1138
+debug: Express-file-upload: Upload avatar->file.svg completed, bytes:1138.
+debug: Express-file-upload: Busboy finished parsing request.
+info: POST: /v1/avatar/upload
 ```
 
 ### v17.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ declare module "express-zod-api" {
   interface LoggerOverrides extends Logger {}
 }
 
-export const config = createConfig({
+const config = createConfig({
   server: {
     listen: 8090,
     logger: { level: "debug" }, // simplified Winston config enabling debug level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Version 17
 
+### v17.3.0
+
+- Ability to use the configured logger for debugging uploads.
+  - In the `express-fileupload` package starting from version 1.5.0
+    [I made the logger customizable](https://github.com/richardgirges/express-fileupload/pull/371).
+  - Using at least the specified version of `express-fileupload` and having its `debug` option enabled, the upload
+    related logs are processed using the logger from the `express-zod-api` configuration.
+  - Please note: the `.debug()` method of the configured logger is used for upload related logging, therefore the
+    severity `level` of that logger must be configured accordingly in order to see those messages.
+
+```typescript
+import { createConfig } from "express-zod-api";
+import { Logger } from "winston";
+
+// using Winston logger
+declare module "express-zod-api" {
+  interface LoggerOverrides extends Logger {}
+}
+
+export const config = createConfig({
+  server: {
+    logger: { level: "debug" }, // simplified Winston config enabling debug level
+    upload: { debug: true }, // writes messages using Winston::debug()
+  },
+});
+```
+
 ### v17.2.1
 
 - Fixed a bug due to which a custom logger instance could be perceived as a simplified `winston` logger config.

--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ import createHttpError from "http-errors";
 const config = createConfig({
   server: {
     upload: {
+      debug: true, // uses the debug() method of the configured logger
       limits: { fileSize: 51200 }, // 50 KB
       limitError: createHttpError(413, "The file is too large"), // handled by errorHandler in config
       beforeUpload: ({ app, logger }) => {

--- a/example/config.ts
+++ b/example/config.ts
@@ -13,6 +13,7 @@ export const config = createConfig({
   server: {
     listen: 8090,
     upload: {
+      debug: true,
       limits: { fileSize: 51200 },
       limitError: createHttpError(413, "The file is too large"), // affects uploadAvatarEndpoint
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,10 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
         ...derivedConfig,
         abortOnLimit: false,
         parseNested: true,
+        // @todo remove ignore when the types updated:
+        // @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69016
+        // @ts-ignore
+        logger: { log: rootLogger.debug.bind(rootLogger) },
       }),
     );
     if (limitError) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,9 +66,6 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
         ...derivedConfig,
         abortOnLimit: false,
         parseNested: true,
-        // @todo remove ignore when the types updated:
-        // @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69016
-        // @ts-ignore
         logger: { log: rootLogger.debug.bind(rootLogger) },
       }),
     );

--- a/src/uploads-fix.d.ts
+++ b/src/uploads-fix.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @todo remove when the types updated:
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69016
+ */
+export module "express-fileupload" {
+  export interface Options {
+    /**
+     * Customizable logger to write debug messages to.
+     * @default console
+     */
+    logger?: { log: (msg: string) => void } | undefined;
+  }
+}

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -233,6 +233,7 @@ describe("Server", () => {
         abortOnLimit: false,
         parseNested: true,
         limits: { fileSize: 1024 },
+        logger: { log: expect.any(Function) },
       });
     });
 


### PR DESCRIPTION
I made the logger in `express-fileupload` configurable:
https://github.com/richardgirges/express-fileupload/pull/371

So now the configured logger can be used for debugging the upload instead of console.
That, however, also requires the types updated in a separate repo (waiting for that):
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69016
