### PR TITLE
Better `tsup` config for CJS build of migration

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, Options } from "tsup";
 import { version } from "./package.json";
 
 const commons: Options = {
+  format: ["cjs", "esm"],
   splitting: false,
   sourcemap: false,
   clean: true,
@@ -9,16 +10,9 @@ const commons: Options = {
   minify: true,
 };
 
-const migration: Options = {
-  ...commons,
-  entry: { index: "src/migration.ts" },
-  outDir: "migration",
-};
-
 export default defineConfig([
   {
     ...commons,
-    format: ["cjs", "esm"],
     entry: ["src/index.ts"],
     esbuildOptions: (options, { format }) => {
       options.supported = {};
@@ -36,13 +30,9 @@ export default defineConfig([
     },
   },
   {
-    ...migration,
-    format: "esm",
-  },
-  {
-    ...migration,
-    format: "cjs",
-    // @see https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
-    dts: { footer: `export = _default;` },
+    ...commons,
+    entry: { index: "src/migration.ts" },
+    outDir: "migration",
+    cjsInterop: true, // @see https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -33,6 +33,10 @@ export default defineConfig([
     ...commons,
     entry: { index: "src/migration.ts" },
     outDir: "migration",
-    cjsInterop: true, // @see https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+    /**
+     * This replaces "export { _default as default }" with "export = _default" in the CJS DTS build
+     * @link https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+     * */
+    cjsInterop: true,
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,7 +15,7 @@ export default defineConfig([
     ...commons,
     entry: ["src/index.ts"],
     esbuildOptions: (options, { format }) => {
-      options.supported = {};
+      options.supported = options.supported || {};
       if (format === "cjs") {
         /**
          * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest


### PR DESCRIPTION
I found an option for what I've been doing manually.