### PR TITLE
Forcing NPM registry to improve `yarn` stability

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,6 +38,7 @@ jobs:
       # todo use regular "yarn install" when min Node version increased to 18.18
       # @typescript/eslint group compatibility issue fixed by ignoring engines for dev dependencies only:
       run: |
+        yarn config get registry
         npm pkg delete devDependencies
         yarn install
         git checkout -- .
@@ -56,9 +57,13 @@ jobs:
     - name: Build
       run: yarn build
     - name: CJS test
-      run: yarn test:cjs
+      run: |
+        yarn config get registry
+        yarn test:cjs
     - name: ESM test
-      run: yarn test:esm
+      run: |
+        yarn config get registry
+        yarn test:esm
     - name: Check Jest 30 compatibility
       uses: madhead/semver-utils@v4
       id: jest30compat
@@ -68,9 +73,13 @@ jobs:
         lenient: false # require to parse or fail
     - name: Compatibility test
       if: steps.jest30compat.outputs.satisfies == 'true'
-      run: yarn test:compat
+      run: |
+        yarn config get registry
+        yarn test:compat
     - name: Issue 952 # see https://github.com/RobinTail/express-zod-api/issues/952
-      run: yarn test:952
+      run: |
+        yarn config get registry
+        yarn test:952
   finish:
     needs: build
     runs-on: ubuntu-latest

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org"


### PR DESCRIPTION
CI fails to often recently due to the failures of yarn's registry