### PR TITLE
Lint: addressing `any` in sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 20
+
+### v20.0.0
+
+- Publically exposed types are corrected for better constraints:
+  - `IOSchema` type: type arguments generalized to the most wide type possible;
+  - The `requestProps`, `responseProps` and `loggerProps` properties of the `testEndpoint()` method's argument:
+    - changed from `Record<string, any>` to `Record<string, unknown>`;
+    - when assigning objects to those arguments, avoid `as` operator — use `satisfies` if extra constraints needed.
+
 ## Version 19
 
 ### v19.2.1

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,6 @@ export default [
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-empty-pattern": ["error", { allowObjectPatternsAsParameters: true }],
       "@typescript-eslint/no-empty-object-type": "off", // @todo remove
-      "@typescript-eslint/no-explicit-any": "warn", // @todo remove
     },
   },
   // Things to turn on globally

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default [
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-empty-pattern": ["error", { allowObjectPatternsAsParameters: true }],
       "@typescript-eslint/no-empty-object-type": "off", // @todo remove
-      "@typescript-eslint/no-explicit-any": "off", // @todo remove
+      "@typescript-eslint/no-explicit-any": "warn", // @todo remove
     },
   },
   // Things to turn on globally
@@ -60,10 +60,11 @@ export default [
   },
   // Special needs of the generated code
   {
-    files: ["tests/*/quick-start.ts"],
+    files: ["tests/*/quick-start.ts", "example/example.client.ts"],
     rules: {
       "prettier/prettier": "off",
       "import-x/no-duplicates": "off",
+      "@typescript-eslint/no-explicit-any": "off", // @todo remove
     },
   },
 ];

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -11,11 +11,11 @@ type Refined<T extends z.ZodTypeAny> =
  * @param U — only "strip" is allowed for Middlewares due to intersection issue (Zod) #600
  * */
 export type IOSchema<U extends z.UnknownKeysParam = z.UnknownKeysParam> =
-  | z.ZodObject<any, U>
+  | z.ZodObject<z.ZodRawShape, U>
   | z.ZodUnion<[IOSchema<U>, ...IOSchema<U>[]]>
   | z.ZodIntersection<IOSchema<U>, IOSchema<U>>
-  | z.ZodDiscriminatedUnion<string, z.ZodObject<any, U>[]>
-  | Refined<z.ZodObject<any, U>>
+  | z.ZodDiscriminatedUnion<string, z.ZodObject<z.ZodRawShape, U>[]>
+  | Refined<z.ZodObject<z.ZodRawShape, U>>
   | RawSchema;
 
 export type ProbableIntersection<

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -10,7 +10,7 @@ type Refined<T extends z.ZodTypeAny> =
  * @desc The type allowed on the top level of Middlewares and Endpoints
  * @param U — only "strip" is allowed for Middlewares due to intersection issue (Zod) #600
  * */
-export type IOSchema<U extends z.UnknownKeysParam = any> =
+export type IOSchema<U extends z.UnknownKeysParam = z.UnknownKeysParam> =
   | z.ZodObject<any, U>
   | z.ZodUnion<[IOSchema<U>, ...IOSchema<U>[]]>
   | z.ZodIntersection<IOSchema<U>, IOSchema<U>>

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -3,7 +3,7 @@ import { isObject } from "./common-helpers";
 /** @desc You can use any logger compatible with this type. */
 export type AbstractLogger = Record<
   "info" | "debug" | "warn" | "error",
-  (message: string, meta?: any) => any
+  (message: string, meta?: any) => any // eslint-disable-line @typescript-eslint/no-explicit-any
 >;
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,6 +44,7 @@ export interface MiddlewareDefinition<
   type: "proprietary" | "express";
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyMiddlewareDef = MiddlewareDefinition<any, any, any, any>;
 
 export const createMiddleware = <

--- a/src/schema-walker.ts
+++ b/src/schema-walker.ts
@@ -13,7 +13,10 @@ export type SchemaHandler<
   U,
   Context extends FlatObject = {},
   Variant extends HandlingVariant = "regular",
-> = (schema: any, ctx: Context & VariantDependingProps<U>[Variant]) => U;
+> = (
+  schema: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ctx: Context & VariantDependingProps<U>[Variant],
+) => U;
 
 export type HandlingRules<
   U,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import http from "node:http";
+import { FlatObject } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { AbstractEndpoint } from "./endpoint";
 import { AbstractLogger, ActualLogger } from "./logger-helpers";
@@ -18,7 +19,7 @@ export interface MockOverrides {}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockFunction = (implementation?: (...args: any[]) => any) => MockOverrides;
 
-export const makeRequestMock = <REQ extends Record<string, any>>({
+export const makeRequestMock = <REQ extends FlatObject>({
   fnMethod,
   requestProps,
 }: {
@@ -31,7 +32,7 @@ export const makeRequestMock = <REQ extends Record<string, any>>({
     ...requestProps,
   }) as { method: string } & Record<"header", MockOverrides> & REQ;
 
-export const makeResponseMock = <RES extends Record<string, any>>({
+export const makeResponseMock = <RES extends FlatObject>({
   fnMethod,
   responseProps,
 }: {
@@ -71,7 +72,7 @@ export const makeResponseMock = <RES extends Record<string, any>>({
   return responseMock;
 };
 
-export const makeLoggerMock = <LOG extends Record<string, any>>({
+export const makeLoggerMock = <LOG extends FlatObject>({
   fnMethod,
   loggerProps,
 }: {
@@ -119,9 +120,9 @@ interface TestEndpointProps<REQ, RES, LOG> {
 
 /** @desc Requires either jest (with @types/jest) or vitest or to specify the fnMethod option */
 export const testEndpoint = async <
-  LOG extends Record<string, any>,
-  REQ extends Record<string, any>,
-  RES extends Record<string, any>,
+  LOG extends FlatObject,
+  REQ extends FlatObject,
+  RES extends FlatObject,
 >({
   endpoint,
   requestProps,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -46,7 +46,7 @@ export const makeResponseMock = <RES extends FlatObject>({
     set: fnMethod(() => responseMock),
     setHeader: fnMethod(() => responseMock),
     header: fnMethod(() => responseMock),
-    status: fnMethod((code) => {
+    status: fnMethod((code: number) => {
       responseMock.statusCode = code;
       responseMock.statusMessage = http.STATUS_CODES[code]!;
       return responseMock;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -15,6 +15,7 @@ import { LocalResponse } from "./server-helpers";
 export interface MockOverrides {}
 
 /** @desc Compatibility constraints for a function mocking method of a testing framework. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockFunction = (implementation?: (...args: any[]) => any) => MockOverrides;
 
 export const makeRequestMock = <REQ extends Record<string, any>>({

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -27,12 +27,12 @@ describe("ResultHandler", () => {
     {
       resultHandler: defaultResultHandler,
       name: "defaultResultHandler",
-      errorMethod: "json",
+      errorMethod: "json" as const,
     },
     {
       resultHandler: arrayResultHandler,
       name: "arrayResultHandler",
-      errorMethod: "send",
+      errorMethod: "send" as const,
     },
   ])(
     "$name",

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -94,7 +94,7 @@ describe("Server helpers", () => {
           locals: {
             [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
           },
-        } as unknown as Response,
+        },
       });
       await handler(
         requestMock as unknown as Request,


### PR DESCRIPTION
Some public interfaces changed.
Should not be an issue, but nominally it's a breaking change. Therefore, addressing to v20