### PR TITLE
Replacing type intersection with `Extract<>` where narrowing is implied

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -437,11 +437,11 @@ export const depictString: Depicter<z.ZodString> = ({
   },
 }) => {
   const regexCheck = checks.find(
-    (check): check is z.ZodStringCheck & { kind: "regex" } =>
+    (check): check is Extract<z.ZodStringCheck, { kind: "regex" }> =>
       check.kind === "regex",
   );
   const datetimeCheck = checks.find(
-    (check): check is z.ZodStringCheck & { kind: "datetime" } =>
+    (check): check is Extract<z.ZodStringCheck, { kind: "datetime" }> =>
       check.kind === "datetime",
   );
   const regex = regexCheck
@@ -879,7 +879,7 @@ export const depictResponse = ({
 };
 
 type SecurityHelper<K extends Security["type"]> = (
-  security: Security & { type: K },
+  security: Extract<Security, { type: K }>,
   inputSources?: InputSource[],
 ) => SecuritySchemeObject;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,7 +29,9 @@ interface MiddlewareCreationProps<
   SCO extends string,
 > {
   input: IN;
-  security?: LogicalContainer<Security<keyof z.input<IN> & string, SCO>>;
+  security?: LogicalContainer<
+    Security<Extract<keyof z.input<IN>, string>, SCO>
+  >;
   middleware: Middleware<z.output<IN>, OPT, OUT>;
 }
 


### PR DESCRIPTION
Aiming to achieve better types and correctness.

Related article: https://stackoverflow.com/questions/71502114/is-there-a-difference-between-extract-and-the-intersection#:~:text=The%20intersection%20operator%20%26%20is%20used,that%20are%20assignable%20to%20Union%20.