### PR TITLE
Feat: Handling deprecation events by actual logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 20
 
+### v20.11.0
+
+- Feat: Handling deprecation events by actual logger
+  - `express` uses `depd` for emitting `deprecation` events when a certain deprecated approach used;
+  - This version installs a listener of that event and delegates it to the `warn` method of your actual logger.
+
 ### v20.10.0
 
 - Feat: Supporting Express 5

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@tsconfig/node18": "^18.2.1",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.14",
+    "@types/depd": "^1.1.36",
     "@types/eslint": "^9.6.0",
     "@types/express": "^4.17.17",
     "@types/express-fileupload": "^1.5.0",

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -156,3 +156,11 @@ export const makeChildLoggerExtractor =
   (fallback: ActualLogger): ChildLoggerExtractor =>
   (request) =>
     (request as EquippedRequest).res?.locals[metaSymbol]?.logger || fallback;
+
+export const installDeprecationListener = (logger: ActualLogger) =>
+  process.on("deprecation", ({ message, namespace, name, stack }) =>
+    logger.warn(
+      `${name} (${namespace}): ${message}`,
+      stack.split("\n").slice(1),
+    ),
+  );

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,8 +27,6 @@ const makeCommonEntities = (config: CommonConfig) => {
     ? config.logger
     : new BuiltinLogger(config.logger);
   rootLogger.debug("Running", process.env.TSUP_BUILD || "from sources");
-  const onDeprecation = (err: Error) => rootLogger.warn(err.message, err);
-  process.on("deprecation", onDeprecation);
   const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
   const getChildLogger = makeChildLoggerExtractor(rootLogger);
   const commons = { getChildLogger, errorHandler };
@@ -64,6 +62,8 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
     loggingMiddleware,
   } = makeCommonEntities(config);
   const app = express().disable("x-powered-by").use(loggingMiddleware);
