### PR TITLE
Detach from `jest` and `vitest` peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,6 @@ Therefore, many basic tasks can be accomplished faster and easier, in particular
   - Client side types — inspired by [zod-to-ts](https://github.com/sachinraja/zod-to-ts).
 - File uploads — [Express-FileUpload](https://github.com/richardgirges/express-fileupload)
   (based on [Busboy](https://github.com/mscdex/busboy)).
-- Supports any testing framework having a function mocking method;
-  - [Jest](https://github.com/jestjs/jest) and [Vitest](https://github.com/vitest-dev/vitest)
-    are both supported automatically.
 
 ## Concept
 

--- a/package.json
+++ b/package.json
@@ -76,16 +76,13 @@
     "@types/express": "^4.17.13",
     "@types/express-fileupload": "^1.5.0",
     "@types/http-errors": "^2.0.2",
-    "@types/jest": "*",
     "@types/node": "*",
     "compression": "^1.7.4",
     "express": "^4.19.2",
     "express-fileupload": "^1.5.0",
     "http-errors": "^2.0.0",
-    "jest": ">=28 <30",
     "prettier": "^3.1.0",
     "typescript": "^5.1.3",
-    "vitest": "^1.0.4",
     "zod": "^3.23.0"
   },
   "peerDependenciesMeta": {
@@ -104,22 +101,13 @@
     "@types/node": {
       "optional": true
     },
-    "@types/jest": {
-      "optional": true
-    },
     "compression": {
       "optional": true
     },
     "express-fileupload": {
       "optional": true
     },
-    "jest": {
-      "optional": true
-    },
     "prettier": {
-      "optional": true
-    },
-    "vitest": {
       "optional": true
     }
   },


### PR DESCRIPTION
Due to #1800 

Testing framework does not really matter after that since no longer using its mocks.