### PR TITLE
Entrypoint for migration

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -76,6 +76,13 @@ jobs:
         max_attempts: 3
         on_retry_command: yarn config set registry https://registry.npmjs.org
         command: yarn test:952
+    - name: Compatibility test
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 15
+        max_attempts: 3
+        on_retry_command: yarn config set registry https://registry.npmjs.org
+        command: yarn test:compat
   finish:
     needs: build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+migration
 yarn-error.log
 .idea
 .npmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 ```js
 // eslint.config.mjs — minimal config to apply migrations automatically using "eslint --fix" (at least ESLint 8)
 import parser from "@typescript-eslint/parser";
-import { migration } from "express-zod-api";
+import migration from "express-zod-api/migration";
 
 export default [{ languageOptions: { parser } }, migration];
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default [
   prettierOverrides,
   prettierRules,
   // Things to turn off globally
-  { ignores: ["dist/", "coverage/"] },
+  { ignores: ["dist/", "coverage/", "migration/"] },
   {
     rules: {
       "no-empty": ["error", { allowEmptyCatch: true }],

--- a/package.json
+++ b/package.json
@@ -55,10 +55,21 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./migration": {
+      "import": {
+        "types": "./migration/index.d.ts",
+        "default": "./migration/index.js"
+      },
+      "require": {
+        "types": "./migration/index.d.cts",
+        "default": "./migration/index.cjs"
+      }
     }
   },
   "files": [
     "dist",
+    "migration",
     "*.md"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:cjs": "yarn --cwd tests/cjs && vitest run -r tests/cjs",
     "test:esm": "yarn --cwd tests/esm && vitest run -r tests/esm",
     "test:952": "yarn --cwd tests/issue952 && yarn --cwd tests/issue952 test",
+    "test:compat": "yarn --cwd tests/compat && yarn --cwd tests/compat test",
     "bench": "vitest bench --run tests/bench",
     "lint": "eslint && yarn prettier *.md --check",
     "mdfix": "prettier *.md --write",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ export { testEndpoint } from "./testing";
 export { Integration } from "./integration";
 
 export { ez } from "./proprietary-schemas";
-export { migration } from "./migration";
 
 // Convenience types
 export type { Depicter } from "./documentation-helpers";

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -131,7 +131,7 @@ const v20: Rule.RuleModule = {
 const rules = { v20 };
 
 /** @desc ESLint flat config entry for migrating to this version (from previous), requires at least ESLint 8 */
-export const migration = {
+export default {
   rules: { "ez-migration/v20": "error" },
   plugins: { [pluginName]: { rules } },
 } satisfies Linter.FlatConfig<

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -130,7 +130,13 @@ const v20: Rule.RuleModule = {
 
 const rules = { v20 };
 
-/** @desc ESLint flat config entry for migrating to this version (from previous), requires at least ESLint 8 */
+/**
+ * @desc ESLint flat config entry for migrating to this version (from previous), requires at least ESLint 8 or higher
+ * @example // eslint.config.mjs:
+ * @example import parser from "@typescript-eslint/parser";
+ * @example import migration from "express-zod-api/migration";
+ * @example export default [{ languageOptions: { parser } }, migration];
+ * */
 export default {
   rules: { "ez-migration/v20": "error" },
   plugins: { [pluginName]: { rules } },

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -132,10 +132,11 @@ const rules = { v20 };
 
 /**
  * @desc ESLint flat config entry for migrating to this version (from previous), requires at least ESLint 8 or higher
- * @example // eslint.config.mjs:
- * @example import parser from "@typescript-eslint/parser";
- * @example import migration from "express-zod-api/migration";
- * @example export default [{ languageOptions: { parser } }, migration];
+ * @example
+ *          // eslint.config.mjs:
+ *          import parser from "@typescript-eslint/parser";
+ *          import migration from "express-zod-api/migration";
+ *          export default [{ languageOptions: { parser } }, migration];
  * */
 export default {
   rules: { "ez-migration/v20": "error" },

--- a/tests/compat/eslint.config.js
+++ b/tests/compat/eslint.config.js
@@ -1,0 +1,4 @@
+import parser from "@typescript-eslint/parser";
+import migration from "express-zod-api/migration";
+
+export default [{ languageOptions: { parser } }, migration];

--- a/tests/compat/package.json
+++ b/tests/compat/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "express-zod-api-compat-test",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "dependencies": {
+    "express-zod-api": "link:../..",
+    "eslint": "^8.57.0"
+  },
+  "scripts": {
+    "test": "eslint --debug"
+  }
+}

--- a/tests/unit/__snapshots__/index.spec.ts.snap
+++ b/tests/unit/__snapshots__/index.spec.ts.snap
@@ -68,27 +68,6 @@ exports[`Index Entrypoint > exports > getMessageFromError should have certain va
 
 exports[`Index Entrypoint > exports > getStatusCodeFromError should have certain value 1`] = `[Function]`;
 
