### PR TITLE
Ref: disabling dynamic imports in CJS build

### DIFF
--- a/src/peer-helpers.ts
+++ b/src/peer-helpers.ts
@@ -7,16 +7,6 @@ export const loadPeer = async <T>(
   try {
     return (await import(moduleName))[moduleExport];
   } catch {}
-  try {
-    return await Promise.resolve().then(
-      /**
-       * alternative way for environments that do not support dynamic imports even it's CJS compatible
-       * @example jest with ts-jest
-       * @link https://github.com/evanw/esbuild/issues/2651
-       */
-      () => require(moduleName)[moduleExport],
-    );
-  } catch {}
   throw new MissingPeerError(moduleName);
 };
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,13 +10,14 @@ export default defineConfig({
   dts: true,
   minify: true,
   esbuildOptions: (options, { format }) => {
+    options.supported = {};
     if (format === "cjs") {
       /**
        * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest
        * @example jest with ts-jest
        * @link https://github.com/evanw/esbuild/issues/2651
        */
-      options.supported = { ["dynamic-import"]: false };
+      options.supported["dynamic-import"] = false;
     }
     options.define = {
       "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
   dts: true,
   minify: true,
   esbuildOptions: (options, { format }) => {
+    if (format === "cjs") {
+      /**
+       * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest
+       * @example jest with ts-jest
+       * @link https://github.com/evanw/esbuild/issues/2651
+       */
+      options.supported = { ["dynamic-import"]: false };
+    }
     options.define = {
       "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
     };


### PR DESCRIPTION
There is a Jest issue on handling dynamic imports that is really annoying.
I used to apply an approach discussed in this issue:
https://github.com/evanw/esbuild/issues/2651
But now I'm going to apply another approach from the same one, just by disabling the dynamic imports for CJS, as a cleaner way (in my opinion).

https://esbuild.github.io/api/#supported