### PR TITLE
Fix: child logger should be available when using `attachRouting()`

### DIFF
--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -3,7 +3,7 @@ import { metaSymbol } from "./metadata";
 import { loadPeer } from "./peer-helpers";
 import { AnyResultHandlerDefinition } from "./result-handler";
 import { AbstractLogger } from "./logger";
-import { ServerConfig } from "./config-type";
+import { CommonConfig, ServerConfig } from "./config-type";
 import { ErrorRequestHandler, RequestHandler, Response } from "express";
 import createHttpError, { isHttpError } from "http-errors";
 import { lastResortHandler } from "./last-resort";
@@ -131,7 +131,7 @@ export const createLoggingMiddleware =
     config,
   }: {
     rootLogger: AbstractLogger;
-    config: ServerConfig;
+    config: CommonConfig;
   }): RequestHandler =>
   async (request, response: LocalResponse, next) => {
     const logger = config.childLoggerProvider

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,14 +53,13 @@ export const attachRouting = (config: AppConfig, routing: Routing) => {
 };
 
 export const createServer = async (config: ServerConfig, routing: Routing) => {
-  const app = express().disable("x-powered-by");
   const {
     rootLogger,
     notFoundHandler,
     parserFailureHandler,
     loggingMiddleware,
   } = makeCommonEntities(config);
-  app.use(loggingMiddleware);
+  const app = express().disable("x-powered-by").use(loggingMiddleware);
 
   if (config.server.compression) {
     const compressor = await loadPeer<typeof compression>("compression");

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,12 @@ const makeCommonEntities = (config: CommonConfig) => {
 
 export const attachRouting = (config: AppConfig, routing: Routing) => {
   const { rootLogger, notFoundHandler } = makeCommonEntities(config);
-  initRouting({ app: config.app, routing, rootLogger, config });
+  initRouting({
+    app: config.app.use(createLoggingMiddleware({ rootLogger, config })),
+    routing,
+    rootLogger,
+    config,
+  });
   return { notFoundHandler, logger: rootLogger };
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,22 +20,31 @@ const makeCommonEntities = (config: CommonConfig) => {
   if (config.startupLogo !== false) {
     console.log(getStartupLogo());
   }
-  const commons = {
-    errorHandler: config.errorHandler || defaultResultHandler,
-    rootLogger: isBuiltinLoggerConfig(config.logger)
-      ? createLogger(config.logger)
-      : config.logger,
+  const errorHandler = config.errorHandler || defaultResultHandler;
+  const rootLogger = isBuiltinLoggerConfig(config.logger)
+    ? createLogger(config.logger)
+    : config.logger;
+  rootLogger.debug("Running", process.env.TSUP_BUILD || "from sources");
+  const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
+  const notFoundHandler = createNotFoundHandler({ rootLogger, errorHandler });
+  const parserFailureHandler = createParserFailureHandler({
+    rootLogger,
+    errorHandler,
+  });
+  return {
+    rootLogger,
+    errorHandler,
+    notFoundHandler,
+    parserFailureHandler,
+    loggingMiddleware,
   };
-  commons.rootLogger.debug("Running", process.env.TSUP_BUILD || "from sources");
-  const notFoundHandler = createNotFoundHandler(commons);
-  const parserFailureHandler = createParserFailureHandler(commons);
-  return { ...commons, notFoundHandler, parserFailureHandler };
 };
 
 export const attachRouting = (config: AppConfig, routing: Routing) => {
-  const { rootLogger, notFoundHandler } = makeCommonEntities(config);
+  const { rootLogger, notFoundHandler, loggingMiddleware } =
+    makeCommonEntities(config);
   initRouting({
-    app: config.app.use(createLoggingMiddleware({ rootLogger, config })),
+    app: config.app.use(loggingMiddleware),
     routing,
     rootLogger,
     config,
@@ -45,9 +54,13 @@ export const attachRouting = (config: AppConfig, routing: Routing) => {
 
 export const createServer = async (config: ServerConfig, routing: Routing) => {
   const app = express().disable("x-powered-by");
-  const { rootLogger, notFoundHandler, parserFailureHandler } =
-    makeCommonEntities(config);
-  app.use(createLoggingMiddleware({ rootLogger, config }));
+  const {
+    rootLogger,
+    notFoundHandler,
+    parserFailureHandler,
+    loggingMiddleware,
+  } = makeCommonEntities(config);
+  app.use(loggingMiddleware);
 
   if (config.server.compression) {
     const compressor = await loadPeer<typeof compression>("compression");

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -345,7 +345,7 @@ describe("Server", () => {
       );
       expect(logger).toEqual(customLogger);
       expect(typeof notFoundHandler).toBe("function");
-      expect(appMock.use).toHaveBeenCalledTimes(0);
+      expect(appMock.use).toHaveBeenCalledTimes(1); // createLoggingMiddleware
       expect(configMock.errorHandler.handler).toHaveBeenCalledTimes(0);
       expect(infoMethod).toHaveBeenCalledTimes(0);
       expect(appMock.get).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Due to #1748 and #1741 