### PR TITLE
Compat: testing against Jest 30 Alpha 4.

### DIFF
--- a/tests/compat/package.json
+++ b/tests/compat/package.json
@@ -9,7 +9,7 @@
     "express-zod-api": "link:../.."
   },
   "devDependencies": {
-    "jest": "^30.0.0-alpha.3",
+    "jest": "^30.0.0-alpha.4",
     "@types/jest": "^29.5.12",
     "@swc/core": "^1.3.100",
     "@swc/jest": "^0.2.29"


### PR DESCRIPTION
Still has issues with dynamic imports (disabled for CJS in #1757 )
More details on that issue I posted in https://github.com/evanw/esbuild/issues/2651#issuecomment-2106387664

Article on exact issue:
https://nodejs.org/api/vm.html#support-of-dynamic-import-in-compilation-apis