### PR TITLE
Using `const` for literals in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 # z.literal("success")
 before:
   type: string
-  enum:
+  enum: # replaced
     - success
 after:
   type: string
@@ -21,7 +21,7 @@ after:
 ```yaml
 # z.literal(null)
 before:
-  type: object
+  type: object # fixed
   enum:
     - null
 after:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Version 17
 
+### v17.6.0
+
+- Using `const` property for depicting `z.literal()` in the generated documentation;
+- Fixed possibly invalid values of `type` property when depicting `z.literal()`, `z.enum()` and `z.nativeEnum()`.
+
+```yaml
+# z.literal("success")
+before:
+  type: string
+  enum:
+    - success
+after:
+  type: string
+  const: success
+```
+
+```yaml
+# z.literal(null)
+before:
+  type: object
+  enum:
+    - null
+after:
+  type: null
+  const: null
+```
+
 ### v17.5.0
 
 - Depicting the `.rest()` part of `z.tuple()` in the generated `Documentation`:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -29,8 +29,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -69,8 +68,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -147,8 +145,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -185,8 +182,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -230,8 +226,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - created
+                    const: created
                   data:
                     type: object
                     properties:
@@ -254,8 +249,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - created
+                    const: created
                   data:
                     type: object
                     properties:
@@ -278,8 +272,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   reason:
                     type: string
                 required:
@@ -294,8 +287,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - exists
+                    const: exists
                   id:
                     type: integer
                     format: int64
@@ -313,8 +305,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   reason:
                     type: string
                 required:
@@ -440,8 +431,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -478,8 +468,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -518,8 +507,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -542,8 +530,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -268,7 +268,7 @@ export const depictLiteral: Depicter<z.ZodLiteral<unknown>> = ({
   schema: { value },
 }) => ({
   type: typeof value as "string" | "number" | "boolean",
-  enum: [value],
+  const: value,
 });
 
 export const depictObject: Depicter<z.ZodObject<z.ZodRawShape>> = ({

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -259,6 +259,10 @@ export const depictNullable: Depicter<z.ZodNullable<z.ZodTypeAny>> = ({
   return nested;
 };
 
+/**
+ * @todo use similar bigint handling when the following fix released:
+ * @link https://github.com/ramda/types/pull/116/files
+ * */
 const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
   const detected = toLower(type(value)); // toLower is typed well unlike .toLowerCase()
   const isUnsupported =
@@ -269,7 +273,11 @@ const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
     detected === "regexp" ||
     detected === "asyncfunction" ||
     detected === "error";
-  return isUnsupported ? undefined : detected;
+  return typeof value === "bigint"
+    ? "integer"
+    : isUnsupported
+      ? undefined
+      : detected;
 };
 
 export const depictEnum: Depicter<

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -18,6 +18,7 @@ import {
   both,
   complement,
   concat,
+  type as detectType,
   filter,
   fromPairs,
   has,
@@ -33,7 +34,6 @@ import {
   range,
   reject,
   toLower,
-  type,
   union,
   when,
   xprod,
@@ -264,7 +264,7 @@ export const depictNullable: Depicter<z.ZodNullable<z.ZodTypeAny>> = ({
  * @link https://github.com/ramda/types/pull/116/files
  * */
 const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
-  const detected = toLower(type(value)); // toLower is typed well unlike .toLowerCase()
+  const detected = toLower(detectType(value)); // toLower is typed well unlike .toLowerCase()
   const isUnsupported =
     detected === "symbol" ||
     detected === "undefined" ||

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -259,25 +259,20 @@ export const depictNullable: Depicter<z.ZodNullable<z.ZodTypeAny>> = ({
   return nested;
 };
 
-/**
- * @todo use similar bigint handling when the following fix released:
- * @link https://github.com/ramda/types/pull/116/files
- * */
 const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
   const detected = toLower(detectType(value)); // toLower is typed well unlike .toLowerCase()
-  const isUnsupported =
-    detected === "symbol" ||
-    detected === "undefined" ||
-    detected === "function" ||
-    detected === "date" ||
-    detected === "regexp" ||
-    detected === "asyncfunction" ||
-    detected === "error";
+  const isSupported =
+    detected === "number" ||
+    detected === "string" ||
+    detected === "boolean" ||
+    detected === "object" ||
+    detected === "null" ||
+    detected === "array";
   return typeof value === "bigint"
     ? "integer"
-    : isUnsupported
-      ? undefined
-      : detected;
+    : isSupported
+      ? detected
+      : undefined;
 };
 
 export const depictEnum: Depicter<

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -290,7 +290,7 @@ export const depictEnum: Depicter<
 export const depictLiteral: Depicter<z.ZodLiteral<unknown>> = ({
   schema: { value },
 }) => ({
-  type: getSupportedType(value),
+  type: getSupportedType(value), // constructor allows z.Primitive only, but ZodLiteral does not have that constrant
   const: value,
 });
 

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -508,6 +508,13 @@ exports[`Documentation helpers > depictLiteral() > should set type and involve c
 }
 `;
 
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 3 1`] = `
+{
+  "const": Symbol(test),
+  "type": undefined,
+}
+`;
+
 exports[`Documentation helpers > depictNull() > should give type:null 1`] = `
 {
   "type": "null",

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -103,9 +103,7 @@ exports[`Documentation helpers > depictDiscriminatedUnion() > should wrap next d
           "format": "any",
         },
         "status": {
-          "enum": [
-            "success",
-          ],
+          "const": "success",
           "type": "string",
         },
       },
