### PR TITLE
Enabling `vitest` globals

### DIFF
--- a/tests/bench/documentation.bench.ts
+++ b/tests/bench/documentation.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe, expect } from "vitest";
+import { bench } from "vitest";
 import { config } from "../../example/config";
 import { routing } from "../../example/routing";
 import { Documentation } from "../../src";

--- a/tests/bench/endpoint.bench.ts
+++ b/tests/bench/endpoint.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe, expect } from "vitest";
+import { bench } from "vitest";
 import { retrieveUserEndpoint } from "../../example/endpoints/retrieve-user";
 import { testEndpoint } from "../../src";
 

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from "vitest";
+import { bench } from "vitest";
 import { z } from "zod";
 import { depictExamples } from "../../src/documentation-helpers";
 import "../../src/zod-plugin";

--- a/tests/bench/integration.bench.ts
+++ b/tests/bench/integration.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe, expect } from "vitest";
+import { bench } from "vitest";
 import { routing } from "../../example/routing";
 import { Integration } from "../../src";
 

--- a/tests/cjs/quick-start.spec.ts
+++ b/tests/cjs/quick-start.spec.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { afterAll, afterEach, describe, expect, test } from "vitest";
 
 describe("CJS Test", async () => {
   const { givePort, waitFor } = await import("../helpers.js");

--- a/tests/compat/migration.spec.ts
+++ b/tests/compat/migration.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { readFile } from "node:fs/promises";
 
 describe("Migration", () => {

--- a/tests/esm/quick-start.spec.ts
+++ b/tests/esm/quick-start.spec.ts
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
 import { givePort, waitFor } from "../helpers";
-import { afterAll, afterEach, describe, expect, test } from "vitest";
 
 describe("ESM Test", async () => {
   let out = "";

--- a/tests/express-mock.ts
+++ b/tests/express-mock.ts
@@ -1,5 +1,4 @@
-// @see https://github.com/swc-project/vi/issues/14#issuecomment-970189585
-import { Mock, vi } from "vitest";
+import type { Mock } from "vitest";
 
 const expressJsonMock = vi.fn();
 const expressRawMock = vi.fn();

--- a/tests/http-mock.ts
+++ b/tests/http-mock.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import https from "node:https";
-import { MockInstance, vi } from "vitest";
+import type { MockInstance } from "vitest";
 import type { Application } from "express";
 
 const realHttpCreator = http.createServer;

--- a/tests/system/example.spec.ts
+++ b/tests/system/example.spec.ts
@@ -8,14 +8,6 @@ import {
 import { givePort, waitFor } from "../helpers";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import {
-  afterAll,
-  afterEach,
-  describe,
-  expect,
-  expectTypeOf,
-  test,
-} from "vitest";
 
 describe("Example", async () => {
   let out = "";

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -9,7 +9,6 @@ import {
   ResultHandler,
 } from "../../src";
 import { givePort, waitFor } from "../helpers";
-import { afterAll, describe, expect, test, vi } from "vitest";
 
 describe("App", async () => {
   const port = givePort();

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -1,14 +1,5 @@
 import MockDate from "mockdate";
 import { EventEmitter } from "node:events";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from "vitest";
 import { performance } from "node:perf_hooks";
 import { BuiltinLogger, BuiltinLoggerConfig } from "../../src/builtin-logger";
 

--- a/tests/unit/checks.spec.ts
+++ b/tests/unit/checks.spec.ts
@@ -1,5 +1,4 @@
 import { UploadedFile } from "express-fileupload";
-import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { ez } from "../../src";
 import { hasNestedSchema } from "../../src/deep-checks";

--- a/tests/unit/common-helpers.spec.ts
+++ b/tests/unit/common-helpers.spec.ts
@@ -14,7 +14,6 @@ import {
 } from "../../src/common-helpers";
 import { InputValidationError } from "../../src";
 import { z } from "zod";
-import { describe, expect, expectTypeOf, test } from "vitest";
 import { makeRequestMock } from "../../src/testing";
 
 describe("Common Helpers", () => {

--- a/tests/unit/config-type.spec.ts
+++ b/tests/unit/config-type.spec.ts
@@ -1,6 +1,5 @@
 import { Express, IRouter } from "express";
 import { createConfig } from "../../src";
-import { describe, expect, test, vi } from "vitest";
 
 describe("ConfigType", () => {
   describe("createConfig()", () => {

--- a/tests/unit/content-type.spec.ts
+++ b/tests/unit/content-type.spec.ts
@@ -1,5 +1,4 @@
 import { contentTypes } from "../../src/content-type";
-import { describe, expect, test } from "vitest";
 
 describe("contentTypes", () => {
   test("should has predefined properties", () => {

--- a/tests/unit/date-in-schema.spec.ts
+++ b/tests/unit/date-in-schema.spec.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { ezDateInBrand } from "../../src/date-in-schema";
 import { ez } from "../../src";
-import { describe, expect, test } from "vitest";
 import { metaSymbol } from "../../src/metadata";
 
 describe("ez.dateIn()", () => {

--- a/tests/unit/date-out-schema.spec.ts
+++ b/tests/unit/date-out-schema.spec.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { ezDateOutBrand } from "../../src/date-out-schema";
 import { ez } from "../../src";
-import { describe, expect, test } from "vitest";
 import { metaSymbol } from "../../src/metadata";
 
 describe("ez.dateOut()", () => {

--- a/tests/unit/depends-on-method.spec.ts
+++ b/tests/unit/depends-on-method.spec.ts
@@ -4,7 +4,6 @@ import {
   EndpointsFactory,
   defaultResultHandler,
 } from "../../src";
-import { describe, expect, test } from "vitest";
 import { AbstractEndpoint } from "../../src/endpoint";
 
 describe("DependsOnMethod", () => {

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -53,7 +53,6 @@ import {
 } from "../../src/documentation-helpers";
 import { walkSchema } from "../../src/schema-walker";
 import { serializeSchemaForTest } from "../helpers";
-import { beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("Documentation helpers", () => {
   const getRefMock = vi.fn();

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -16,7 +16,6 @@ import {
 import { contentTypes } from "../../src/content-type";
 import { z } from "zod";
 import { givePort } from "../helpers";
-import { describe, expect, expectTypeOf, test, vi } from "vitest";
 
 describe("Documentation", () => {
   const sampleConfig = createConfig({

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -11,7 +11,6 @@ import {
 } from "../../src";
 import { AbstractEndpoint, Endpoint } from "../../src/endpoint";
 import { serializeSchemaForTest } from "../helpers";
-import { describe, expect, test, vi } from "vitest";
 
 describe("Endpoint", () => {
   describe(".getMethods()", () => {

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -10,7 +10,6 @@ import { Endpoint } from "../../src/endpoint";
 import { testMiddleware } from "../../src/testing";
 import { serializeSchemaForTest } from "../helpers";
 import { z } from "zod";
-import { describe, expect, expectTypeOf, test, vi } from "vitest";
 
 describe("EndpointsFactory", () => {
   const resultHandlerMock = new ResultHandler({

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -7,7 +7,6 @@ import {
   OutputValidationError,
   ResultHandlerError,
 } from "../../src/errors";
-import { describe, expect, test } from "vitest";
 
 describe("Errors", () => {
   describe("RoutingError", () => {

--- a/tests/unit/file-schema.spec.ts
+++ b/tests/unit/file-schema.spec.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { ezFileBrand } from "../../src/file-schema";
 import { ez } from "../../src";
 import { readFile } from "node:fs/promises";
-import { describe, expect, expectTypeOf, test } from "vitest";
 import { metaSymbol } from "../../src/metadata";
 
 describe("ez.file()", () => {

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -22,7 +22,6 @@ import {
   Routing,
   ServerConfig,
 } from "../../src";
-import { describe, expect, test, expectTypeOf } from "vitest";
 
 describe("Index Entrypoint", () => {
   describe("exports", () => {

--- a/tests/unit/integration.spec.ts
+++ b/tests/unit/integration.spec.ts
@@ -8,7 +8,6 @@ import {
   defaultEndpointsFactory,
   ResultHandler,
 } from "../../src";
-import { describe, expect, test, vi } from "vitest";
 
 describe("Integration", () => {
   test.each(["client", "types"] as const)(

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -4,7 +4,6 @@ import { getFinalEndpointInputSchema } from "../../src/io-schema";
 import { metaSymbol } from "../../src/metadata";
 import { AbstractMiddleware } from "../../src/middleware";
 import { serializeSchemaForTest } from "../helpers";
-import { describe, expect, expectTypeOf, test, vi } from "vitest";
 
 describe("I/O Schema and related helpers", () => {
   describe("IOSchema", () => {

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { lastResortHandler } from "../../src/last-resort";
 import { makeLoggerMock, makeResponseMock } from "../../src/testing";
 

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -5,7 +5,6 @@ import {
   formatDuration,
   isLoggerInstance,
 } from "../../src/logger-helpers";
-import { describe, expect, test } from "vitest";
 
 describe("Logger helpers", () => {
   describe("isLoggerInstance()", () => {

--- a/tests/unit/logical-container.spec.ts
+++ b/tests/unit/logical-container.spec.ts
@@ -4,7 +4,6 @@ import {
   combineContainers,
   mapLogicalContainer,
 } from "../../src/logical-container";
-import { describe, expect, test } from "vitest";
 
 describe("LogicalContainer", () => {
   describe("mapLogicalContainer()", () => {

--- a/tests/unit/metadata.spec.ts
+++ b/tests/unit/metadata.spec.ts
@@ -1,7 +1,6 @@
 import "../../src/zod-plugin"; // required for this test
 import { z } from "zod";
 import { copyMeta, metaSymbol } from "../../src/metadata";
-import { describe, expect, test } from "vitest";
 
 describe("Metadata", () => {
   describe("copyMeta()", () => {

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { InputValidationError, Middleware } from "../../src";
-import { describe, expect, test, vi } from "vitest";
 import { AbstractMiddleware } from "../../src/middleware";
 import {
   makeLoggerMock,

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -1,6 +1,5 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import migration from "../../src/migration";
-import { describe, test, expect, afterAll, it } from "vitest";
 import parser from "@typescript-eslint/parser";
 
 RuleTester.afterAll = afterAll;

--- a/tests/unit/peer-helpers.spec.ts
+++ b/tests/unit/peer-helpers.spec.ts
@@ -1,6 +1,5 @@
 import { MissingPeerError } from "../../src";
 import { loadPeer } from "../../src/peer-helpers";
-import { describe, expect, test } from "vitest";
 
 describe("Peer loading helpers", () => {
   describe("loadPeer()", () => {

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -9,7 +9,6 @@ import {
 } from "../../src";
 import { ResultHandlerError } from "../../src/errors";
 import { metaSymbol } from "../../src/metadata";
-import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import { AbstractResultHandler, Result } from "../../src/result-handler";
 import {
   makeLoggerMock,

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -21,7 +21,6 @@ import {
 } from "../../src/testing";
 import { initRouting } from "../../src/routing";
 import type { IRouter, RequestHandler } from "express";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("Routing", () => {
   describe("initRouting()", () => {

--- a/tests/unit/schema-helpers.spec.ts
+++ b/tests/unit/schema-helpers.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { isValidDate } from "../../src/schema-helpers";
 
 describe("Schema helpers", () => {

--- a/tests/unit/serve-static.spec.ts
+++ b/tests/unit/serve-static.spec.ts
@@ -1,5 +1,4 @@
 import { ServeStatic } from "../../src";
-import { describe, expect, test } from "vitest";
 
 describe("ServeStatic", () => {
   describe("constructor()", () => {

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -9,7 +9,6 @@ import {
   makeChildLoggerExtractor,
   moveRaw,
 } from "../../src/server-helpers";
-import { describe, expect, test, vi } from "vitest";
 import { defaultResultHandler, ResultHandler } from "../../src";
 import { Request } from "express";
 import assert from "node:assert/strict";

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -24,7 +24,6 @@ import {
   ez,
 } from "../../src";
 import express from "express";
-import { afterAll, describe, expect, test, vi } from "vitest";
 
 describe("Server", () => {
   afterAll(() => {

--- a/tests/unit/startup-logo.spec.ts
+++ b/tests/unit/startup-logo.spec.ts
@@ -1,5 +1,4 @@
 import { getStartupLogo } from "../../src/startup-logo";
-import { describe, expect, test } from "vitest";
 
 describe("Startup logo", () => {
   describe("getStartupLogo()", () => {

--- a/tests/unit/testing.spec.ts
+++ b/tests/unit/testing.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defaultEndpointsFactory, Middleware, testEndpoint } from "../../src";
-import { Mock, describe, expect, expectTypeOf, test, vi } from "vitest";
+import type { Mock } from "vitest";
 import { testMiddleware } from "../../src/testing";
 
 describe("Testing", () => {

--- a/tests/unit/upload-schema.spec.ts
+++ b/tests/unit/upload-schema.spec.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { ez } from "../../src";
-import { describe, expect, test, vi } from "vitest";
 import { metaSymbol } from "../../src/metadata";
 import { ezUploadBrand } from "../../src/upload-schema";
 

--- a/tests/unit/zod-plugin.spec.ts
+++ b/tests/unit/zod-plugin.spec.ts
@@ -1,6 +1,5 @@
 import "../../src/zod-plugin"; // required for this test
 import camelize from "camelize-ts";
-import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { metaSymbol } from "../../src/metadata";
 

--- a/tests/unit/zts.spec.ts
+++ b/tests/unit/zts.spec.ts
@@ -5,7 +5,6 @@ import { f } from "../../src/integration-helpers";
 import { defaultSerializer } from "../../src/common-helpers";
 import { zodToTs } from "../../src/zts";
 import { ZTSContext, createTypeAlias, printNode } from "../../src/zts-helpers";
-import { describe, expect, test, vi } from "vitest";
 
 describe("zod-to-ts", () => {
   const printNodeTest = (node: ts.Node) =>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "noImplicitOverride": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "types": ["vitest/globals"]
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     env: {
       FORCE_COLOR: "1",
     },
+    globals: true,
     pool: "threads",
     testTimeout: 10000,
     reporters: "basic",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/60844d79-d602-44fb-8397-3c6bcdd63c18)
