### PR TITLE
Set `vitest` `pool` back to `threads`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     env: {
       FORCE_COLOR: "1",
     },
+    pool: "threads",
     testTimeout: 10000,
     reporters: "basic",
     coverage: {


### PR DESCRIPTION
The default was changed to `forks` in v2