### PR TITLE
Revert "CI: Avoiding Node 22.5"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,6 @@ jobs:
       id: setup-node
       uses: actions/setup-node@v4
       with:
-        check-latest: true
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules
       uses: actions/cache@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.18.0, 18.x, 20.9.0, 20.x, 22.0.0, 22.4]
+        node-version: [18.18.0, 18.x, 20.9.0, 20.x, 22.0.0, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - name: Get yarn cache dir

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,6 +27,7 @@ jobs:
       id: setup-node
       uses: actions/setup-node@v4
       with:
+        check-latest: true
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules
       uses: actions/cache@v4


### PR DESCRIPTION
Reverts RobinTail/express-zod-api#1920

Seems to be fixed in 22.5.1