### PR TITLE
Expressing `Method` via `IRouter`

### DIFF
--- a/src/method.ts
+++ b/src/method.ts
@@ -1,3 +1,13 @@
-export type Method = "get" | "post" | "put" | "delete" | "patch";
-export const methods: Method[] = ["get", "post", "put", "delete", "patch"];
-export type AuxMethod = "options";
+import type { IRouter } from "express";
+
+export const methods = [
+  "get",
+  "post",
+  "put",
+  "delete",
+  "patch",
+] satisfies Array<keyof IRouter>;
+
+export type Method = (typeof methods)[number];
+
+export type AuxMethod = Extract<keyof IRouter, "options">;


### PR DESCRIPTION
This serves two purposes:

- Enforcing constraints on its actual usage in `walkRouting()`,
- Should ease adoption of the new `QUERY` method in the future, see:
  - https://github.com/expressjs/express/issues/5615
  - https://github.com/nodejs/node/issues/51562