-exports[`Index Entrypoint > exports > migration should have certain value 1`] = `
-{
-  "plugins": {
-    "ez-migration": {
-      "rules": {
-        "v20": {
-          "create": [Function],
-          "meta": {
-            "fixable": "code",
-            "type": "problem",
-          },
-        },
-      },
-    },
-  },
-  "rules": {
-    "ez-migration/v20": "error",
-  },
-}
-`;
-
 exports[`Index Entrypoint > exports > should have certain entities exposed 1`] = `
 [
   "createConfig",
@@ -116,7 +95,6 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "testEndpoint",
   "Integration",
   "ez",
-  "migration",
 ]
 `;
 

--- a/tests/unit/__snapshots__/migration.spec.ts.snap
+++ b/tests/unit/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Migration > should consist of one rule 1`] = `
+{
+  "plugins": {
+    "ez-migration": {
+      "rules": {
+        "v20": {
+          "create": [Function],
+          "meta": {
+            "fixable": "code",
+            "type": "problem",
+          },
+        },
+      },
+    },
+  },
+  "rules": {
+    "ez-migration/v20": "error",
+  },
+}
+`;

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -1,5 +1,5 @@
 import { RuleTester } from "eslint";
-import { migration } from "../../src/migration";
+import migration from "../../src/migration";
 import { describe, test, expect } from "vitest";
 import parser from "@typescript-eslint/parser";
 

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from "eslint";
-import { migration } from "../../src";
-import { describe, test } from "vitest";
+import { migration } from "../../src/migration";
+import { describe, test, expect } from "vitest";
 import parser from "@typescript-eslint/parser";
 
 const tester = new RuleTester({
@@ -8,6 +8,10 @@ const tester = new RuleTester({
 });
 
 describe("Migration", () => {
+  test("should consist of one rule", () => {
+    expect(migration).toMatchSnapshot();
+  });
+
   test("should pass ESLint rule tester", () => {
     tester.run("v20", migration.plugins["ez-migration"].rules.v20, {
       valid: [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,5 @@
-import { renameSync, statSync } from "node:fs";
 import { defineConfig, Options } from "tsup";
 import { version } from "./package.json";
-import { waitFor } from "./tests/helpers";
 
 const commons: Options = {
   format: ["cjs", "esm"],
@@ -33,17 +31,7 @@ export default defineConfig([
   },
   {
     ...commons,
-    entry: ["src/migration.ts"],
+    entry: { index: "src/migration.ts" },
     outDir: "migration",
-    onSuccess: async () => {
-      for (const ext of ["js", "d.ts", "cjs", "d.cts"]) {
-        const subject = `migration/migration.${ext}`;
-        await waitFor(
-          () => statSync(subject, { throwIfNoEntry: false })?.isFile() || false,
-        );
-        renameSync(subject, `migration/index.${ext}`);
-        console.log(subject);
-      }
-    },
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -33,5 +33,7 @@ export default defineConfig([
     ...commons,
     entry: { index: "src/migration.ts" },
     outDir: "migration",
+    // @see https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+    dts: { footer: `export = _default;` },
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,26 +1,49 @@
-import { defineConfig } from "tsup";
+import { renameSync, statSync } from "node:fs";
+import { defineConfig, Options } from "tsup";
 import { version } from "./package.json";
+import { waitFor } from "./tests/helpers";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
+const commons: Options = {
   format: ["cjs", "esm"],
   splitting: false,
   sourcemap: false,
   clean: true,
   dts: true,
   minify: true,
-  esbuildOptions: (options, { format }) => {
-    options.supported = {};
-    if (format === "cjs") {
-      /**
-       * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest
-       * @example jest with ts-jest
-       * @link https://github.com/evanw/esbuild/issues/2651
-       */
-      options.supported["dynamic-import"] = false;
-    }
-    options.define = {
-      "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
-    };
+};
+
+export default defineConfig([
+  {
+    ...commons,
+    entry: ["src/index.ts"],
+    esbuildOptions: (options, { format }) => {
+      options.supported = {};
+      if (format === "cjs") {
+        /**
+         * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest
+         * @example jest with ts-jest
+         * @link https://github.com/evanw/esbuild/issues/2651
+         */
+        options.supported["dynamic-import"] = false;
+      }
+      options.define = {
+        "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
+      };
+    },
   },
-});
+  {
+    ...commons,
+    entry: ["src/migration.ts"],
+    outDir: "migration",
+    onSuccess: async () => {
+      for (const ext of ["js", "d.ts", "cjs", "d.cts"]) {
+        const subject = `migration/migration.${ext}`;
+        await waitFor(
+          () => statSync(subject, { throwIfNoEntry: false })?.isFile() || false,
+        );
+        renameSync(subject, `migration/index.${ext}`);
+        console.log(subject);
+      }
+    },
+  },
+]);


### PR DESCRIPTION
This should detach the migration helper from the actual library code and make it easier to maintain and drop if needed.