### PR TITLE
Ungroup `@eslint/js`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "@eslint/js"
       typescript-eslint:
         patterns:
           - "typescript-eslint"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.0",
-    "@eslint/js": "^9.3.0",
     "@tsconfig/node18": "^18.2.1",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,7 +379,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.5.0", "@eslint/js@^9.3.0":
+"@eslint/js@9.5.0":
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.5.0.tgz#0e9c24a670b8a5c86bff97b40be13d8d8f238045"
   integrity sha512-A7+AOT2ICkodvtsWnxZP4Xxk3NbZ3VMHd8oihydLRGrJgqqdEz1qSeEgXYyT/Cu8h1TWWsQRejIx48mtjZ5y1w==


### PR DESCRIPTION
`eslint` installs its dependency `@eslint/js` by itself.