### PR TITLE
Simpler intersections

### DIFF
--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -3,11 +3,7 @@ import { z } from "zod";
 import { EmptyObject, FlatObject } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { Endpoint, Handler } from "./endpoint";
-import {
-  IOSchema,
-  ProbableIntersection,
-  getFinalEndpointInputSchema,
-} from "./io-schema";
+import { IOSchema, getFinalEndpointInputSchema } from "./io-schema";
 import { Method } from "./method";
 import {
   AbstractMiddleware,
@@ -23,14 +19,14 @@ import {
 type BuildProps<
   IN extends IOSchema,
   OUT extends IOSchema,
-  MIN extends IOSchema<"strip"> | null,
+  MIN extends IOSchema<"strip">,
   OPT extends FlatObject,
   SCO extends string,
   TAG extends string,
 > = {
   input: IN;
   output: OUT;
-  handler: Handler<z.output<ProbableIntersection<MIN, IN>>, z.input<OUT>, OPT>;
+  handler: Handler<z.output<z.ZodIntersection<MIN, IN>>, z.input<OUT>, OPT>;
   description?: string;
   shortDescription?: string;
   operationId?: string | ((method: Method) => string);
@@ -39,7 +35,7 @@ type BuildProps<
   ({ tags?: TAG[] } | { tag?: TAG });
 
 export class EndpointsFactory<
-  IN extends IOSchema<"strip"> | null = null,
+  IN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
   OUT extends FlatObject = EmptyObject,
   SCO extends string = string,
   TAG extends string = string,
@@ -66,7 +62,7 @@ export class EndpointsFactory<
   }
 
   static #create<
-    CIN extends IOSchema<"strip"> | null,
+    CIN extends IOSchema<"strip">,
     COUT extends FlatObject,
     CSCO extends string,
     CTAG extends string,
@@ -89,7 +85,7 @@ export class EndpointsFactory<
       | ConstructorParameters<typeof Middleware<AIN, OUT, AOUT, ASCO>>[0],
   ) {
     return EndpointsFactory.#create<
-      ProbableIntersection<IN, AIN>,
+      z.ZodIntersection<IN, AIN>,
       OUT & AOUT,
       SCO & ASCO,
       TAG
@@ -135,7 +131,7 @@ export class EndpointsFactory<
     operationId,
     ...rest
   }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
-    ProbableIntersection<IN, BIN>,
+    z.ZodIntersection<IN, BIN>,
     BOUT,
     OUT,
     SCO,

--- a/src/io-schema.ts
+++ b/src/io-schema.ts
@@ -18,28 +18,20 @@ export type IOSchema<U extends z.UnknownKeysParam = z.UnknownKeysParam> =
   | Refined<z.ZodObject<z.ZodRawShape, U>>
   | RawSchema;
 
-export type ProbableIntersection<
-  A extends IOSchema<"strip"> | null,
-  B extends IOSchema,
-> = A extends null
-  ? B
-  : A extends IOSchema<"strip">
-    ? z.ZodIntersection<A, B>
-    : never;
-
 /**
  * @description intersects input schemas of middlewares and the endpoint
  * @since 07.03.2022 former combineEndpointAndMiddlewareInputSchemas()
  * @since 05.03.2023 is immutable to metadata
+ * @since 26.05.2024 uses the regular ZodIntersection
  * @see copyMeta
  */
 export const getFinalEndpointInputSchema = <
-  MIN extends IOSchema<"strip"> | null,
+  MIN extends IOSchema<"strip">,
   IN extends IOSchema,
 >(
   middlewares: AbstractMiddleware[],
   input: IN,
-): ProbableIntersection<MIN, IN> => {
+): z.ZodIntersection<MIN, IN> => {
   const allSchemas = middlewares
     .map((mw) => mw.getSchema() as IOSchema)
     .concat(input);
@@ -49,5 +41,5 @@ export const getFinalEndpointInputSchema = <
   return allSchemas.reduce(
     (acc, schema) => copyMeta(schema, acc),
     finalSchema,
-  ) as ProbableIntersection<MIN, IN>;
+  ) as z.ZodIntersection<MIN, IN>;
 };

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -320,12 +320,7 @@ describe("EndpointsFactory", () => {
       expect(
         serializeSchemaForTest(endpoint.getSchema("output")),
       ).toMatchSnapshot();
-      expectType<
-        z.ZodIntersection<
-          z.ZodObject<{ n: z.ZodNumber }>,
-          z.ZodObject<{ s: z.ZodString }>
-        >
-      >(endpoint.getSchema("input"));
+      expectType<{ n: number; s: string }>(endpoint.getSchema("input")._output);
     });
 
     test("Should create an endpoint with refined object middleware", () => {
@@ -364,17 +359,9 @@ describe("EndpointsFactory", () => {
       expect(
         serializeSchemaForTest(endpoint.getSchema("output")),
       ).toMatchSnapshot();
-      expectType<
-        z.ZodIntersection<
-          z.ZodEffects<
-            z.ZodObject<{
-              a: z.ZodOptional<z.ZodNumber>;
-              b: z.ZodOptional<z.ZodString>;
-            }>
-          >,
-          z.ZodObject<{ i: z.ZodString }>
-        >
-      >(endpoint.getSchema("input"));
+      expectType<{ a?: number; b?: string; i: string }>(
+        endpoint.getSchema("input")._output,
+      );
     });
 
     test("Should create an endpoint with intersection middleware", () => {
@@ -417,15 +404,9 @@ describe("EndpointsFactory", () => {
       expect(
         serializeSchemaForTest(endpoint.getSchema("output")),
       ).toMatchSnapshot();
-      expectType<
-        z.ZodIntersection<
-          z.ZodIntersection<
-            z.ZodObject<{ n1: z.ZodNumber }>,
-            z.ZodObject<{ n2: z.ZodNumber }>
-          >,
-          z.ZodObject<{ s: z.ZodString }>
-        >
-      >(endpoint.getSchema("input"));
+      expectType<{ n1: number; n2: number; s: string }>(
+        endpoint.getSchema("input")._output,
+      );
     });
 
     test("Should create an endpoint with union middleware", () => {
@@ -471,14 +452,9 @@ describe("EndpointsFactory", () => {
       expect(
         serializeSchemaForTest(endpoint.getSchema("output")),
       ).toMatchSnapshot();
-      expectType<
-        z.ZodIntersection<
-          z.ZodUnion<
-            [z.ZodObject<{ n1: z.ZodNumber }>, z.ZodObject<{ n2: z.ZodNumber }>]
-          >,
-          z.ZodObject<{ s: z.ZodString }>
-        >
-      >(endpoint.getSchema("input"));
+      expectType<{ s: string } & ({ n1: number } | { n2: number })>(
+        endpoint.getSchema("input")._output,
+      );
     });
   });
 });


### PR DESCRIPTION
After #1792 it's time to get rid of redundant complication and use regular intersection schema.
Utilizing the `EmptyObject` type introduced in #1788 for v20 #1787 