### PR TITLE
Improving `testEndpoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@
   - Both properties can now accept static values and the previously assigned functions.
 - Method `createMiddleware()` removed — use either `new Middleware()` or `EndpointsFactory::addMiddleware()` instead:
   - The argument's property `middleware` renamed to `handler`.
-- Publicly exposed types are corrected for better constraints:
-  - `IOSchema` type: type arguments generalized to the most wide type possible;
-  - The `requestProps`, `responseProps` and `loggerProps` properties of the `testEndpoint()` method's argument:
-    - changed from `Record<string, any>` to `Record<string, unknown>`;
-    - when assigning objects to those arguments, avoid `as` operator — use `satisfies` if extra constraints needed.
-  - The `options` property of a Middleware' and Endpoint's handler extends from `Record<string, never>` by default:
-    - You can not assign additional properties to the `options` directly — use middlewares to combine options.
+- Method `testEndpoint()` was changed:
+  - It was detached from any testing frameworks, `fnMethod` property removed from the argument;
+  - Mocked request and response are now fully operational and do not require to mock anything to do the job;
+  - The `responseProps` property changed to `responseOptions`, it's no longer meant to be used for custom props;
+  - The returned entities `requestMock`, `responseMock` and `loggerMock` no longer rely on testing framework for props.  
+    Instead, they provide methods to assert expectations in tests:
+    - `responseMock._getStatusCode()`, `responseMock._getHeaders()`, `responseMock._getData()`, `loggerMock._getLogs()`;
+    - See [the documentation of node-mocks-http library](https://www.npmjs.com/package/node-mocks-http) for details.
 
 ```ts
 // before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,11 @@ factory // variant 1:
 
 ```ts
 // before
+declare module "express-zod-api" {
+  interface MockOverrides extends Mock {} // remove it
+}
 const { responseMock: responseMockBefore, loggerMock: loggerMockBefore } =
-  testEndpoint({
-    fnMethod: vi.fn,
-    endpoint,
-  });
+  testEndpoint({ endpoint });
 expect(responseMockBefore.status).toHaveBeenCalledWith(200);
 expect(loggerMockBefore.error).not.toHaveBeenCalled();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,24 @@ factory // variant 1:
   .addMiddleware({ input: z.object({}), handler: async () => ({}) });
 ```
 
+```ts
+// before
+const { responseMock: responseMockBefore, loggerMock: loggerMockBefore } =
+  testEndpoint({
+    fnMethod: vi.fn,
+    endpoint,
+  });
+expect(responseMockBefore.status).toHaveBeenCalledWith(200);
+expect(loggerMockBefore.error).not.toHaveBeenCalled();
+
+// after
+const { responseMock, loggerMock } = testEndpoint({ endpoint });
+expect(responseMock._getStatusCode()).toBe(200);
+expect(responseMock._getHeaders()).toEqual({ "x-custom": "one" });
+expect(responseMock._getData()).toBe(JSON.stringify({ status: "success" }));
+expect(loggerMock._getLogs().error).toEqual([]);
+```
+
 ## Version 19
 
 ### v19.2.1

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,7 @@ export default [
       "import-x/no-extraneous-dependencies": "error",
       "@typescript-eslint/no-empty-object-type": [
         "error",
-        { allowWithName: "LoggerOverrides|MockOverrides" },
+        { allowWithName: "LoggerOverrides" },
       ],
     },
   },
@@ -51,10 +51,7 @@ export default [
     files: ["tests/**/*.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-empty-object-type": [
-        "warn",
-        { allowWithName: "MockOverrides" },
-      ],
+      "@typescript-eslint/no-empty-object-type": ["warn"],
     },
   },
   // Special needs of plugin

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "ansis": "^3.1.0",
+    "node-mocks-http": "^1.14.1",
     "openapi3-ts": "^4.3.2",
     "ramda": "^0.30.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ export type { Depicter } from "./documentation-helpers";
 export type { Producer } from "./zts-helpers";
 
 // Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
-export type { MockOverrides } from "./testing";
 export type { Routing } from "./routing";
 export type { LoggerOverrides } from "./logger-helpers";
 export type { FlatObject } from "./common-helpers";

--- a/src/peer-helpers.ts
+++ b/src/peer-helpers.ts
@@ -9,17 +9,3 @@ export const loadPeer = async <T>(
   } catch {}
   throw new MissingPeerError(moduleName);
 };
