### PR TITLE
Add `eslint` group to dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/js"
       typescript-eslint:
         patterns:
           - "typescript-eslint"


### PR DESCRIPTION
Due to
- #1808 
- #1811 