### PR TITLE
Dependabot: new group to track after switching to ESLint 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,5 @@ updates:
     groups:
       typescript-eslint:
         patterns:
-          - "@typescript-eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/utils"


### PR DESCRIPTION
While on beta, temporary using resolutions for plugin `import-x`