-
-export const loadAlternativePeer = async <T>(
-  options: {
-    moduleName: string;
-    moduleExport?: string;
-  }[],
-) => {
-  for (const { moduleName, moduleExport } of options) {
-    try {
-      return await loadPeer<T>(moduleName, moduleExport);
-    } catch {}
-  }
-  throw new MissingPeerError(options.map(({ moduleName }) => moduleName));
-};

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -72,7 +72,7 @@ interface TestEndpointProps<REQ, LOG> {
 
 export const testEndpoint = async <
   LOG extends FlatObject,
-  REQ extends FlatObject,
+  REQ extends RequestOptions,
 >({
   endpoint,
   requestProps,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -34,16 +34,15 @@ export const makeLoggerMock = <LOG extends FlatObject>(loggerProps?: LOG) => {
     (loggerProps || {}) as AbstractLogger &
       LOG & { _getLogs: () => typeof logs },
     {
-      get(target, prop) {
+      get(target, prop, recv) {
         if (prop === "_getLogs") {
           return () => logs;
         }
         if (prop in severity) {
           return (...args: unknown[]) =>
             logs[prop as keyof AbstractLogger].push(args);
-          // @todo maybe should also check props
         }
-        return target[prop as keyof typeof target];
+        return Reflect.get(target, prop, recv);
       },
     },
   );

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -53,7 +53,7 @@ interface TestEndpointProps<REQ, LOG> {
   endpoint: AbstractEndpoint;
   /**
    * @desc Additional properties to set on Request mock
-   * @default { method: "GET", headers: {"content-type": "application/json" } }
+   * @default { method: "GET", headers: { "content-type": "application/json" } }
    * */
   requestProps?: REQ;
   /** @link https://www.npmjs.com/package/node-mocks-http */

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -56,7 +56,10 @@ interface TestEndpointProps<REQ, LOG> {
    * @default { method: "GET", headers: { "content-type": "application/json" } }
    * */
   requestProps?: REQ;
-  /** @link https://www.npmjs.com/package/node-mocks-http */
+  /**
+   * @link https://www.npmjs.com/package/node-mocks-http
+   * @default { req: requestMock }
+   * */
   responseOptions?: ResponseOptions;
   /**
    * @desc Additional properties to set on config mock
@@ -81,7 +84,10 @@ export const testEndpoint = async <
   loggerProps,
 }: TestEndpointProps<REQ, LOG>) => {
   const requestMock = makeRequestMock(requestProps);
-  const responseMock = makeResponseMock(responseOptions);
+  const responseMock = makeResponseMock({
+    req: requestMock,
+    ...responseOptions,
+  });
   const loggerMock = makeLoggerMock(loggerProps);
   const configMock = {
     cors: false,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -88,7 +88,7 @@ interface TestEndpointProps<REQ, RES, LOG> {
   endpoint: AbstractEndpoint;
   /**
    * @desc Additional properties to set on Request mock
-   * @default { method: "GET", header: () => "application/json" }
+   * @default { method: "GET", headers: {"content-type": "application/json" } }
    * */
   requestProps?: REQ;
   /**

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -12,14 +12,6 @@ import {
   ResponseOptions,
 } from "node-mocks-http";
 
-/**
- * @desc Using module augmentation approach you can set the Mock type of your actual testing framework.
- * @example declare module "express-zod-api" { interface MockOverrides extends Mock {} }
- * @link https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
- * @todo remove
- * */
-export interface MockOverrides {}
-
 export const makeRequestMock = <REQ extends RequestOptions>(props?: REQ) => {
   const mock = createRequest<Request>({
     ...props,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -20,11 +20,13 @@ export interface MockOverrides {}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for assignment compatibility
 type MockFunction = (implementation?: (...args: any[]) => any) => MockOverrides;
 
-export const makeRequestMock = <REQ extends RequestOptions>(props?: REQ) =>
-  createRequest({
+export const makeRequestMock = <REQ extends RequestOptions>(props?: REQ) => {
+  const mock = createRequest<Request>({
     ...props,
     headers: { "content-type": contentTypes.json, ...props?.headers },
-  }) as ReturnType<typeof createRequest> & REQ;
+  });
+  return mock as typeof mock & REQ;
+};
 
 export const makeResponseMock = <RES extends FlatObject>({
   fnMethod,

--- a/tests/compat/jest.spec.ts
+++ b/tests/compat/jest.spec.ts
@@ -21,11 +21,13 @@ describe("Jest compatibility test", () => {
           requestProps: { method: "POST", body: { n: 123 } },
           fnMethod,
         });
-        expect(responseMock.status).toHaveBeenCalledWith(200);
-        expect(responseMock.json).toHaveBeenCalledWith({
-          status: "success",
-          data: { inc: 124 },
-        });
+        expect(responseMock._getStatusCode()).toBe(200);
+        expect(responseMock._getData()).toBe(
+          JSON.stringify({
+            status: "success",
+            data: { inc: 124 },
+          }),
+        );
       },
     );
   });

--- a/tests/compat/jest.spec.ts
+++ b/tests/compat/jest.spec.ts
@@ -1,34 +1,26 @@
 import { defaultEndpointsFactory, testEndpoint } from "express-zod-api";
 import { z } from "zod";
 
-declare module "express-zod-api" {
-  interface MockOverrides extends jest.Mock {}
-}
-
 describe("Jest compatibility test", () => {
   describe("testEndpoint()", () => {
-    test.each([undefined, jest.fn])(
-      "should support jest.fn %#",
-      async (fnMethod) => {
-        const endpoint = defaultEndpointsFactory.build({
-          method: "post",
-          input: z.object({ n: z.number() }),
-          output: z.object({ inc: z.number() }),
-          handler: async ({ input }) => ({ inc: input.n + 1 }),
-        });
-        const { responseMock } = await testEndpoint({
-          endpoint,
-          requestProps: { method: "POST", body: { n: 123 } },
-          fnMethod,
-        });
-        expect(responseMock._getStatusCode()).toBe(200);
-        expect(responseMock._getData()).toBe(
-          JSON.stringify({
-            status: "success",
-            data: { inc: 124 },
-          }),
-        );
-      },
-    );
+    test("should support jest.fn %#", async () => {
+      const endpoint = defaultEndpointsFactory.build({
+        method: "post",
+        input: z.object({ n: z.number() }),
+        output: z.object({ inc: z.number() }),
+        handler: async ({ input }) => ({ inc: input.n + 1 }),
+      });
+      const { responseMock } = await testEndpoint({
+        endpoint,
+        requestProps: { method: "POST", body: { n: 123 } },
+      });
+      expect(responseMock._getStatusCode()).toBe(200);
+      expect(responseMock._getData()).toBe(
+        JSON.stringify({
+          status: "success",
+          data: { inc: 124 },
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/__snapshots__/endpoint.spec.ts.snap
+++ b/tests/unit/__snapshots__/endpoint.spec.ts.snap
@@ -39,11 +39,3 @@ exports[`Endpoint > .getSchema() > should return the positive response schema 1`
   },
 }
 `;
-
-exports[`Endpoint > Feature #600: Top level refinements > should accept valid inputs 1`] = `"{"status":"success","data":{}}"`;
-
-exports[`Endpoint > Feature #600: Top level refinements > should fail during the refinement of invalid inputs 1`] = `"{"status":"error","error":{"message":"Please provide at least one property"}}"`;
-
-exports[`Endpoint > Issue #654: Top level refinements > should accept valid inputs 1`] = `"{"status":"success","data":{}}"`;
-
-exports[`Endpoint > Issue #654: Top level refinements > should fail during the refinement of invalid inputs 1`] = `"{"status":"error","error":{"message":"dynamicValue: type1Attribute is required if type is type1"}}"`;

--- a/tests/unit/__snapshots__/endpoint.spec.ts.snap
+++ b/tests/unit/__snapshots__/endpoint.spec.ts.snap
@@ -39,3 +39,11 @@ exports[`Endpoint > .getSchema() > should return the positive response schema 1`
   },
 }
 `;
+
+exports[`Endpoint > Feature #600: Top level refinements > should accept valid inputs 1`] = `"{"status":"success","data":{}}"`;
+
+exports[`Endpoint > Feature #600: Top level refinements > should fail during the refinement of invalid inputs 1`] = `"{"status":"error","error":{"message":"Please provide at least one property"}}"`;
+
+exports[`Endpoint > Issue #654: Top level refinements > should accept valid inputs 1`] = `"{"status":"success","data":{}}"`;
+
+exports[`Endpoint > Issue #654: Top level refinements > should fail during the refinement of invalid inputs 1`] = `"{"status":"error","error":{"message":"dynamicValue: type1Attribute is required if type is type1"}}"`;

--- a/tests/unit/__snapshots__/result-handler.spec.ts.snap
+++ b/tests/unit/__snapshots__/result-handler.spec.ts.snap
@@ -1,32 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle HTTP error 1`] = `
-[
-  "Something not found",
-]
-`;
+exports[`ResultHandler > 'arrayResultHandler' > Should handle HTTP error 1`] = `"Something not found"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle generic error 1`] = `
-[
-  "Some error",
-]
-`;
+exports[`ResultHandler > 'arrayResultHandler' > Should handle generic error 1`] = `"Some error"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle regular response 1`] = `
-[
-  [
-    "One",
-    "Two",
-    "Three",
-  ],
-]
-`;
+exports[`ResultHandler > 'arrayResultHandler' > Should handle regular response 1`] = `"["One","Two","Three"]"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle schema error 1`] = `
-[
-  "something: Expected string, got number",
-]
-`;
+exports[`ResultHandler > 'arrayResultHandler' > Should handle schema error 1`] = `"something: Expected string, got number"`;
 
 exports[`ResultHandler > 'arrayResultHandler' > should forward output schema examples 1`] = `
 {
@@ -48,54 +28,13 @@ exports[`ResultHandler > 'arrayResultHandler' > should generate negative respons
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle HTTP error 1`] = `
-[
-  {
-    "error": {
-      "message": "Something not found",
-    },
-    "status": "error",
-  },
-]
-`;
+exports[`ResultHandler > 'defaultResultHandler' > Should handle HTTP error 1`] = `"{"status":"error","error":{"message":"Something not found"}}"`;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 1`] = `
-[
-  {
-    "error": {
-      "message": "Some error",
-    },
-    "status": "error",
-  },
-]
-`;
+exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 1`] = `"{"status":"error","error":{"message":"Some error"}}"`;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle regular response 1`] = `
-[
-  {
-    "data": {
-      "anything": 118,
-      "items": [
-        "One",
-        "Two",
-        "Three",
-      ],
-    },
-    "status": "success",
-  },
-]
-`;
+exports[`ResultHandler > 'defaultResultHandler' > Should handle regular response 1`] = `"{"status":"success","data":{"anything":118,"items":["One","Two","Three"]}}"`;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`] = `
-[
-  {
-    "error": {
-      "message": "something: Expected string, got number",
-    },
-    "status": "error",
-  },
-]
-`;
+exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`] = `"{"status":"error","error":{"message":"something: Expected string, got number"}}"`;
 
 exports[`ResultHandler > 'defaultResultHandler' > should forward output schema examples 1`] = `
 {
@@ -128,8 +67,4 @@ exports[`ResultHandler > 'defaultResultHandler' > should generate negative respo
 }
 `;
 
-exports[`ResultHandler > arrayResultHandler should fail when there is no items prop in the output 1`] = `
-[
-  "Property 'items' is missing in the endpoint output",
-]
-`;
+exports[`ResultHandler > arrayResultHandler should fail when there is no items prop in the output 1`] = `"Property 'items' is missing in the endpoint output"`;

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -110,7 +110,7 @@ describe("Endpoint", () => {
         options: { inc: 454 },
         logger: loggerMock,
       });
-      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(resultHandlerSpy).toHaveBeenCalledWith({
         error: null,
         input: { n: 453 },
@@ -149,7 +149,7 @@ describe("Endpoint", () => {
           }),
         },
       });
-      expect(loggerMock.error).toHaveBeenCalledTimes(0);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(responseMock._getStatusCode()).toBe(200);
       expect(handlerMock).toHaveBeenCalledTimes(0);
       expect(responseMock._getHeaders()).toEqual({
@@ -192,7 +192,7 @@ describe("Endpoint", () => {
         }),
       });
       const { responseMock, loggerMock } = await testEndpoint({ endpoint });
-      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock._getLogs().error).toHaveLength(1);
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getData()).toBe(
         JSON.stringify({
@@ -233,12 +233,13 @@ describe("Endpoint", () => {
       });
       expect(handlerMock).toHaveBeenCalledTimes(0);
       expect(middlewareMock).toHaveBeenCalledTimes(1);
-      expect(loggerMock.error).toHaveBeenCalledTimes(0);
-      expect(loggerMock.warn).toHaveBeenCalledTimes(1);
-      expect(loggerMock.warn.mock.calls[0][0]).toBe(
-        "A middleware has closed the stream. Accumulated options:",
-      );
-      expect(loggerMock.warn.mock.calls[0][1]).toEqual({ inc: 454 });
+      expect(loggerMock._getLogs().error).toHaveLength(0);
+      expect(loggerMock._getLogs().warn).toEqual([
+        [
+          "A middleware has closed the stream. Accumulated options:",
+          { inc: 454 },
+        ],
+      ]);
       expect(responseMock._getStatusCode()).toBe(200);
       expect(responseMock._getStatusMessage()).toBe("OK");
     });
@@ -264,10 +265,9 @@ describe("Endpoint", () => {
       const { loggerMock, responseMock, requestMock } = await testEndpoint({
         endpoint,
       });
-      expect(loggerMock.error).toHaveBeenCalledTimes(1);
-      expect(loggerMock.error.mock.calls[0][0]).toBe(
-        "Result handler failure: Something unexpected happened.",
-      );
+      expect(loggerMock._getLogs().error).toEqual([
+        ["Result handler failure: Something unexpected happened."],
+      ]);
       expect(spy).toHaveBeenCalledWith({
         error: null,
         logger: loggerMock,
@@ -463,7 +463,7 @@ describe("Endpoint", () => {
         }),
       });
       const { responseMock, loggerMock } = await testEndpoint({ endpoint });
-      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock._getLogs().error).toHaveLength(1);
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getData()).toBe(
         JSON.stringify({
@@ -490,10 +490,9 @@ describe("Endpoint", () => {
         handler: async () => ({ test: "OK" }),
       });
       const { loggerMock, responseMock } = await testEndpoint({ endpoint });
-      expect(loggerMock.error).toHaveBeenCalledTimes(1);
-      expect(loggerMock.error.mock.calls[0][0]).toBe(
-        "Result handler failure: Something unexpected happened.",
-      );
+      expect(loggerMock._getLogs().error).toEqual([
+        ["Result handler failure: Something unexpected happened."],
+      ]);
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getData()).toBe(
         "An error occurred while serving the result: Something unexpected happened.",
@@ -518,7 +517,7 @@ describe("Endpoint", () => {
           body: {},
         },
       });
-      expect(loggerMock.error).toHaveBeenCalledTimes(1);
+      expect(loggerMock._getLogs().error).toHaveLength(1);
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getData()).toBe(
         JSON.stringify({
@@ -736,7 +735,7 @@ describe("Endpoint", () => {
         },
       });
 
-      expect(loggerMock.debug.mock.calls).toEqual([
+      expect(loggerMock._getLogs().debug).toEqual([
         ["date in mw handler", "object"],
         ["date in endpoint handler", "object"],
       ]);

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -575,7 +575,9 @@ describe("Endpoint", () => {
           },
         },
       });
-      expect(responseMock._getData()).toMatchSnapshot();
+      expect(responseMock._getData()).toBe(
+        JSON.stringify({ status: "success", data: {} }),
+      );
       expect(responseMock._getStatusCode()).toBe(200);
     });
 
@@ -590,7 +592,15 @@ describe("Endpoint", () => {
           },
         },
       });
-      expect(responseMock._getData()).toMatchSnapshot();
+      expect(responseMock._getData()).toBe(
+        JSON.stringify({
+          status: "error",
+          error: {
+            message:
+              "dynamicValue: type1Attribute is required if type is type1",
+          },
+        }),
+      );
       expect(responseMock._getStatusCode()).toBe(400);
     });
 
@@ -643,7 +653,9 @@ describe("Endpoint", () => {
           },
         },
       });
-      expect(responseMock._getData()).toMatchSnapshot();
+      expect(responseMock._getData()).toBe(
+        JSON.stringify({ status: "success", data: {} }),
+      );
       expect(responseMock._getStatusCode()).toBe(200);
     });
 
@@ -655,7 +667,12 @@ describe("Endpoint", () => {
           body: {},
         },
       });
-      expect(responseMock._getData()).toMatchSnapshot();
+      expect(responseMock._getData()).toBe(
+        JSON.stringify({
+          status: "error",
+          error: { message: "Please provide at least one property" },
+        }),
+      );
       expect(responseMock._getStatusCode()).toBe(400);
     });
 

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -113,7 +113,7 @@ describe("EndpointsFactory", () => {
           options: {},
           request: {} as Request,
           response: {} as Response,
-          logger: makeLoggerMock({ fnMethod: vi.fn }),
+          logger: makeLoggerMock(),
         }),
       ).toEqual({
         option1: "some value",

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -17,14 +17,13 @@ import {
   InputSecurity,
   LoggerOverrides,
   Method,
-  MockOverrides,
   OAuth2Security,
   OpenIdSecurity,
   Producer,
   Routing,
   ServerConfig,
 } from "../../src";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 describe("Index Entrypoint", () => {
   describe("exports", () => {
@@ -51,7 +50,6 @@ describe("Index Entrypoint", () => {
     });
 
     test("Issue 952, 1182, 1269: should expose certain types and interfaces", () => {
-      expectType<MockOverrides>(vi.fn());
       expectType<Method>("get");
       expectType<IOSchema>(z.object({}));
       expectType<FlatObject>({});

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { Request, Response } from "express";
 import { InputValidationError, Middleware } from "../../src";
 import { IOSchemaError } from "../../src/errors";
 import { describe, expect, test, vi } from "vitest";
@@ -66,10 +65,8 @@ describe("Middleware", () => {
           input: { test: 123 },
           options: {},
           logger: makeLoggerMock({ fnMethod: vi.fn }),
-          request: makeRequestMock({ fnMethod: vi.fn }) as unknown as Request,
-          response: makeResponseMock({
-            fnMethod: vi.fn,
-          }) as unknown as Response,
+          request: makeRequestMock(),
+          response: makeResponseMock(),
         }),
       ).rejects.toThrow(InputValidationError);
     });
@@ -81,15 +78,15 @@ describe("Middleware", () => {
         handler: handlerMock,
       });
       const loggerMock = makeLoggerMock({ fnMethod: vi.fn });
-      const requestMock = makeRequestMock({ fnMethod: vi.fn });
-      const responseMock = makeResponseMock({ fnMethod: vi.fn });
+      const requestMock = makeRequestMock();
+      const responseMock = makeResponseMock();
       expect(
         await mw.execute({
           input: { test: "something" },
           options: { opt: "anything " },
           logger: loggerMock,
-          request: requestMock as unknown as Request,
-          response: responseMock as unknown as Response,
+          request: requestMock,
+          response: responseMock,
         }),
       ).toEqual({ result: "test" });
       expect(handlerMock).toHaveBeenCalledWith({

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -64,7 +64,7 @@ describe("Middleware", () => {
         mw.execute({
           input: { test: 123 },
           options: {},
-          logger: makeLoggerMock({ fnMethod: vi.fn }),
+          logger: makeLoggerMock(),
           request: makeRequestMock(),
           response: makeResponseMock(),
         }),
@@ -77,7 +77,7 @@ describe("Middleware", () => {
         input: z.object({ test: z.string() }),
         handler: handlerMock,
       });
-      const loggerMock = makeLoggerMock({ fnMethod: vi.fn });
+      const loggerMock = makeLoggerMock();
       const requestMock = makeRequestMock();
       const responseMock = makeResponseMock();
       expect(

--- a/tests/unit/peer-helpers.spec.ts
+++ b/tests/unit/peer-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { MissingPeerError } from "../../src";
-import { loadAlternativePeer, loadPeer } from "../../src/peer-helpers";
+import { loadPeer } from "../../src/peer-helpers";
 import { describe, expect, test } from "vitest";
 
 describe("Peer loading helpers", () => {
@@ -10,27 +10,6 @@ describe("Peer loading helpers", () => {
     test("should throw when module not found", async () => {
       await expect(async () => loadPeer("missing")).rejects.toThrow(
         new MissingPeerError("missing"),
-      );
-    });
-  });
-
-  describe("loadAltPeer()", () => {
-    test("should load an alternative module", async () => {
-      expect(
-        await loadAlternativePeer([
-          { moduleName: "vitest", moduleExport: "vi" },
-          { moduleName: "@jest/globals", moduleExport: "jest" },
-        ]),
-      ).toBeTruthy();
-    });
-    test("should throw when no alternatives found", async () => {
-      await expect(async () =>
-        loadAlternativePeer([
-          { moduleName: "@jest/globals" },
-          { moduleName: "@also/missing" },
-        ]),
-      ).rejects.toThrow(
-        new MissingPeerError(["@jest/globals", "@also/missing"]),
       );
     });
   });

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -68,8 +68,8 @@ describe("ResultHandler", () => {
   });
 
   const requestMock = makeRequestMock({
-    fnMethod: vi.fn,
-    requestProps: { method: "POST", url: "http://something/v1/anything" },
+    method: "POST",
+    url: "http://something/v1/anything",
   });
 
   describe.each([

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -129,7 +129,7 @@ describe("ResultHandler", () => {
         response: responseMock,
         logger: loggerMock,
       });
-      expect(loggerMock._getLogs().error).toEqual([]);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(responseMock._getStatusCode()).toBe(400);
       expect(responseMock._getData()).toMatchSnapshot();
     });
@@ -146,7 +146,7 @@ describe("ResultHandler", () => {
         response: responseMock,
         logger: loggerMock,
       });
-      expect(loggerMock._getLogs().error).toEqual([]);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(responseMock._getStatusCode()).toBe(404);
       expect(responseMock._getData()).toMatchSnapshot();
     });
@@ -163,7 +163,7 @@ describe("ResultHandler", () => {
         response: responseMock,
         logger: loggerMock,
       });
-      expect(loggerMock._getLogs().error).toEqual([]);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(responseMock._getStatusCode()).toBe(200);
       expect(responseMock._getData()).toMatchSnapshot();
     });
@@ -203,7 +203,7 @@ describe("ResultHandler", () => {
       response: responseMock,
       logger: loggerMock,
     });
-    expect(loggerMock._getLogs().error).toEqual([]);
+    expect(loggerMock._getLogs().error).toHaveLength(0);
     expect(responseMock._getStatusCode()).toBe(500);
     expect(responseMock._getData()).toMatchSnapshot();
   });

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -98,9 +98,7 @@ describe("ResultHandler", () => {
         [
           expect.stringMatching(/^Internal server error\nError: Some error/),
           {
-            payload: {
-              something: 453,
-            },
+            payload: { something: 453 },
             url: "http://something/v1/anything",
           },
         ],

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -375,7 +375,7 @@ describe("Routing", () => {
       await routeHandler(requestMock, responseMock, nextMock);
       expect(nextMock).toHaveBeenCalledTimes(0);
       expect(handlerMock).toHaveBeenCalledTimes(1);
-      expect(loggerMock._getLogs().error).toEqual([]);
+      expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(handlerMock).toHaveBeenCalledWith({
         input: {
           test: 123,

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -236,10 +236,7 @@ describe("Routing", () => {
       expect(appMock.options.mock.calls[0][0]).toBe("/hello");
       const fn = appMock.options.mock.calls[0][1];
       expect(typeof fn).toBe("function"); // async (req, res) => void
-      const requestMock = makeRequestMock({
-        fnMethod: vi.fn,
-        requestProps: { method: "PUT" },
-      });
+      const requestMock = makeRequestMock({ method: "PUT" });
       const responseMock = makeResponseMock({ fnMethod: vi.fn });
       await fn(requestMock, responseMock);
       expect(responseMock.status).toHaveBeenCalledWith(200);
@@ -371,8 +368,8 @@ describe("Routing", () => {
       expect(appMock.post).toHaveBeenCalledTimes(1);
       const routeHandler = appMock.post.mock.calls[0][1] as RequestHandler;
       const requestMock = makeRequestMock({
-        fnMethod: vi.fn,
-        requestProps: { method: "POST", body: { test: 123 } },
+        method: "POST",
+        body: { test: 123 },
       });
       const responseMock = makeResponseMock({ fnMethod: vi.fn });
       const nextMock = vi.fn();
@@ -424,7 +421,7 @@ describe("Routing", () => {
       });
       expect(appMock.get).toHaveBeenCalledTimes(1);
       const routeHandler = appMock.get.mock.calls[0][1] as RequestHandler;
-      const requestMock = makeRequestMock({ fnMethod: vi.fn });
+      const requestMock = makeRequestMock();
       const responseMock = makeResponseMock({
         fnMethod: vi.fn,
         responseProps: {

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -53,13 +53,10 @@ describe("Server helpers", () => {
         new SyntaxError("Unexpected end of JSON input"),
         null as unknown as Request,
         makeResponseMock({
-          fnMethod: vi.fn,
-          responseProps: {
-            locals: {
-              [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
-            },
+          locals: {
+            [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
           },
-        }) as unknown as Response,
+        }),
         vi.fn<any>(),
       );
       expect(spy).toHaveBeenCalledTimes(1);
@@ -90,18 +87,11 @@ describe("Server helpers", () => {
         body: { n: 453 },
       });
       const responseMock = makeResponseMock({
-        fnMethod: vi.fn,
-        responseProps: {
-          locals: {
-            [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
-          },
+        locals: {
+          [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
         },
       });
-      await handler(
-        requestMock as unknown as Request,
-        responseMock as unknown as Response,
-        next,
-      );
+      await handler(requestMock, responseMock, next);
       expect(next).toHaveBeenCalledTimes(0);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy.mock.calls[0]).toHaveLength(1);
@@ -134,18 +124,12 @@ describe("Server helpers", () => {
         path: "/v1/test",
         body: { n: 453 },
       });
-      const responseMock = makeResponseMock({ fnMethod: vi.fn });
-      handler(
-        requestMock as unknown as Request,
-        responseMock as unknown as Response,
-        next,
-      );
+      const responseMock = makeResponseMock();
+      handler(requestMock, responseMock, next);
       expect(next).toHaveBeenCalledTimes(0);
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(responseMock.status).toHaveBeenCalledTimes(1);
-      expect(responseMock.status.mock.calls[0][0]).toBe(500);
-      expect(responseMock.end).toHaveBeenCalledTimes(1);
-      expect(responseMock.end.mock.calls[0][0]).toBe(
+      expect(responseMock._getStatusCode()).toBe(500);
+      expect(responseMock._getData()).toBe(
         "An error occurred while serving the result: I am faulty.\n" +
           "Original error: Can not POST /v1/test.",
       );
@@ -209,7 +193,7 @@ describe("Server helpers", () => {
       rootLogger,
     });
     const requestMock = makeRequestMock();
-    const responseMock = makeResponseMock({ fnMethod: vi.fn });
+    const responseMock = makeResponseMock();
     const nextMock = vi.fn();
 
     test("should return an array of RequestHandler", () => {
@@ -224,22 +208,14 @@ describe("Server helpers", () => {
       beforeUploadMock.mockImplementationOnce(() => {
         throw error;
       });
-      await parsers[0](
-        requestMock as unknown as Request,
-        responseMock as unknown as Response,
-        nextMock,
-      );
+      await parsers[0](requestMock, responseMock, nextMock);
       expect(nextMock).toHaveBeenCalledWith(error);
     });
 
     test("should install the uploader with its special logger", async () => {
       const interalMw = vi.fn();
       fileUploadMock.mockImplementationOnce(() => interalMw);
-      await parsers[0](
-        requestMock as unknown as Request,
-        responseMock as unknown as Response,
-        nextMock,
-      );
+      await parsers[0](requestMock, responseMock, nextMock);
       expect(beforeUploadMock).toHaveBeenCalledWith({
         request: requestMock,
         logger: rootLogger,
@@ -268,7 +244,7 @@ describe("Server helpers", () => {
         body: buffer,
       });
       const nextMock = vi.fn();
-      moveRaw(requestMock as unknown as Request, {} as Response, nextMock);
+      moveRaw(requestMock, makeResponseMock(), nextMock);
       expect(requestMock.body).toEqual({ raw: buffer });
       expect(nextMock).toHaveBeenCalled();
     });

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -22,7 +22,7 @@ import createHttpError from "http-errors";
 describe("Server helpers", () => {
   describe("createParserFailureHandler()", () => {
     test("the handler should call next if there is no error", () => {
-      const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+      const rootLogger = makeLoggerMock();
       const handler = createParserFailureHandler({
         errorHandler: defaultResultHandler,
         rootLogger,
@@ -44,7 +44,7 @@ describe("Server helpers", () => {
         handler: vi.fn(),
       });
       const spy = vi.spyOn(errorHandler, "execute");
-      const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+      const rootLogger = makeLoggerMock({ isRoot: true });
       const handler = createParserFailureHandler({
         errorHandler,
         rootLogger,
@@ -54,7 +54,7 @@ describe("Server helpers", () => {
         null as unknown as Request,
         makeResponseMock({
           locals: {
-            [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
+            [metaSymbol]: { logger: makeLoggerMock({ isChild: true }) },
           },
         }),
         vi.fn<any>(),
@@ -75,7 +75,7 @@ describe("Server helpers", () => {
         handler: vi.fn(),
       });
       const spy = vi.spyOn(errorHandler, "execute");
-      const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+      const rootLogger = makeLoggerMock({ isRoot: true });
       const handler = createNotFoundHandler({
         errorHandler,
         rootLogger,
@@ -88,7 +88,7 @@ describe("Server helpers", () => {
       });
       const responseMock = makeResponseMock({
         locals: {
-          [metaSymbol]: { logger: { ...rootLogger, isChild: true } },
+          [metaSymbol]: { logger: makeLoggerMock({ isChild: true }) },
         },
       });
       await handler(requestMock, responseMock, next);
@@ -107,7 +107,7 @@ describe("Server helpers", () => {
     });
 
     test("should call Last Resort Handler in case of ResultHandler is faulty", () => {
-      const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+      const rootLogger = makeLoggerMock();
       const errorHandler = new ResultHandler({
         positive: vi.fn(),
         negative: vi.fn(),
@@ -163,19 +163,19 @@ describe("Server helpers", () => {
   });
 
   describe("createUploadLogger()", () => {
-    const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+    const rootLogger = makeLoggerMock();
     const uploadLogger = createUploadLogger(rootLogger);
 
     test("should debug the messages", () => {
       uploadLogger.log("Express-file-upload: Busboy finished parsing request.");
-      expect(rootLogger.debug).toHaveBeenCalledWith(
-        "Express-file-upload: Busboy finished parsing request.",
-      );
+      expect(rootLogger._getLogs().debug).toEqual([
+        ["Express-file-upload: Busboy finished parsing request."],
+      ]);
     });
   });
 
   describe("createUploadParsers()", async () => {
-    const rootLogger = makeLoggerMock({ fnMethod: vi.fn });
+    const rootLogger = makeLoggerMock();
     const beforeUploadMock = vi.fn();
     const parsers = await createUploadParsers({
       config: {

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -85,12 +85,9 @@ describe("Server helpers", () => {
       });
       const next = vi.fn();
       const requestMock = makeRequestMock({
-        fnMethod: vi.fn,
-        requestProps: {
-          method: "POST",
-          path: "/v1/test",
-          body: { n: 453 },
-        },
+        method: "POST",
+        path: "/v1/test",
+        body: { n: 453 },
       });
       const responseMock = makeResponseMock({
         fnMethod: vi.fn,
@@ -133,12 +130,9 @@ describe("Server helpers", () => {
       });
       const next = vi.fn();
       const requestMock = makeRequestMock({
-        fnMethod: vi.fn,
-        requestProps: {
-          method: "POST",
-          path: "/v1/test",
-          body: { n: 453 },
-        },
+        method: "POST",
+        path: "/v1/test",
+        body: { n: 453 },
       });
       const responseMock = makeResponseMock({ fnMethod: vi.fn });
       handler(
@@ -214,7 +208,7 @@ describe("Server helpers", () => {
       },
       rootLogger,
     });
-    const requestMock = makeRequestMock({ fnMethod: vi.fn });
+    const requestMock = makeRequestMock();
     const responseMock = makeResponseMock({ fnMethod: vi.fn });
     const nextMock = vi.fn();
 
@@ -270,11 +264,8 @@ describe("Server helpers", () => {
     test("should place the body into the raw prop of the body object", () => {
       const buffer = Buffer.from([]);
       const requestMock = makeRequestMock({
-        fnMethod: vi.fn,
-        requestProps: {
-          method: "POST",
-          body: buffer,
-        },
+        method: "POST",
+        body: buffer,
       });
       const nextMock = vi.fn();
       moveRaw(requestMock as unknown as Request, {} as Response, nextMock);

--- a/tests/unit/testing.spec.ts
+++ b/tests/unit/testing.spec.ts
@@ -9,52 +9,45 @@ declare module "../../src" {
 
 describe("Testing", () => {
   describe("testEndpoint()", () => {
-    test.each([undefined, vi.fn])(
-      "Should test the endpoint %#",
-      async (fnMethod) => {
-        const endpoint = defaultEndpointsFactory
-          .addMiddleware({
-            input: z.object({}),
-            handler: async ({ response }) => {
-              response
-                .setHeader("X-Some", "header")
-                .header("X-Another", "header as well")
-                .send("this is just for testing mocked methods");
-              return {};
-            },
-          })
-          .build({
-            method: "get",
-            input: z.object({}),
-            output: z.object({}),
-            handler: async () => ({}),
-          });
-        const { responseMock, requestMock, loggerMock } = await testEndpoint({
-          endpoint,
-          responseOptions: { locals: { prop1: vi.fn(), prop2: 123 } },
-          requestProps: { test1: vi.fn(), test2: 456 },
-          loggerProps: { feat1: vi.fn(), feat2: 789 },
-          fnMethod,
+    test("Should test the endpoint", async () => {
+      const endpoint = defaultEndpointsFactory
+        .addMiddleware({
+          input: z.object({}),
+          handler: async ({ response }) => {
+            response
+              .setHeader("X-Some", "header")
+              .header("X-Another", "header as well")
+              .send("this is just for testing mocked methods");
+            return {};
+          },
+        })
+        .build({
+          method: "get",
+          input: z.object({}),
+          output: z.object({}),
+          handler: async () => ({}),
         });
-        expect(responseMock._getHeaders()).toEqual({
-          "x-some": "header",
-          "x-another": "header as well",
-        });
-        expect(responseMock._getData()).toBe(
-          "this is just for testing mocked methods",
-        );
-        expect(responseMock.locals).toHaveProperty(
-          "prop1",
-          expect.any(Function),
-        );
-        expect(responseMock.locals).toHaveProperty("prop2", 123);
-        expect(requestMock.test1).toEqual(expect.any(Function));
-        expect(requestMock.test2).toBe(456);
-        expect(loggerMock.feat1).toEqual(expect.any(Function));
-        expect(loggerMock.feat2).toBe(789);
-        expectType<Mock>(requestMock.test1);
-        expectType<Mock>(loggerMock.feat1);
-      },
-    );
+      const { responseMock, requestMock, loggerMock } = await testEndpoint({
+        endpoint,
+        responseOptions: { locals: { prop1: vi.fn(), prop2: 123 } },
+        requestProps: { test1: vi.fn(), test2: 456 },
+        loggerProps: { feat1: vi.fn(), feat2: 789 },
+      });
+      expect(responseMock._getHeaders()).toEqual({
+        "x-some": "header",
+        "x-another": "header as well",
+      });
+      expect(responseMock._getData()).toBe(
+        "this is just for testing mocked methods",
+      );
+      expect(responseMock.locals).toHaveProperty("prop1", expect.any(Function));
+      expect(responseMock.locals).toHaveProperty("prop2", 123);
+      expect(requestMock.test1).toEqual(expect.any(Function));
+      expect(requestMock.test2).toBe(456);
+      expect(loggerMock.feat1).toEqual(expect.any(Function));
+      expect(loggerMock.feat2).toBe(789);
+      expectType<Mock>(requestMock.test1);
+      expectType<Mock>(loggerMock.feat1);
+    });
   });
 });

--- a/tests/unit/testing.spec.ts
+++ b/tests/unit/testing.spec.ts
@@ -31,26 +31,27 @@ describe("Testing", () => {
           });
         const { responseMock, requestMock, loggerMock } = await testEndpoint({
           endpoint,
-          responseProps: { prop1: vi.fn(), prop2: 123 },
+          responseOptions: { locals: { prop1: vi.fn(), prop2: 123 } },
           requestProps: { test1: vi.fn(), test2: 456 },
           loggerProps: { feat1: vi.fn(), feat2: 789 },
           fnMethod,
         });
-        expect(responseMock.setHeader).toHaveBeenCalledWith("X-Some", "header");
-        expect(responseMock.header).toHaveBeenCalledWith(
-          "X-Another",
-          "header as well",
-        );
-        expect(responseMock.send).toHaveBeenCalledWith(
+        expect(responseMock._getHeaders()).toEqual({
+          "x-some": "header",
+          "x-another": "header as well",
+        });
+        expect(responseMock._getData()).toBe(
           "this is just for testing mocked methods",
         );
-        expect(responseMock.prop1).toEqual(expect.any(Function));
-        expect(responseMock.prop2).toBe(123);
+        expect(responseMock.locals).toHaveProperty(
+          "prop1",
+          expect.any(Function),
+        );
+        expect(responseMock.locals).toHaveProperty("prop2", 123);
         expect(requestMock.test1).toEqual(expect.any(Function));
         expect(requestMock.test2).toBe(456);
         expect(loggerMock.feat1).toEqual(expect.any(Function));
         expect(loggerMock.feat2).toBe(789);
-        expectType<Mock>(responseMock.prop1);
         expectType<Mock>(requestMock.test1);
         expectType<Mock>(loggerMock.feat1);
       },

--- a/tests/unit/testing.spec.ts
+++ b/tests/unit/testing.spec.ts
@@ -3,10 +3,6 @@ import { z } from "zod";
 import { defaultEndpointsFactory, testEndpoint } from "../../src";
 import { Mock, describe, expect, test, vi } from "vitest";
 
-declare module "../../src" {
-  interface MockOverrides extends Mock {}
-}
-
 describe("Testing", () => {
   describe("testEndpoint()", () => {
     test("Should test the endpoint", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,7 +765,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*", "@types/express@^4.17.17":
+"@types/express@*", "@types/express@^4.17.17", "@types/express@^4.17.21":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
   integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
@@ -799,6 +799,13 @@
   version "20.12.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.12.tgz#7cbecdf902085cec634fdb362172dfe12b8f2050"
   integrity sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^20.10.6":
+  version "20.12.13"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.12.13.tgz#90ed3b8a4e52dd3c5dc5a42dde5b85b74ad8ed88"
+  integrity sha512-gBGeanV41c1L171rR7wjbMiEpEI/l5XFQdLLfhr/REwpgDy/4U8y89+i8kRiLzDyZdOkXh+cRaTetUnCYutoXA==
   dependencies:
     undici-types "~5.26.4"
 
@@ -994,7 +1001,7 @@
     loupe "^2.3.7"
     pretty-format "^29.7.0"
 
-accepts@~1.3.5, accepts@~1.3.8:
+accepts@^1.3.7, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -1413,7 +1420,7 @@ confbox@^0.1.7:
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.7.tgz#ccfc0a2bcae36a84838e83a3b7f770fb17d6c579"
   integrity sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==
 
-content-disposition@0.5.4:
+content-disposition@0.5.4, content-disposition@^0.5.3:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -1523,6 +1530,11 @@ depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+depd@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -2047,7 +2059,7 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
@@ -2718,6 +2730,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
 
+merge-descriptors@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -2728,7 +2745,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -2753,7 +2770,7 @@ mime-types@~2.1.24, mime-types@~2.1.34:
   dependencies:
     mime-db "1.52.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.3.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -2869,6 +2886,24 @@ node-emoji@^2.1.3:
     char-regex "^1.0.2"
     emojilib "^2.4.0"
     skin-tone "^2.0.0"
+
+node-mocks-http@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.14.1.tgz#6a387ce09229fe545dcc0154d16bc3480618e013"
+  integrity sha512-mfXuCGonz0A7uG1FEjnypjm34xegeN5+HI6xeGhYKecfgaZhjsmYoLE9LEFmT+53G1n8IuagPZmVnEL/xNsFaA==
+  dependencies:
+    "@types/express" "^4.17.21"
+    "@types/node" "^20.10.6"
+    accepts "^1.3.7"
+    content-disposition "^0.5.3"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    parseurl "^1.3.3"
+    range-parser "^1.2.0"
+    type-is "^1.6.18"
 
 node-releases@^2.0.14:
   version "2.0.14"
@@ -3050,7 +3085,7 @@ parse5@^6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseurl@~1.3.3:
+parseurl@^1.3.3, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -3222,7 +3257,7 @@ ramda@^0.30.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.30.0.tgz#3cc4f0ddddfa6334dad2f371bd72c33237d92cd0"
   integrity sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q==
 
-range-parser@~1.2.1:
+range-parser@^1.2.0, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
@@ -3859,7 +3894,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-is@~1.6.18:
+type-is@^1.6.18, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==


### PR DESCRIPTION
Based on discussion #1799

During the time of `testEndpoint` exists I've got 3 feedback from users struggling to set it up correctly or being confused by the way it's organized. I'd like to make it easier to use due to that fact.

I'm going to change the way `testEndpont()` works. Instead of using mocking functions from testing frameworks, I will use the library that mocks request and response completely.

- This enables a fully functional `request` object.
- This affects the way assertions on `response` should be made: using new methods `_getStatusCode()`, `_getData()` and `_getHeaders()`.
- Logger mocking will be also changed for consistency.