### PR TITLE
Ref: Removing `string` type comparison in migration

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -141,7 +141,7 @@ const v20 = ESLintUtils.RuleCreator.withoutDocs({
     Identifier: (node) => {
       if (
         node.name === "MockOverrides" &&
-        `${node.parent.type}` === "TSInterfaceDeclaration"
+        node.parent.type === "TSInterfaceDeclaration"
       ) {
         ctx.report({
           node,


### PR DESCRIPTION
After moving to `@typescript-eslint/utils` for creating the rule.