### PR TITLE
Branded types will not be distinguishable in runtime

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -4,10 +4,6 @@ import { clone, mergeDeepRight } from "ramda";
 import { ProprietaryKind } from "./proprietary-schemas";
 
 export interface Metadata<T extends z.ZodTypeAny> {
-  /**
-   * @todo if the following PR merged, use native branding instead:
-   * @link https://github.com/colinhacks/zod/pull/2860
-   * */
   kind?: ProprietaryKind;
   examples: z.input<T>[];
 }


### PR DESCRIPTION
Can not express my disappointment in this regard.

https://github.com/colinhacks/zod/pull/2860#issuecomment-2092003453