### PR TITLE
add optional type dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Ensure having the following options in your `tsconfig.json` file in order to mak
 }
 ```
 
+### Optional Dependencies
+
+If you want or need to omit the `skipLibCheck` setting recommended above, you can install the following
+optional type dependencies to ensure that `express-zod-api` doesn't fail when compiling via `tsc`:
+
+```shell
+yarn add --dev @types/compression @types/express-fileupload
+```
+
+or
+
+```shell
+npm install -D @types/compression @types/express-fileupload
+```
+
 ## Set up config
 
 Create a minimal configuration. _See all available options


### PR DESCRIPTION
Adds a sub heading in the "Installation" section for optional dependency installation to support projects that don't use `skipLibCheck`.

Addresses https://github.com/RobinTail/express-zod-api/issues/1684
