### PR TITLE
Ref: Deasync `attachRouting()` in v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,18 @@
 - Non-breaking significant changes:
   - Due to detaching from `winston`, the `attachRouting()` method is back to being syncronous.
 - How to migrate confidently:
+  - If you're using `attachRouting()` method:
+    - Remove `await` before it (and possible async IIFE wrapper if present) — no longer required.
   - If you're using a custom logger in config:
     - No action required.
   - If you're using `createLogger()` method in your code:
     - Remove the `winston` property from its argument.
   - If you're using the default logger in config (which used to be `winston` as a peer dependency):
-    - If you're using its `info()`, `debug()`, `error()` and `warn()` methods only:
+    - If you're only using its `info()`, `debug()`, `error()` and `warn()` methods:
       - You can now uninstall `winston` — no further action required.
     - If you're using its other methods, like `.child()` or `profile()`:
       - Configure `winston` as a custom logger [according to the documentation](README.md#customizing-logger),
       - Or consider any other compatible logger, like `pino` for example, which is easier to configure.
-  - If you're using `attachRouting()` method:
-    - Remove `await` before it (and possible async IIFE wrapper if present) — no longer required.
 
 ## Version 17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Features:
   - New built-in console logger with colorful pretty inspections and basic methods only.
 - Non-breaking significant changes:
-  - Due to detaching from `winston`, the `attachRouting()` method is back to being syncronous.
+  - Due to detaching from `winston`, the `attachRouting()` method is back to being synchronous.
 - How to migrate confidently:
   - If you're using `attachRouting()` method:
     - Remove `await` before it (and possible async IIFE wrapper if present) — no longer required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - `createLogger()` argument is changed, and it now returns a built-in logger instead of `winston`.
 - Features:
   - New built-in console logger with colorful pretty inspections and basic methods only.
+- Non-breaking significant changes:
+  - Due to detaching from `winston`, the `attachRouting()` method is back to being syncronous.
 - How to migrate confidently:
   - If you're using a custom logger in config:
     - No action required.
@@ -20,6 +22,8 @@
     - If you're using its other methods, like `.child()` or `profile()`:
       - Configure `winston` as a custom logger [according to the documentation](README.md#customizing-logger),
       - Or consider any other compatible logger, like `pino` for example, which is easier to configure.
+  - If you're using `attachRouting()` method:
+    - Remove `await` before it (and possible async IIFE wrapper if present) — no longer required.
 
 ## Version 17
 

--- a/README.md
+++ b/README.md
@@ -872,15 +872,11 @@ const app = express(); // or express.Router()
 const config = createConfig({ app /* cors, logger, ... */ });
 const routing: Routing = {}; // your endpoints go here
 
-// This async IIFE is only required for the top level CommonJS
-(async () => {
-  const { notFoundHandler, logger } = await attachRouting(config, routing);
+const { notFoundHandler, logger } = attachRouting(config, routing);
 
-  app.use(notFoundHandler); // optional
-  app.listen();
-
-  logger.info("Glory to science!");
-})();
+app.use(notFoundHandler); // optional
+app.listen();
+logger.info("Glory to science!");
 ```
 
 **Please note** that in this case you probably need to parse `request.body`, call `app.listen()` and handle `404`

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import {
 } from "./server-helpers";
 import { getStartupLogo } from "./startup-logo";
 
-const makeCommonEntities = async (config: CommonConfig) => {
+const makeCommonEntities = (config: CommonConfig) => {
   if (config.startupLogo !== false) {
     console.log(getStartupLogo());
   }
@@ -30,8 +30,9 @@ const makeCommonEntities = async (config: CommonConfig) => {
   return { rootLogger, errorHandler, notFoundHandler, parserFailureHandler };
 };
 
+/** @todo consider deasync */
 export const attachRouting = async (config: AppConfig, routing: Routing) => {
-  const { rootLogger, notFoundHandler } = await makeCommonEntities(config);
+  const { rootLogger, notFoundHandler } = makeCommonEntities(config);
   initRouting({ app: config.app, routing, rootLogger, config });
   return { notFoundHandler, logger: rootLogger };
 };
@@ -51,7 +52,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
   app.use(config.server.jsonParser || express.json());
 
   const { rootLogger, notFoundHandler, parserFailureHandler } =
-    await makeCommonEntities(config);
+    makeCommonEntities(config);
 
   if (config.server.upload) {
     const uploader = await loadPeer<typeof fileUpload>("express-fileupload");

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,8 +30,7 @@ const makeCommonEntities = (config: CommonConfig) => {
   return { rootLogger, errorHandler, notFoundHandler, parserFailureHandler };
 };
 
-/** @todo consider deasync */
-export const attachRouting = async (config: AppConfig, routing: Routing) => {
+export const attachRouting = (config: AppConfig, routing: Routing) => {
   const { rootLogger, notFoundHandler } = makeCommonEntities(config);
   initRouting({ app: config.app, routing, rootLogger, config });
   return { notFoundHandler, logger: rootLogger };

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -276,7 +276,7 @@ describe("Server", () => {
   });
 
   describe("attachRouting()", () => {
-    test("should attach routing to the custom express app", async () => {
+    test("should attach routing to the custom express app", () => {
       const app = express();
       expect(appMock).toBeTruthy();
       const customLogger = createLogger({ level: "silent" });
@@ -304,7 +304,7 @@ describe("Server", () => {
           }),
         },
       };
-      const { logger, notFoundHandler } = await attachRouting(
+      const { logger, notFoundHandler } = attachRouting(
         configMock as unknown as AppConfig,
         routingMock,
       );


### PR DESCRIPTION
In v18 after detaching from winston, certain entities can be made sync again.