### PR TITLE
Replacing ESLint `import-x` plugin with `no-restricted-imports`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,3 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/coverage-istanbul"
-      typescript-eslint:
-        patterns:
-          - "typescript-eslint"
-          - "@typescript-eslint/utils"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,14 +5,18 @@ import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
 import manifest from "./package.json" with { type: "json" };
+import { reject, startsWith, partition } from "ramda";
 
-const dependencies = Object.keys(manifest.dependencies);
-const peers = Object.keys(manifest.peerDependencies).filter(
-  (peer) => !peer.startsWith("@types/"),
-);
-const allowed = dependencies.concat(peers);
-const typeOnly = ["eslint", "prettier"];
+const excludeTypes = reject(startsWith("@types/"));
+const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
+const isOptional = (name) => manifest.peerDependenciesMeta[name]?.optional;
+const [optPeers, reqPeers] = partition(isOptional, allPeers);
+const production = Object.keys(manifest.dependencies);
+const allowed = production.concat(reqPeers);
+const typeOnly = optPeers.concat(["eslint", "prettier"]);
+
 console.debug("Allowed imports", allowed);
+console.debug("Type only imports", typeOnly);
 
 export default [
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,8 +4,12 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
-import manifest from "./package.json" assert { type: "json" }; // @todo use "with" after Node 18.20 and 20.10
+
+import { readFile } from "node:fs/promises";
 import { reject, startsWith, partition } from "ramda";
+
+// @todo consider "import with" starting Node 18.20 and 20.10
+const manifest = JSON.parse(await readFile("./package.json", "utf-8"));
 
 const unlistedPeers = ["eslint", "prettier"];
 const excludeTypes = reject(startsWith("@types/"));

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,12 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
-import { allowed, typeOnly } from "./tools/allowed-deps.js";
+import { getDependencies } from "./tools/allowed-deps.js";
+
+const { allowed, typeOnly } = await getDependencies("./package.json", [
+  "eslint",
+  "prettier",
+]);
 
 export default [
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,15 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
+import manifest from "./package.json" with { type: "json" };
+
+const dependencies = Object.keys(manifest.dependencies);
+const peers = Object.keys(manifest.peerDependencies).filter(
+  (peer) => !peer.startsWith("@types/"),
+);
+const allowed = dependencies.concat(peers);
+const typeOnly = ["eslint", "prettier"];
+console.debug("Allowed imports", allowed);
 
 export default [
   {
@@ -34,7 +43,13 @@ export default [
   {
     files: ["src/*.ts"],
     rules: {
-      "@typescript-eslint/no-restricted-imports": ["error", { paths: [] }], // @todo
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [{ regex: `^(?!\\.|node:)(?!${allowed.join("|")}).+$` }],
+          paths: typeOnly.map((name) => ({ name, allowTypeImports: true })),
+        },
+      ],
     },
   },
   // For tests

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,15 +6,16 @@ import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
 
 import { readFile } from "node:fs/promises";
-import { reject, startsWith, partition } from "ramda";
+import { reject, startsWith, partition, path, flip } from "ramda";
 
 // @todo consider "import with" starting Node 18.20 and 20.10
 const manifest = JSON.parse(await readFile("./package.json", "utf-8"));
 
 const unlistedPeers = ["eslint", "prettier"];
 const excludeTypes = reject(startsWith("@types/"));
+const lookup = flip(path)(manifest);
 const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
-const isOptional = (name) => manifest.peerDependenciesMeta[name]?.optional;
+const isOptional = (name) => lookup(["peerDependenciesMeta", name, "optional"]);
 const [optPeers, reqPeers] = partition(isOptional, allPeers);
 const production = Object.keys(manifest.dependencies);
 const allowed = production.concat(reqPeers);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
-import manifest from "./package.json" with { type: "json" };
+import manifest from "./package.json" assert { type: "json" }; // @todo use "with" after Node 18.20 and 20.10
 import { reject, startsWith, partition } from "ramda";
 
 const excludeTypes = reject(startsWith("@types/"));

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,10 +6,10 @@ import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
 import { getDependencies } from "./tools/allowed-deps.js";
 
-const { allowed, typeOnly } = await getDependencies("./package.json", [
-  "eslint",
-  "prettier",
-]);
+const unlisted = ["eslint", "prettier"];
+const { allowed, typeOnly } = await getDependencies("./package.json", unlisted);
+
+console.debug(allowed, typeOnly);
 
 export default [
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,13 +7,14 @@ import unicornPlugin from "eslint-plugin-unicorn";
 import manifest from "./package.json" assert { type: "json" }; // @todo use "with" after Node 18.20 and 20.10
 import { reject, startsWith, partition } from "ramda";
 
+const unlistedPeers = ["eslint", "prettier"];
 const excludeTypes = reject(startsWith("@types/"));
 const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
 const isOptional = (name) => manifest.peerDependenciesMeta[name]?.optional;
 const [optPeers, reqPeers] = partition(isOptional, allPeers);
 const production = Object.keys(manifest.dependencies);
 const allowed = production.concat(reqPeers);
-const typeOnly = optPeers.concat(["eslint", "prettier"]);
+const typeOnly = optPeers.concat(unlistedPeers);
 
 console.debug("Allowed imports", allowed);
 console.debug("Type only imports", typeOnly);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,19 +4,12 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
-import importPlugin from "eslint-plugin-import";
 
 export default [
   {
     languageOptions: { globals: globals.node },
     plugins: {
       unicorn: unicornPlugin,
-      import: importPlugin,
-    },
-    settings: {
-      // "import-x" plugin installed as "import", in order to suppress the warning from the typescript resolver
-      // @link https://github.com/import-js/eslint-import-resolver-typescript/issues/293
-      "import-x/resolver": { typescript: true, node: true },
     },
   },
   jsPlugin.configs.recommended,
@@ -35,16 +28,13 @@ export default [
   {
     rules: {
       "unicorn/prefer-node-protocol": "error",
-      "import/named": "error",
-      "import/export": "error",
-      "import/no-duplicates": "warn",
     },
   },
   // For the sources
   {
     files: ["src/*.ts"],
     rules: {
-      "import/no-extraneous-dependencies": "error",
+      "@typescript-eslint/no-restricted-imports": ["error", { paths: [] }], // @todo
     },
   },
   // For tests
@@ -67,7 +57,6 @@ export default [
     files: ["tests/*/quick-start.ts", "example/example.client.ts"],
     rules: {
       "prettier/prettier": "off",
-      "import/no-duplicates": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-object-type": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,25 +4,7 @@ import tsPlugin from "typescript-eslint";
 import prettierOverrides from "eslint-config-prettier";
 import prettierRules from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
-
-import { readFile } from "node:fs/promises";
-import { reject, startsWith, partition, path, flip } from "ramda";
-
-// @todo consider "import with" starting Node 18.20 and 20.10
-const manifest = JSON.parse(await readFile("./package.json", "utf-8"));
-
-const unlistedPeers = ["eslint", "prettier"];
-const excludeTypes = reject(startsWith("@types/"));
-const lookup = flip(path)(manifest);
-const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
-const isOptional = (name) => lookup(["peerDependenciesMeta", name, "optional"]);
-const [optPeers, reqPeers] = partition(isOptional, allPeers);
-const production = Object.keys(manifest.dependencies);
-const allowed = production.concat(reqPeers);
-const typeOnly = optPeers.concat(unlistedPeers);
-
-console.debug("Allowed imports", allowed);
-console.debug("Type only imports", typeOnly);
+import { allowed, typeOnly } from "./tools/allowed-deps.js";
 
 export default [
   {

--- a/package.json
+++ b/package.json
@@ -134,8 +134,6 @@
     "cors": "^2.8.5",
     "eslint": "^9.3.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "npm:eslint-plugin-import-x@^3.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^55.0.0",
     "express": "^4.19.2",
@@ -155,9 +153,6 @@
     "typescript-eslint": "^8.0.0",
     "vitest": "^2.0.3",
     "zod": "^3.23.0"
-  },
-  "resolutions": {
-    "**/@typescript-eslint/utils": "^8.0.0"
   },
   "keywords": [
     "nodejs",

--- a/tools/allowed-deps.js
+++ b/tools/allowed-deps.js
@@ -9,14 +9,13 @@ export const getDependencies = async (packageJson, unlistedPeers) => {
   const lookup = flip(path)(manifest);
   const isOptional = (name) =>
     lookup(["peerDependenciesMeta", name, "optional"]);
+
   const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
   const [optPeers, reqPeers] = partition(isOptional, allPeers);
   const production = Object.keys(manifest.dependencies);
-  const allowed = production.concat(reqPeers);
-  const typeOnly = optPeers.concat(unlistedPeers);
 
-  console.debug("Allowed imports", allowed);
-  console.debug("Type only imports", typeOnly);
-
-  return { allowed, typeOnly };
+  return {
+    allowed: production.concat(reqPeers),
+    typeOnly: optPeers.concat(unlistedPeers),
+  };
 };

--- a/tools/allowed-deps.js
+++ b/tools/allowed-deps.js
@@ -1,18 +1,22 @@
 import { readFile } from "node:fs/promises";
 import { reject, startsWith, partition, path, flip } from "ramda";
 
-// @todo consider "import with" starting Node 18.20 and 20.10
-const manifest = JSON.parse(await readFile("./package.json", "utf-8"));
-
-const unlistedPeers = ["eslint", "prettier"];
 const excludeTypes = reject(startsWith("@types/"));
-const lookup = flip(path)(manifest);
-const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
-const isOptional = (name) => lookup(["peerDependenciesMeta", name, "optional"]);
-const [optPeers, reqPeers] = partition(isOptional, allPeers);
-const production = Object.keys(manifest.dependencies);
-export const allowed = production.concat(reqPeers);
-export const typeOnly = optPeers.concat(unlistedPeers);
 
-console.debug("Allowed imports", allowed);
-console.debug("Type only imports", typeOnly);
+/** @todo make it a plugin later */
+export const getDependencies = async (packageJson, unlistedPeers) => {
+  const manifest = JSON.parse(await readFile(packageJson, "utf-8"));
+  const lookup = flip(path)(manifest);
+  const isOptional = (name) =>
+    lookup(["peerDependenciesMeta", name, "optional"]);
+  const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
+  const [optPeers, reqPeers] = partition(isOptional, allPeers);
+  const production = Object.keys(manifest.dependencies);
+  const allowed = production.concat(reqPeers);
+  const typeOnly = optPeers.concat(unlistedPeers);
+
+  console.debug("Allowed imports", allowed);
+  console.debug("Type only imports", typeOnly);
+
+  return { allowed, typeOnly };
+};

--- a/tools/allowed-deps.js
+++ b/tools/allowed-deps.js
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+import { reject, startsWith, partition, path, flip } from "ramda";
+
+// @todo consider "import with" starting Node 18.20 and 20.10
+const manifest = JSON.parse(await readFile("./package.json", "utf-8"));
+
+const unlistedPeers = ["eslint", "prettier"];
+const excludeTypes = reject(startsWith("@types/"));
+const lookup = flip(path)(manifest);
+const allPeers = excludeTypes(Object.keys(manifest.peerDependencies));
+const isOptional = (name) => lookup(["peerDependenciesMeta", name, "optional"]);
+const [optPeers, reqPeers] = partition(isOptional, allPeers);
+const production = Object.keys(manifest.dependencies);
+export const allowed = production.concat(reqPeers);
+export const typeOnly = optPeers.concat(unlistedPeers);
+
+console.debug("Allowed imports", allowed);
+console.debug("Type only imports", typeOnly);

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,7 +877,7 @@
     semver "^7.6.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/utils@8.0.0", "@typescript-eslint/utils@^7.4.0", "@typescript-eslint/utils@^8.0.0":
+"@typescript-eslint/utils@8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.0.0.tgz#1794d6f4b37ec253172a173dc938ae68651b9b99"
   integrity sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==
@@ -1404,13 +1404,6 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
@@ -1459,13 +1452,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
-  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
-  dependencies:
-    esutils "^2.0.2"
-
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -1500,14 +1486,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
-
-enhanced-resolve@^5.12.0:
-  version "5.17.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
-  integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1611,51 +1589,6 @@ eslint-config-prettier@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
-
-eslint-import-resolver-node@^0.3.9:
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"
-  integrity sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==
-  dependencies:
-    debug "^3.2.7"
-    is-core-module "^2.13.0"
-    resolve "^1.22.4"
-
-eslint-import-resolver-typescript@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz#7b983680edd3f1c5bce1a5829ae0bc2d57fe9efa"
-  integrity sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==
-  dependencies:
-    debug "^4.3.4"
-    enhanced-resolve "^5.12.0"
-    eslint-module-utils "^2.7.4"
-    fast-glob "^3.3.1"
-    get-tsconfig "^4.5.0"
-    is-core-module "^2.11.0"
-    is-glob "^4.0.3"
-
-eslint-module-utils@^2.7.4:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz#52f2404300c3bd33deece9d7372fb337cc1d7c34"
-  integrity sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==
-  dependencies:
-    debug "^3.2.7"
-
-"eslint-plugin-import@npm:eslint-plugin-import-x@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import-x/-/eslint-plugin-import-x-3.1.0.tgz#e1d132bde47c431b37f3b294d9ff813098375e7d"
-  integrity sha512-/UbPA+bYY7nIxcjL3kpcDY3UNdoLHFhyBFzHox2M0ypcUoueTn6woZUUmzzi5et/dXChksasYYFeKE2wshOrhg==
-  dependencies:
-    "@typescript-eslint/utils" "^7.4.0"
-    debug "^4.3.4"
-    doctrine "^3.0.0"
-    eslint-import-resolver-node "^0.3.9"
-    get-tsconfig "^4.7.3"
-    is-glob "^4.0.3"
-    minimatch "^9.0.3"
-    semver "^7.6.0"
-    stable-hash "^0.0.4"
-    tslib "^2.6.2"
 
 eslint-plugin-prettier@^5.1.3:
   version "5.2.1"
@@ -1874,7 +1807,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
-fast-glob@^3.2.9, fast-glob@^3.3.1:
+fast-glob@^3.2.9:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -2027,7 +1960,7 @@ get-stream@^8.0.1:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
-get-tsconfig@^4.5.0, get-tsconfig@^4.7.3, get-tsconfig@^4.7.5:
+get-tsconfig@^4.7.5:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.6.tgz#118fd5b7b9bae234cc7705a00cd771d7eb65d62a"
   integrity sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==
@@ -2093,11 +2026,6 @@ gopd@^1.0.1:
   integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
   dependencies:
     get-intrinsic "^1.1.3"
-
-graceful-fs@^4.2.4:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
@@ -2238,7 +2166,7 @@ is-builtin-module@^3.2.1:
   dependencies:
     builtin-modules "^3.3.0"
 
-is-core-module@^2.11.0, is-core-module@^2.13.0:
+is-core-module@^2.13.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.0.tgz#71c72ec5442ace7e76b306e9d48db361f22699ea"
   integrity sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==
@@ -2602,7 +2530,7 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^9.0.3, minimatch@^9.0.4:
+minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -2634,7 +2562,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -3061,7 +2989,7 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.10.0, resolve@^1.22.4:
+resolve@^1.10.0:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -3277,11 +3205,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz#22aa922dcf2f2885a6494a261f2d8b75345d0326"
   integrity sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==
 
-stable-hash@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.4.tgz#55ae7dadc13e4b3faed13601587cec41859b42f7"
-  integrity sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==
-
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
@@ -3431,11 +3354,6 @@ synckit@^0.9.1:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
-
-tapable@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
-  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 test-exclude@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
Maintainers can not maintain.