+  const onDeprecation = (err: Error) => rootLogger.warn(err.message, err);
+  process.on("deprecation", onDeprecation);
 
   if (config.server.compression) {
     const compressor = await loadPeer<typeof compression>("compression");

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,9 @@ const makeCommonEntities = (config: CommonConfig) => {
     ? config.logger
     : new BuiltinLogger(config.logger);
   rootLogger.debug("Running", process.env.TSUP_BUILD || "from sources");
+  process.on("deprecation", (error: Error) =>
+    rootLogger.warn(error.message, error),
+  );
   const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
   const getChildLogger = makeChildLoggerExtractor(rootLogger);
   const commons = { getChildLogger, errorHandler };

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,9 +27,8 @@ const makeCommonEntities = (config: CommonConfig) => {
     ? config.logger
     : new BuiltinLogger(config.logger);
   rootLogger.debug("Running", process.env.TSUP_BUILD || "from sources");
-  process.on("deprecation", (error: Error) =>
-    rootLogger.warn(error.message, error),
-  );
+  const onDeprecation = (err: Error) => rootLogger.warn(err.message, err);
+  process.on("deprecation", onDeprecation);
   const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
   const getChildLogger = makeChildLoggerExtractor(rootLogger);
   const commons = { getChildLogger, errorHandler };

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,8 +62,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
     loggingMiddleware,
   } = makeCommonEntities(config);
   const app = express().disable("x-powered-by").use(loggingMiddleware);
-  const onDeprecation = (err: Error) => rootLogger.warn(err.message, err);
-  process.on("deprecation", onDeprecation);
+  process.on("deprecation", (err) => rootLogger.warn(err.message, err));
 
   if (config.server.compression) {
     const compressor = await loadPeer<typeof compression>("compression");

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,7 +62,12 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
     loggingMiddleware,
   } = makeCommonEntities(config);
   const app = express().disable("x-powered-by").use(loggingMiddleware);
-  process.on("deprecation", (err) => rootLogger.warn(err.message, err));
+  process.on("deprecation", ({ message, namespace, name, stack }) =>
+    rootLogger.warn(
+      `${name} (${namespace}): ${message}`,
+      stack.split("\n").slice(1),
+    ),
+  );
 
   if (config.server.compression) {
     const compressor = await loadPeer<typeof compression>("compression");

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,10 +95,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
   const starter = <T extends http.Server | https.Server>(
     server: T,
     subject: typeof config.server.listen,
-  ) =>
-    server.listen(subject, () => {
-      rootLogger.info("Listening", subject);
-    }) as T;
+  ) => server.listen(subject, () => rootLogger.info("Listening", subject)) as T;
 
   const servers = {
     httpServer: starter(http.createServer(app), config.server.listen),

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -151,8 +151,8 @@ describe("App", async () => {
   ).httpServer;
   await vi.waitFor(() => assert(server.listening), { timeout: 1e4 });
   expect(warnMethod).toHaveBeenCalledWith(
-    "Sample deprecation message",
-    new Error("Sample deprecation message"),
+    "DeprecationError (express): Sample deprecation message",
+    expect.any(Array), // stack
   );
 
   afterAll(async () => {

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -24,7 +24,6 @@ import {
   ez,
 } from "../../src";
 import express from "express";
-import depd from "depd";
 
 describe("Server", () => {
   afterAll(() => {
@@ -89,16 +88,13 @@ describe("Server", () => {
     test("Should create server with custom JSON parser, raw parser, logger, error handler and beforeRouting", async () => {
       const customLogger = new BuiltinLogger({ level: "silent" });
       const infoMethod = vi.spyOn(customLogger, "info");
-      const warnMethod = vi.spyOn(customLogger, "warn");
       const port = givePort();
       const configMock = {
         server: {
           listen: { port }, // testing Net::ListenOptions
           jsonParser: vi.fn(),
           rawParser: vi.fn(),
-          beforeRouting: vi.fn(() => {
-            depd("express")("Sample deprecation message");
-          }),
+          beforeRouting: vi.fn(),
         },
         cors: true,
         startupLogo: false,
@@ -144,11 +140,6 @@ describe("Server", () => {
       });
       expect(infoMethod).toHaveBeenCalledTimes(1);
       expect(infoMethod).toHaveBeenCalledWith(`Listening`, { port });
-      expect(warnMethod).toHaveBeenCalledTimes(1);
-      expect(warnMethod).toHaveBeenCalledWith(
-        "Sample deprecation message",
-        new Error("Sample deprecation message"),
-      );
       expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get).toHaveBeenCalledWith(
         "/v1/test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/depd@^1.1.36":
+  version "1.1.36"
+  resolved "https://registry.npmjs.org/@types/depd/-/depd-1.1.36.tgz#7633366ce394e6aa046cedb55e70143e9bca67cd"
+  integrity sha512-+apvfj5Bn6ORfud9XrgoIu6H6s2pTN+X8rQ2LgkA3YUXY+PiXkCJjizh8qxv8CrLtXlxw3NCmYrNbbeckVOQrA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint@^9.6.0":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.1.tgz#d5795ad732ce81715f27f75da913004a56751584"


### PR DESCRIPTION
`express` uses `depd` for deprecating things.

This library emits a special event on process, and when there is a listener of that event, it can be handled other way than `stderr`.

https://www.npmjs.com/package/depd#processondeprecation-fn


```
2024-09-13T19:34:38.556Z warn: DeprecationError (express): res.location("back"): use res.location(req.get("Referrer") || "/") and refer to https://dub.sh/security-redirect for best practices [
  '    at file://.../example/config.ts:1:649',
  '    at Layer.handle [as handle_request] (.../node_modules/express/lib/router/layer.js:95:5)',
  '    at next (/.../node_modules/express/lib/router/route.js:149:13)',
  '    at Route.dispatch (/.../node_modules/express/lib/router/route.js:119:3)',
  '    at Layer.handle [as handle_request] (/.../node_modules/express/lib/router/layer.js:95:5)'
]
```