@@ -128,9 +126,7 @@ exports[`Documentation helpers > depictDiscriminatedUnion() > should wrap next d
           "type": "object",
         },
         "status": {
-          "enum": [
-            "error",
-          ],
+          "const": "error",
           "type": "string",
         },
       },
@@ -317,9 +313,7 @@ exports[`Documentation helpers > depictIntersection() > should fall back to allO
       "type": "number",
     },
     {
-      "enum": [
-        5,
-      ],
+      "const": 5,
       "type": "number",
     },
   ],
@@ -392,9 +386,7 @@ exports[`Documentation helpers > depictIntersection() > should maintain uniquene
 {
   "properties": {
     "test": {
-      "enum": [
-        5,
-      ],
+      "const": 5,
       "format": "double",
       "maximum": 1.7976931348623157e+308,
       "minimum": -1.7976931348623157e+308,
@@ -495,11 +487,9 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 }
 `;
 
-exports[`Documentation helpers > depictLiteral() > should set type and involve enum property 1`] = `
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 1`] = `
 {
-  "enum": [
-    "testing",
-  ],
+  "const": "testing",
   "type": "string",
 }
 `;
@@ -1221,9 +1211,7 @@ exports[`Documentation helpers > depictTuple() > should utilize prefixItems 1`] 
       "type": "string",
     },
     {
-      "enum": [
-        "test",
-      ],
+      "const": "test",
       "type": "string",
     },
   ],

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -487,10 +487,24 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 }
 `;
 
-exports[`Documentation helpers > depictLiteral() > should set type and involve const property 1`] = `
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 0 1`] = `
 {
-  "const": "testing",
+  "const": "testng",
   "type": "string",
+}
+`;
+
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 1 1`] = `
+{
+  "const": null,
+  "type": "null",
+}
+`;
+
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 2 1`] = `
+{
+  "const": 123n,
+  "type": "integer",
 }
 `;
 

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -21,8 +21,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -37,8 +36,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -92,8 +90,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -108,8 +105,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -146,8 +142,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -162,8 +157,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -217,8 +211,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -233,8 +226,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -266,8 +258,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -282,8 +273,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -351,8 +341,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -375,8 +364,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -416,8 +404,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -432,8 +419,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -471,8 +457,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -487,8 +472,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -559,8 +543,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -583,8 +566,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -664,15 +646,13 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
                       literal:
                         type: string
-                        enum:
-                          - something
+                        const: something
                       transformation:
                         type: number
                         format: double
@@ -693,8 +673,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -748,8 +727,7 @@ paths:
                   properties:
                     type:
                       type: string
-                      enum:
-                        - a
+                      const: a
                     a:
                       type: string
                   required:
@@ -759,8 +737,7 @@ paths:
                   properties:
                     type:
                       type: string
-                      enum:
-                        - b
+                      const: b
                     b:
                       type: string
                   required:
@@ -776,8 +753,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     discriminator:
                       propertyName: status
@@ -786,8 +762,7 @@ paths:
                         properties:
                           status:
                             type: string
-                            enum:
-                              - success
+                            const: success
                           data:
                             format: any
                         required:
@@ -796,8 +771,7 @@ paths:
                         properties:
                           status:
                             type: string
-                            enum:
-                              - error
+                            const: error
                           error:
                             type: object
                             properties:
@@ -820,8 +794,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -892,8 +865,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -924,8 +896,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1011,8 +982,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1034,8 +1004,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1122,8 +1091,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1148,8 +1116,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1214,8 +1181,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1254,8 +1220,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1332,8 +1297,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1370,8 +1334,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1415,8 +1378,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - created
+                    const: created
                   data:
                     type: object
                     properties:
@@ -1439,8 +1401,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - created
+                    const: created
                   data:
                     type: object
                     properties:
@@ -1463,8 +1424,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   reason:
                     type: string
                 required:
@@ -1479,8 +1439,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - exists
+                    const: exists
                   id:
                     type: integer
                     format: int64
@@ -1498,8 +1457,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   reason:
                     type: string
                 required:
@@ -1625,8 +1583,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1663,8 +1620,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -1703,8 +1659,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -1727,8 +1682,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -2092,8 +2046,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
           properties:
@@ -2128,8 +2081,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -2147,8 +2099,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
           properties:
@@ -2174,8 +2125,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -2211,8 +2161,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - created
+          const: created
         data:
           type: object
           properties:
@@ -2231,8 +2180,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - created
+          const: created
         data:
           type: object
           properties:
@@ -2251,8 +2199,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - exists
+          const: exists
         id:
           type: integer
           format: int64
@@ -2266,8 +2213,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         reason:
           type: string
       required:
@@ -2278,8 +2224,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         reason:
           type: string
       required:
@@ -2324,8 +2269,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
           properties:
@@ -2358,8 +2302,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -2383,8 +2326,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
           properties:
@@ -2403,8 +2345,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -2488,8 +2429,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -2517,8 +2457,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -2581,8 +2520,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -2610,8 +2548,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -2675,8 +2612,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - OK
+                    const: OK
                   result:
                     type: object
                 required:
@@ -2692,8 +2628,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - NOT OK
+                    const: NOT OK
                 required:
                   - status
 components:
@@ -2792,8 +2727,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -2814,8 +2748,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -2934,8 +2867,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -2956,8 +2888,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3023,8 +2954,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3047,8 +2977,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3106,8 +3035,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3172,8 +3100,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3242,8 +3169,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3263,8 +3189,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3347,8 +3272,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3369,8 +3293,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3429,8 +3352,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3448,8 +3370,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3516,8 +3437,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3537,8 +3457,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3604,8 +3523,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - ok
+                    const: ok
                   data:
                     type: object
                     properties:
@@ -3625,8 +3543,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - kinda
+                    const: kinda
                   data:
                     type: object
                     properties:
@@ -3643,16 +3560,14 @@ paths:
             application/json:
               schema:
                 type: string
-                enum:
-                  - error
+                const: error
         "500":
           description: POST /v1/mtpl Negative response 500
           content:
             application/json:
               schema:
                 type: string
-                enum:
-                  - failure
+                const: failure
 components:
   schemas: {}
   responses: {}
@@ -3701,8 +3616,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -3717,8 +3631,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3780,8 +3693,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3804,8 +3716,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3848,8 +3759,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -3872,8 +3782,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -3949,8 +3858,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     oneOf:
                       - type: object
@@ -3983,8 +3891,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4051,8 +3958,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4093,8 +3999,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4174,8 +4079,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
       required:
@@ -4186,8 +4090,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -4250,8 +4153,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4282,8 +4184,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4345,8 +4246,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4374,8 +4274,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4442,8 +4341,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4471,8 +4369,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4533,8 +4430,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4556,8 +4452,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4617,8 +4512,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                     properties:
@@ -4642,8 +4536,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4693,11 +4586,9 @@ paths:
           schema:
             oneOf:
               - type: string
-                enum:
-                  - John
+                const: John
               - type: string
-                enum:
-                  - Jane
+                const: Jane
       requestBody:
         description: the body of request
         content:
@@ -4719,8 +4610,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -4735,8 +4625,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4815,18 +4704,15 @@ components:
     ParameterOfPostV1NameName:
       oneOf:
         - type: string
-          enum:
-            - John
+          const: John
         - type: string
-          enum:
-            - Jane
+          const: Jane
     SuperPositiveResponseOfV1Name:
       type: object
       properties:
         status:
           type: string
-          enum:
-            - success
+          const: success
         data:
           type: object
       required:
@@ -4837,8 +4723,7 @@ components:
       properties:
         status:
           type: string
-          enum:
-            - error
+          const: error
         error:
           type: object
           properties:
@@ -4887,11 +4772,9 @@ paths:
           schema:
             oneOf:
               - type: string
-                enum:
-                  - John
+                const: John
               - type: string
-                enum:
-                  - Jane
+                const: Jane
         - name: other
           in: query
           required: true
@@ -4908,8 +4791,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -4924,8 +4806,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:
@@ -4975,11 +4856,9 @@ paths:
           schema:
             oneOf:
               - type: string
-                enum:
-                  - John
+                const: John
               - type: string
-                enum:
-                  - Jane
+                const: Jane
       requestBody:
         description: POST /v1/:name Request body
         content:
@@ -5001,8 +4880,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - success
+                    const: success
                   data:
                     type: object
                 required:
@@ -5017,8 +4895,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    enum:
-                      - error
+                    const: error
                   error:
                     type: object
                     properties:

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -455,15 +455,18 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictLiteral()", () => {
-    test("should set type and involve const property", () => {
-      expect(
-        depictLiteral({
-          schema: z.literal("testing"),
-          ...requestCtx,
-          next: makeNext(requestCtx),
-        }),
-      ).toMatchSnapshot();
-    });
+    test.each(["testng", null, BigInt(123)])(
+      "should set type and involve const property %#",
+      (value) => {
+        expect(
+          depictLiteral({
+            schema: z.literal(value),
+            ...requestCtx,
+            next: makeNext(requestCtx),
+          }),
+        ).toMatchSnapshot();
+      },
+    );
   });
 
   describe("depictObject()", () => {

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -455,7 +455,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictLiteral()", () => {
-    test("should set type and involve enum property", () => {
+    test("should set type and involve const property", () => {
       expect(
         depictLiteral({
           schema: z.literal("testing"),

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -455,7 +455,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictLiteral()", () => {
-    test.each(["testng", null, BigInt(123)])(
+    test.each(["testng", null, BigInt(123), Symbol("test")])(
       "should set type and involve const property %#",
       (value) => {
         expect(


### PR DESCRIPTION
This is not documented well on the OpenAPI website, but it's inherited from the JSON Schema validation standard.
And it works:

![image](https://github.com/RobinTail/express-zod-api/assets/13189514/92e12a7a-3879-43ee-b4ab-345d7f64c930)


```
0 problems (0 error, 0 warnings, 0 information, 0 hints)
```