### PR TITLE
Experimental: Detaching from Winston for even faster Quick Start

### DIFF
--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -3,7 +3,7 @@ import { IRouter, Request, RequestHandler } from "express";
 import type fileUpload from "express-fileupload";
 import { ServerOptions } from "node:https";
 import { AbstractEndpoint } from "./endpoint";
-import { AbstractLogger, SimplifiedWinstonConfig } from "./logger";
+import { AbstractLogger, LoggerConfig } from "./logger";
 import { Method } from "./method";
 import { AnyResultHandlerDefinition } from "./result-handler";
 import { ListenOptions } from "node:net";
@@ -50,7 +50,7 @@ export interface CommonConfig<TAG extends string = string> {
    * @desc Logger configuration (winston) or instance of any other logger.
    * @example { level: "debug", color: true }
    * */
-  logger: SimplifiedWinstonConfig | AbstractLogger;
+  logger: LoggerConfig | AbstractLogger;
   /**
    * @desc A child logger returned by this function can override the logger in all handlers for each request
    * @example ({ parent }) => parent.child({ requestId: uuid() })

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
+import chalk, { ChalkInstance } from "chalk";
 import { inspect } from "node:util";
-import type Winston from "winston";
 import { isObject } from "./common-helpers";
 
 /**
@@ -16,7 +16,7 @@ export type AbstractLogger = Record<
 > &
   LoggerOverrides;
 
-export interface SimplifiedWinstonConfig {
+export interface LoggerConfig {
   /**
    * @desc The minimal severity to log or "silent" to disable logging
    * @example "debug" also enables pretty output for inspected entities
@@ -36,9 +36,21 @@ export interface SimplifiedWinstonConfig {
   depth?: number | null;
 }
 
-export const isSimplifiedWinstonConfig = (
-  subject: unknown,
-): subject is SimplifiedWinstonConfig =>
+const severity: Record<keyof AbstractLogger, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const colors: Record<keyof AbstractLogger, ChalkInstance> = {
+  debug: chalk.blue,
+  info: chalk.green,
+  warn: chalk.yellow,
+  error: chalk.red,
+};
+
+export const isLoggerConfig = (subject: unknown): subject is LoggerConfig =>
   isObject(subject) &&
   "level" in subject &&
   ("color" in subject ? typeof subject.color === "boolean" : true) &&
@@ -51,64 +63,45 @@ export const isSimplifiedWinstonConfig = (
     undefined;
 
 /**
- * @desc a helper for creating a winston logger easier
- * @requires winston
- * @example createLogger({ winston, level: "debug", color: true, depth: 4 })
+ * @desc Creates a basic console logger with optional colorful inspections
+ * @example createLogger({ level: "debug", color: true, depth: 4 })
  * */
 export const createLogger = ({
-  winston: {
-    createLogger: create,
-    transports,
-    format: { printf, timestamp: useTimestamp, colorize, combine },
-    config: { npm },
-  },
-  ...config
-}: SimplifiedWinstonConfig & {
-  winston: typeof Winston;
-}): Winston.Logger => {
-  const isSilent = config.level === "silent";
-  const isDebug = config.level === "debug";
+  level,
+  color = false,
+  depth = 2,
+}: LoggerConfig): AbstractLogger => {
+  const isDebug = level === "debug";
+  const minSeverity = level === "silent" ? 100 : severity[level];
 
-  const prettyPrint = (value: unknown) =>
-    inspect(value, {
-      colors: config.color,
-      depth: config.depth,
-      breakLength: isDebug ? 80 : Infinity,
-      compact: isDebug ? 3 : true,
-    });
+  const print = (method: keyof AbstractLogger, message: string, meta?: any) => {
+    if (severity[method] < minSeverity) {
+      return;
+    }
+    console.log(
+      [
+        new Date().toISOString(),
+        `${color ? colors[method](method) : method}:`,
+        message,
+      ]
+        .concat(
+          meta === undefined
+            ? []
+            : inspect(meta, {
+                colors: color,
+                depth,
+                breakLength: isDebug ? 80 : Infinity,
+                compact: isDebug ? 3 : true,
+              }),
+        )
+        .join(" "),
+    );
+  };
 
-  const customFormat = printf(
-    ({ timestamp, message, level, durationMs, ...rest }) => {
-      if (typeof message === "object") {
-        rest[Symbol.for("splat")] = [message];
-        message = "[No message]";
-      }
-      const details = [];
-      if (durationMs) {
-        details.push("duration:", `${durationMs}ms`);
-      }
-      const splat = rest?.[Symbol.for("splat")];
-      if (Array.isArray(splat)) {
-        details.push(...splat.map(prettyPrint));
-      }
-      return [timestamp, `${level}:`, message, ...details].join(" ");
-    },
-  );
-
-  return create({
-    silent: isSilent,
-    levels: npm.levels,
-    exitOnError: false,
-    transports: [
-      new transports.Console({
-        level: isSilent ? "warn" : config.level,
-        handleExceptions: true,
-        format: combine(
-          useTimestamp(),
-          ...(config.color ? [colorize()] : []),
-          customFormat,
-        ),
-      }),
-    ],
-  });
+  return {
+    info: (message: string, meta?: any) => print("info", message, meta),
+    debug: (message: string, meta?: any) => print("debug", message, meta),
+    warn: (message: string, meta?: any) => print("warn", message, meta),
+    error: (message: string, meta?: any) => print("error", message, meta),
+  };
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,11 +4,7 @@ import type fileUpload from "express-fileupload";
 import http from "node:http";
 import https from "node:https";
 import { AppConfig, CommonConfig, ServerConfig } from "./config-type";
-import {
-  AbstractLogger,
-  createLogger,
-  isSimplifiedWinstonConfig,
-} from "./logger";
+import { AbstractLogger, createLogger, isLoggerConfig } from "./logger";
 import { loadPeer } from "./peer-helpers";
 import { defaultResultHandler } from "./result-handler";
 import { Routing, initRouting } from "./routing";
@@ -19,8 +15,8 @@ import {
 } from "./server-helpers";
 
 const makeCommonEntities = async (config: CommonConfig) => {
-  const rootLogger: AbstractLogger = isSimplifiedWinstonConfig(config.logger)
-    ? createLogger({ ...config.logger, winston: await loadPeer("winston") })
+  const rootLogger: AbstractLogger = isLoggerConfig(config.logger)
+    ? createLogger({ ...config.logger })
     : config.logger;
   const errorHandler = config.errorHandler || defaultResultHandler;
   const { childLoggerProvider: getChildLogger } = config;

--- a/tests/unit/__snapshots__/logger.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger.spec.ts.snap
@@ -3,20 +3,7 @@
 exports[`Logger > createWinstonLogger() > Should create debug logger 1`] = `
 [
   [
-    {
-      "level": "[34mdebug[39m",
-      "message": "testing debug message",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      "withColorful": "output",
-      Symbol(level): "debug",
-      Symbol(splat): [
-        {
-          "withColorful": "output",
-        },
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [34mdebug[39m: testing debug message { withColorful: [32m'output'[39m }",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [34mdebug[39m: testing debug message { withColorful: [32m'output'[39m }",
   ],
 ]
 `;
@@ -24,20 +11,7 @@ exports[`Logger > createWinstonLogger() > Should create debug logger 1`] = `
 exports[`Logger > createWinstonLogger() > Should create warn logger 1`] = `
 [
   [
-    {
-      "level": "warn",
-      "message": "testing warn message",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      "withMeta": true,
-      Symbol(level): "warn",
-      Symbol(splat): [
-        {
-          "withMeta": true,
-        },
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z warn: testing warn message { withMeta: true }",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z warn: testing warn message { withMeta: true }",
   ],
 ]
 `;
@@ -45,20 +19,7 @@ exports[`Logger > createWinstonLogger() > Should create warn logger 1`] = `
 exports[`Logger > createWinstonLogger() > Should handle array 0 1`] = `
 [
   [
-    {
-      "0": "test",
-      "level": "[31merror[39m",
-      "message": "Array",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        [
-          "test",
-        ],
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array [ [32m'test'[39m ]",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Array [ [32m'test'[39m ]",
   ],
 ]
 `;
@@ -66,20 +27,7 @@ exports[`Logger > createWinstonLogger() > Should handle array 0 1`] = `
 exports[`Logger > createWinstonLogger() > Should handle array 1 1`] = `
 [
   [
-    {
-      "0": "test",
-      "level": "[31merror[39m",
-      "message": "Array",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        [
-          "test",
-        ],
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Array [ [32m'test'[39m ]",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Array [ [32m'test'[39m ]",
   ],
 ]
 `;
@@ -87,46 +35,10 @@ exports[`Logger > createWinstonLogger() > Should handle array 1 1`] = `
 exports[`Logger > createWinstonLogger() > Should handle circular references within subject 0 1`] = `
 [
   [
-    {
-      "a": [
-        {
-          "a": [Circular],
-          "b": {
-            "inner": [Circular],
-            "obj": [Circular],
-          },
-        },
-      ],
-      "b": {
-        "inner": [Circular],
-        "obj": {
-          "a": [
-            [Circular],
-          ],
-          "b": [Circular],
-        },
-      },
-      "level": "error",
-      "message": "Recursive",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        {
-          "a": [
-            [Circular],
-          ],
-          "b": {
-            "inner": [Circular],
-            "obj": [Circular],
-          },
-        },
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z error: Recursive <ref *1> {
+    "2022-01-01T00:00:00.000Z error: Recursive <ref *1> {
   a: [ [Circular *1] ],
   b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }
 }",
-    },
-    [Function],
   ],
 ]
 `;
@@ -134,60 +46,7 @@ exports[`Logger > createWinstonLogger() > Should handle circular references with
 exports[`Logger > createWinstonLogger() > Should handle circular references within subject 1 1`] = `
 [
   [
-    {
-      "a": [
-        {
-          "a": [Circular],
-          "b": {
-            "inner": [Circular],
-            "obj": [Circular],
-          },
-        },
-      ],
-      "b": {
-        "inner": [Circular],
-        "obj": {
-          "a": [
-            [Circular],
-          ],
-          "b": [Circular],
-        },
-      },
-      "level": "error",
-      "message": "Recursive",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        {
-          "a": [
-            [Circular],
-          ],
-          "b": {
-            "inner": [Circular],
-            "obj": [Circular],
-          },
-        },
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z error: Recursive <ref *1> { a: [ [Circular *1] ], b: <ref *2> { inner: [Circular *2], obj: [Circular *1] } }",
-    },
-    [Function],
-  ],
-]
-`;
-
-exports[`Logger > createWinstonLogger() > Should handle empty message 1`] = `
-[
-  [
-    {
-      "level": "[31merror[39m",
-      "message": {
-        "someData": "test",
-      },
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: [No message] { someData: [32m'test'[39m }",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z error: Recursive <ref *1> { a: [ [Circular *1] ], b: <ref *2> { inner: [Circular *2], obj: [Circular *1] } }",
   ],
 ]
 `;
@@ -195,17 +54,7 @@ exports[`Logger > createWinstonLogger() > Should handle empty message 1`] = `
 exports[`Logger > createWinstonLogger() > Should handle empty object meta 0 1`] = `
 [
   [
-    {
-      "level": "[31merror[39m",
-      "message": "Payload",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        {},
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Payload {}",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Payload {}",
   ],
 ]
 `;
@@ -213,42 +62,7 @@ exports[`Logger > createWinstonLogger() > Should handle empty object meta 0 1`] 
 exports[`Logger > createWinstonLogger() > Should handle empty object meta 1 1`] = `
 [
   [
-    {
-      "level": "[31merror[39m",
-      "message": "Payload",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        {},
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Payload {}",
-    },
-    [Function],
-  ],
-]
-`;
-
-exports[`Logger > createWinstonLogger() > Should handle excessive arguments 1`] = `
-[
-  [
-    {
-      "level": "debug",
-      "message": "Test",
-      "some": "value",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "debug",
-      Symbol(splat): [
-        {
-          "some": "value",
-        },
-        [
-          123,
-        ],
-        456,
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z debug: Test { some: 'value' } [ 123 ] 456",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Payload {}",
   ],
 ]
 `;
@@ -256,17 +70,7 @@ exports[`Logger > createWinstonLogger() > Should handle excessive arguments 1`] 
 exports[`Logger > createWinstonLogger() > Should handle non-object meta 0 1`] = `
 [
   [
-    {
-      "level": "[31merror[39m",
-      "message": "Code",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        8090,
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
   ],
 ]
 `;
@@ -274,33 +78,7 @@ exports[`Logger > createWinstonLogger() > Should handle non-object meta 0 1`] = 
 exports[`Logger > createWinstonLogger() > Should handle non-object meta 1 1`] = `
 [
   [
-    {
-      "level": "[31merror[39m",
-      "message": "Code",
-      "timestamp": "2022-01-01T00:00:00.000Z",
-      Symbol(level): "error",
-      Symbol(splat): [
-        8090,
-      ],
-      Symbol(message): "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
-    },
-    [Function],
-  ],
-]
-`;
-
-exports[`Logger > createWinstonLogger() > Should manage profiling 1`] = `
-[
-  [
-    {
-      "durationMs": 554,
-      "level": "[32minfo[39m",
-      "message": "long-test",
-      "timestamp": "2022-01-01T00:00:00.554Z",
-      Symbol(level): "info",
-      Symbol(message): "2022-01-01T00:00:00.554Z [32minfo[39m: long-test duration: 554ms",
-    },
-    [Function],
+    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
   ],
 ]
 `;


### PR DESCRIPTION
The idea here is to make the Quick Start with Express Zod API even faster by making a basic console logger detached from Winston.

### Benefits

- Reducing required peer dependencies (easier installation command),
- No need for declaring `LoggerOverrides` in the Quick Start section (easier documentation for beginners),
- Simpler implementation.

### Caveats

- Breaking changes to the publicly exposed method `createLogger` (removing `winston` prop from its argument),
- No advanced features like child logger and profiling by default — that would require user to configure a custom logger.
- Need `chalk` as production dependency.