### PR TITLE
Vitest: Improving comparison of HTTP Errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "tests/bench",
     "tests/*.ts",
     "tools",
-    "*.config.ts"
+    "*.config.ts",
+    "*.setup.ts"
   ],
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     pool: "threads",
     testTimeout: 10000,
     reporters: "basic",
+    setupFiles: "vitest.setup.ts",
     coverage: {
       provider: "istanbul",
       reporter: [["text", { maxCols: 120 }], "json-summary", "html", "lcov"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 export default defineConfig({
   test: {
@@ -9,7 +11,10 @@ export default defineConfig({
     pool: "threads",
     testTimeout: 10000,
     reporters: "basic",
-    setupFiles: "vitest.setup.ts",
+    setupFiles: join(
+      dirname(fileURLToPath(import.meta.url)),
+      "vitest.setup.ts",
+    ),
     coverage: {
       provider: "istanbul",
       reporter: [["text", { maxCols: 120 }], "json-summary", "html", "lcov"],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,17 @@
+import { isHttpError } from "http-errors";
+
+const compareHttpErrors = (a: unknown, b: unknown) => {
+  const hasCodeA = isHttpError(a);
+  const hasCodeB = isHttpError(b);
+  return hasCodeA && hasCodeB
+    ? a.statusCode === b.statusCode && a.message === b.message
+    : hasCodeA === hasCodeB
+      ? undefined
+      : false;
+};
+
+/**
+ * @see https://vitest.dev/api/expect.html#expect-addequalitytesters
+ * @see https://jestjs.io/docs/expect#expectaddequalitytesterstesters
+ * */
+expect.addEqualityTesters([compareHttpErrors]);


### PR DESCRIPTION
Problem: `expect::toEqual()` does not really check other props of Error than `message`:
https://vitest.dev/api/expect.html#toequal

Solution:
https://vitest.dev/api/expect.html#expect-addequalitytesters
https://jestjs.io/docs/expect#expectaddequalitytesterstesters

Partially reverts https://github.com/RobinTail/express-zod-api/pull/1899