### PR TITLE
Feat: Selective parsers

### DIFF
--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -95,12 +95,13 @@ type UploadOptions = Pick<
    * */
   limitError?: Error;
   /**
-   * @desc A code to execute before connecting the upload middleware.
-   * @desc It can be used to connect a middleware that restricts the ability to upload.
+   * @desc A middleware to execute before processing uploads.
+   * @desc It can be used to restrict the ability to upload.
+   * @since v19 must call next() or next(err) within
    * @default undefined
-   * @example ({ app }) => { app.use( ... ); }
+   * @example (req, res, next) => next(createHttpError(403, "Not authorized")
    * */
-  beforeUpload?: AppExtension;
+  beforeUpload?: RequestHandler;
 };
 
 type CompressionOptions = Pick<

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
       ...(typeof config.server.upload === "object" && config.server.upload),
     };
     if (beforeUpload) {
-      beforeUpload({ app, logger: rootLogger });
+      app.use(beforeUpload);
     }
     app.use(
       uploader({

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -222,12 +222,8 @@ describe("Server", () => {
           }),
         },
       };
-      const { logger } = await createServer(configMock, routingMock);
-      expect(appMock.use).toHaveBeenCalledTimes(5);
-      expect(configMock.server.upload.beforeUpload).toHaveBeenCalledWith({
-        app: appMock,
-        logger,
-      });
+      await createServer(configMock, routingMock);
+      expect(appMock.use).toHaveBeenCalledTimes(6);
       expect(fileUploadMock).toHaveBeenCalledTimes(1);
       expect(fileUploadMock).toHaveBeenCalledWith({
         abortOnLimit: false,


### PR DESCRIPTION
Enabled by #1739 
Addressing v19

This should connect only the parsers needed for particular endpoint.
Then can revert #1733 