### PR TITLE
Fix: freezing arrays returned by public methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
   - `zod`: 3.23.0.
 - The deprecated ~~`withMeta()`~~ is removed:
   - See the changes to [v18.5.0](#v1850) on details.
-- The following methods of `Endpoint` return readonly arrays:
-  - `.getMethods()`, `.getMimeTypes()`, `.getResponses()`, `.getScopes()`, `.getTags()`.
+- Several public methods and properties exposing arrays from class instances made readonly and frozen:
+  - On `Endpoint`: `.getMethods()`, `.getMimeTypes()`, `.getResponses()`, `.getScopes()`, `.getTags()`,
+  - On `DependsOnMethod`: `.pairs`, `.siblingMethods`.
 
 ## Version 18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - `zod`: 3.23.0.
 - The deprecated ~~`withMeta()`~~ is removed:
   - See the changes to [v18.5.0](#v1850) on details.
+- The following methods of `Endpoint` return readonly arrays:
+  - `.getMethods()`, `.getMimeTypes()`, `.getResponses()`, `.getScopes()`, `.getTags()`.
 
 ## Version 18
 

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -5,7 +5,7 @@ import { Method } from "./method";
 export class DependsOnMethod {
   public readonly pairs: [Method, AbstractEndpoint][];
   public readonly firstEndpoint: AbstractEndpoint | undefined;
-  public readonly siblingMethods: Method[];
+  public readonly siblingMethods: ReadonlyArray<Method>;
 
   constructor(endpoints: Partial<Record<Method, AbstractEndpoint>>) {
     this.pairs = toPairs(endpoints).filter(
@@ -13,6 +13,8 @@ export class DependsOnMethod {
         pair !== undefined && pair[1] !== undefined,
     );
     this.firstEndpoint = head(this.pairs)?.[1];
-    this.siblingMethods = tail(this.pairs).map(([method]) => method);
+    this.siblingMethods = Object.freeze(
+      tail(this.pairs).map(([method]) => method),
+    );
   }
 }

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -3,14 +3,16 @@ import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
 
 export class DependsOnMethod {
-  public readonly pairs: [Method, AbstractEndpoint][];
+  public readonly pairs: ReadonlyArray<[Method, AbstractEndpoint]>;
   public readonly firstEndpoint: AbstractEndpoint | undefined;
   public readonly siblingMethods: ReadonlyArray<Method>;
 
   constructor(endpoints: Partial<Record<Method, AbstractEndpoint>>) {
-    this.pairs = toPairs(endpoints).filter(
-      (pair): pair is [Method, AbstractEndpoint] =>
-        pair !== undefined && pair[1] !== undefined,
+    this.pairs = Object.freeze(
+      toPairs(endpoints).filter(
+        (pair): pair is [Method, AbstractEndpoint] =>
+          pair !== undefined && pair[1] !== undefined,
+      ),
     );
     this.firstEndpoint = head(this.pairs)?.[1];
     this.siblingMethods = Object.freeze(

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -99,7 +99,7 @@ interface ReqResDepictHelperCommonProps
     "serializer" | "getRef" | "makeRef" | "path" | "method"
   > {
   schema: z.ZodTypeAny;
-  mimeTypes: string[];
+  mimeTypes: ReadonlyArray<string>;
   composition: "inline" | "components";
   description?: string;
 }

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -212,7 +212,7 @@ export class Documentation extends OpenApiBuilder {
         ? depictRequest({
             ...commonParams,
             schema: endpoint.getSchema("input"),
-            mimeTypes: endpoint.getMimeTypes("input").slice(),
+            mimeTypes: endpoint.getMimeTypes("input"),
             description: descriptions?.requestBody?.call(null, {
               method,
               path,

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -229,7 +229,7 @@ export class Documentation extends OpenApiBuilder {
             const scopes = ["oauth2", "openIdConnect"].includes(
               securitySchema.type,
             )
-              ? endpoint.getScopes()
+              ? endpoint.getScopes().slice()
               : [];
             this.addSecurityScheme(name, securitySchema);
             return { name, scopes };

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -212,7 +212,7 @@ export class Documentation extends OpenApiBuilder {
         ? depictRequest({
             ...commonParams,
             schema: endpoint.getSchema("input"),
-            mimeTypes: endpoint.getMimeTypes("input"),
+            mimeTypes: endpoint.getMimeTypes("input").slice(),
             description: descriptions?.requestBody?.call(null, {
               method,
               path,

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -61,7 +61,7 @@ export abstract class AbstractEndpoint {
   ): ReadonlyArray<NormalizedResponse>;
   public abstract getSecurity(): LogicalContainer<Security>;
   public abstract getScopes(): ReadonlyArray<string>;
-  public abstract getTags(): string[];
+  public abstract getTags(): ReadonlyArray<string>;
   public abstract getOperationId(method: Method): string | undefined;
 }
 
@@ -84,7 +84,7 @@ export class Endpoint<
   readonly #resultHandler: AnyResultHandlerDefinition;
   readonly #schemas: { input: IN; output: OUT };
   readonly #scopes: ReadonlyArray<SCO>;
-  readonly #tags: TAG[];
+  readonly #tags: ReadonlyArray<TAG>;
   readonly #getOperationId: (method: Method) => string | undefined;
 
   constructor({
@@ -119,7 +119,7 @@ export class Endpoint<
     this.#getOperationId = getOperationId;
     this.#methods = Object.freeze(methods);
     this.#scopes = Object.freeze(scopes);
-    this.#tags = tags;
+    this.#tags = Object.freeze(tags);
     this.#descriptions = { long, short };
     this.#schemas = { input: inputSchema, output: outputSchema };
     for (const [variant, schema] of Object.entries(this.#schemas)) {
@@ -209,7 +209,7 @@ export class Endpoint<
     return this.#scopes;
   }
 
-  public override getTags(): TAG[] {
+  public override getTags() {
     return this.#tags;
   }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -47,7 +47,7 @@ export abstract class AbstractEndpoint {
     response: Response;
     logger: AbstractLogger;
     config: CommonConfig;
-    siblingMethods?: Method[];
+    siblingMethods?: ReadonlyArray<Method>;
   }): Promise<void>;
   public abstract getDescription(
     variant: DescriptionVariant,

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -60,7 +60,7 @@ export abstract class AbstractEndpoint {
     variant: ResponseVariant,
   ): ReadonlyArray<NormalizedResponse>;
   public abstract getSecurity(): LogicalContainer<Security>;
-  public abstract getScopes(): string[];
+  public abstract getScopes(): ReadonlyArray<string>;
   public abstract getTags(): string[];
   public abstract getOperationId(method: Method): string | undefined;
 }
@@ -83,7 +83,7 @@ export class Endpoint<
   readonly #handler: Handler<z.output<IN>, z.input<OUT>, OPT>;
   readonly #resultHandler: AnyResultHandlerDefinition;
   readonly #schemas: { input: IN; output: OUT };
-  readonly #scopes: SCO[];
+  readonly #scopes: ReadonlyArray<SCO>;
   readonly #tags: TAG[];
   readonly #getOperationId: (method: Method) => string | undefined;
 
@@ -118,7 +118,7 @@ export class Endpoint<
     this.#middlewares = middlewares;
     this.#getOperationId = getOperationId;
     this.#methods = Object.freeze(methods);
-    this.#scopes = scopes;
+    this.#scopes = Object.freeze(scopes);
     this.#tags = tags;
     this.#descriptions = { long, short };
     this.#schemas = { input: inputSchema, output: outputSchema };
@@ -205,7 +205,7 @@ export class Endpoint<
     );
   }
 
-  public override getScopes(): SCO[] {
+  public override getScopes() {
     return this.#scopes;
   }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -55,7 +55,7 @@ export abstract class AbstractEndpoint {
   public abstract getMethods(): ReadonlyArray<Method>;
   public abstract getSchema(variant: IOVariant): IOSchema;
   public abstract getSchema(variant: ResponseVariant): z.ZodTypeAny;
-  public abstract getMimeTypes(variant: MimeVariant): string[];
+  public abstract getMimeTypes(variant: MimeVariant): ReadonlyArray<string>;
   public abstract getResponses(variant: ResponseVariant): NormalizedResponse[];
   public abstract getSecurity(): LogicalContainer<Security>;
   public abstract getScopes(): string[];
@@ -73,7 +73,7 @@ export class Endpoint<
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
   readonly #methods: ReadonlyArray<Method>;
   readonly #middlewares: AnyMiddlewareDef[];
-  readonly #mimeTypes: Record<MimeVariant, string[]>;
+  readonly #mimeTypes: Record<MimeVariant, ReadonlyArray<string>>;
   readonly #responses: Record<ResponseVariant, NormalizedResponse[]>;
   readonly #handler: Handler<z.output<IN>, z.input<OUT>, OPT>;
   readonly #resultHandler: AnyResultHandlerDefinition;
@@ -144,13 +144,19 @@ export class Endpoint<
       );
     }
     this.#mimeTypes = {
-      input: hasUpload(inputSchema)
-        ? [mimeMultipart]
-        : hasRaw(inputSchema)
-          ? [mimeRaw]
-          : [mimeJson],
-      positive: this.#responses.positive.flatMap(({ mimeTypes }) => mimeTypes),
-      negative: this.#responses.negative.flatMap(({ mimeTypes }) => mimeTypes),
+      input: Object.freeze(
+        hasUpload(inputSchema)
+          ? [mimeMultipart]
+          : hasRaw(inputSchema)
+            ? [mimeRaw]
+            : [mimeJson],
+      ),
+      positive: Object.freeze(
+        this.#responses.positive.flatMap(({ mimeTypes }) => mimeTypes),
+      ),
+      negative: Object.freeze(
+        this.#responses.negative.flatMap(({ mimeTypes }) => mimeTypes),
+      ),
     };
   }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -56,7 +56,9 @@ export abstract class AbstractEndpoint {
   public abstract getSchema(variant: IOVariant): IOSchema;
   public abstract getSchema(variant: ResponseVariant): z.ZodTypeAny;
   public abstract getMimeTypes(variant: MimeVariant): ReadonlyArray<string>;
-  public abstract getResponses(variant: ResponseVariant): NormalizedResponse[];
+  public abstract getResponses(
+    variant: ResponseVariant,
+  ): ReadonlyArray<NormalizedResponse>;
   public abstract getSecurity(): LogicalContainer<Security>;
   public abstract getScopes(): string[];
   public abstract getTags(): string[];
@@ -74,7 +76,10 @@ export class Endpoint<
   readonly #methods: ReadonlyArray<Method>;
   readonly #middlewares: AnyMiddlewareDef[];
   readonly #mimeTypes: Record<MimeVariant, ReadonlyArray<string>>;
-  readonly #responses: Record<ResponseVariant, NormalizedResponse[]>;
+  readonly #responses: Record<
+    ResponseVariant,
+    ReadonlyArray<NormalizedResponse>
+  >;
   readonly #handler: Handler<z.output<IN>, z.input<OUT>, OPT>;
   readonly #resultHandler: AnyResultHandlerDefinition;
   readonly #schemas: { input: IN; output: OUT };
@@ -126,14 +131,18 @@ export class Endpoint<
       );
     }
     this.#responses = {
-      positive: normalizeApiResponse(
-        resultHandler.getPositiveResponse(outputSchema),
-        { mimeTypes: [mimeJson], statusCodes: [defaultStatusCodes.positive] },
+      positive: Object.freeze(
+        normalizeApiResponse(resultHandler.getPositiveResponse(outputSchema), {
+          mimeTypes: [mimeJson],
+          statusCodes: [defaultStatusCodes.positive],
+        }),
       ),
-      negative: normalizeApiResponse(resultHandler.getNegativeResponse(), {
-        mimeTypes: [mimeJson],
-        statusCodes: [defaultStatusCodes.negative],
-      }),
+      negative: Object.freeze(
+        normalizeApiResponse(resultHandler.getNegativeResponse(), {
+          mimeTypes: [mimeJson],
+          statusCodes: [defaultStatusCodes.negative],
+        }),
+      ),
     };
     for (const [variant, responses] of Object.entries(this.#responses)) {
       assert(

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -52,7 +52,7 @@ export abstract class AbstractEndpoint {
   public abstract getDescription(
     variant: DescriptionVariant,
   ): string | undefined;
-  public abstract getMethods(): Method[];
+  public abstract getMethods(): ReadonlyArray<Method>;
   public abstract getSchema(variant: IOVariant): IOSchema;
   public abstract getSchema(variant: ResponseVariant): z.ZodTypeAny;
   public abstract getMimeTypes(variant: MimeVariant): string[];
@@ -71,7 +71,7 @@ export class Endpoint<
   TAG extends string,
 > extends AbstractEndpoint {
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
-  readonly #methods: Method[];
+  readonly #methods: ReadonlyArray<Method>;
   readonly #middlewares: AnyMiddlewareDef[];
   readonly #mimeTypes: Record<MimeVariant, string[]>;
   readonly #responses: Record<ResponseVariant, NormalizedResponse[]>;
@@ -112,7 +112,7 @@ export class Endpoint<
     this.#resultHandler = resultHandler;
     this.#middlewares = middlewares;
     this.#getOperationId = getOperationId;
-    this.#methods = methods;
+    this.#methods = Object.freeze(methods);
     this.#scopes = scopes;
     this.#tags = tags;
     this.#descriptions = { long, short };
@@ -158,7 +158,7 @@ export class Endpoint<
     return this.#descriptions[variant];
   }
 
-  public override getMethods(): Method[] {
+  public override getMethods() {
     return this.#methods;
   }
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -216,7 +216,7 @@ export class Integration {
               negative: negativeResponseId,
               response: genericResponseId,
               isJson: endpoint.getMimeTypes("positive").includes(mimeJson),
-              tags: endpoint.getTags(),
+              tags: endpoint.getTags().slice(),
             },
           );
         }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -93,7 +93,7 @@ export class Integration {
     { method: Method; path: string },
     Partial<Record<IOKind, string>> & {
       isJson: boolean;
-      tags: string[];
+      tags: ReadonlyArray<string>;
     }
   >();
   protected paths: string[] = [];
@@ -220,7 +220,7 @@ export class Integration {
               negative: negativeResponseId,
               response: genericResponseId,
               isJson: endpoint.getMimeTypes("positive").includes(mimeJson),
-              tags: endpoint.getTags().slice(),
+              tags: endpoint.getTags(),
             },
           );
         }

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,3 +1,13 @@
-export type Method = "get" | "post" | "put" | "delete" | "patch";
-export const methods: Method[] = ["get", "post", "put", "delete", "patch"];
-export type AuxMethod = "options";
+import type { IRouter } from "express";
+
+export const methods = [
+  "get",
+  "post",
+  "put",
+  "delete",
+  "patch",
+] satisfies Array<keyof IRouter>;
+
+export type Method = (typeof methods)[number];
+
+export type AuxMethod = Extract<keyof IRouter, "options">;

--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -12,7 +12,7 @@ export interface RoutingWalkerParams {
     endpoint: AbstractEndpoint,
     path: string,
     method: Method | AuxMethod,
-    siblingMethods?: Method[],
+    siblingMethods?: ReadonlyArray<Method>,
   ) => void;
   onStatic?: (path: string, handler: StaticHandler) => void;
   parentPath?: string;


### PR DESCRIPTION
This is a fix that prevents changing arrays after they have been assigned upon building an Endpoint, however, it could be potentially breaking, therefore I'm addressing it to v19.