### PR TITLE
Inverting definition of `AbstractLogger`

### DIFF
--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -5,7 +5,7 @@ import type { FlatObject } from "./common-helpers";
 import {
   AbstractLogger,
   formatDuration,
-  sevCompare,
+  isHidden,
   Severity,
 } from "./logger-helpers";
 
@@ -73,10 +73,7 @@ export class BuiltinLogger implements AbstractLogger {
   }
 
   protected print(method: Severity, message: string, meta?: unknown) {
-    if (
-      this.config.level === "silent" ||
-      sevCompare(method, this.config.level) < 0
-    ) {
+    if (this.config.level === "silent" || isHidden(method, this.config.level)) {
       return;
     }
     const { requestId, ...ctx } = this.config.ctx || {};

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -5,8 +5,8 @@ import type { FlatObject } from "./common-helpers";
 import {
   AbstractLogger,
   formatDuration,
+  sevCompare,
   Severity,
-  severity,
 } from "./logger-helpers";
 
 interface Context extends FlatObject {
@@ -75,7 +75,7 @@ export class BuiltinLogger implements AbstractLogger {
   protected print(method: Severity, message: string, meta?: unknown) {
     if (
       this.config.level === "silent" ||
-      severity[method] < severity[this.config.level]
+      sevCompare(method, this.config.level) < 0
     ) {
       return;
     }

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -2,7 +2,12 @@ import { Ansis, blue, cyanBright, green, hex, red } from "ansis";
 import { inspect } from "node:util";
 import { performance } from "node:perf_hooks";
 import type { FlatObject } from "./common-helpers";
-import { AbstractLogger, formatDuration, severity } from "./logger-helpers";
+import {
+  AbstractLogger,
+  formatDuration,
+  Severity,
+  severity,
+} from "./logger-helpers";
 
 interface Context extends FlatObject {
   requestId?: string;
@@ -36,7 +41,7 @@ export interface BuiltinLoggerConfig {
 interface ProfilerOptions {
   message: string;
   /** @default "debug" */
-  severity?: keyof AbstractLogger | ((ms: number) => keyof AbstractLogger);
+  severity?: Severity | ((ms: number) => Severity);
   /** @default formatDuration - adaptive units and limited fraction */
   formatter?: (ms: number) => string | number;
 }
@@ -44,7 +49,7 @@ interface ProfilerOptions {
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
   protected hasColor: boolean;
-  protected readonly styles: Record<keyof AbstractLogger, Ansis> = {
+  protected readonly styles: Record<Severity, Ansis> = {
     debug: blue,
     info: green,
     warn: hex("#FFA500"),
@@ -67,11 +72,7 @@ export class BuiltinLogger implements AbstractLogger {
     });
   }
 
-  protected print(
-    method: keyof AbstractLogger,
-    message: string,
-    meta?: unknown,
-  ) {
+  protected print(method: Severity, message: string, meta?: unknown) {
     if (
       this.config.level === "silent" ||
       severity[method] < severity[this.config.level]

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -31,9 +31,8 @@ export const isLoggerInstance = (subject: unknown): subject is AbstractLogger =>
 export const isSeverity = (subject: PropertyKey): subject is Severity =>
   subject in severity;
 
-/** @desc returns positive number when subject has a higher severity than the reference */
-export const sevCompare = (subject: Severity, reference: Severity) =>
-  severity[subject] - severity[reference];
+export const isHidden = (subject: Severity, gate: Severity) =>
+  severity[subject] < severity[gate];
 
 /**
  * @todo consider Intl units when Node 18 dropped (microsecond unit is missing, picosecond is not in list)

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -28,6 +28,9 @@ export const isLoggerInstance = (subject: unknown): subject is AbstractLogger =>
   isObject(subject) &&
   Object.keys(severity).some((method) => method in subject);
 
+export const isSeverity = (subject: PropertyKey): subject is Severity =>
+  subject in severity;
+
 /**
  * @todo consider Intl units when Node 18 dropped (microsecond unit is missing, picosecond is not in list)
  * @link https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -1,6 +1,6 @@
 import { isObject } from "./common-helpers";
 
-export const severity = {
+const severity = {
   debug: 10,
   info: 20,
   warn: 30,
@@ -30,6 +30,10 @@ export const isLoggerInstance = (subject: unknown): subject is AbstractLogger =>
 
 export const isSeverity = (subject: PropertyKey): subject is Severity =>
   subject in severity;
+
+/** @desc returns positive number when subject has a higher severity than the reference */
+export const sevCompare = (subject: Severity, reference: Severity) =>
+  severity[subject] - severity[reference];
 
 /**
  * @todo consider Intl units when Node 18 dropped (microsecond unit is missing, picosecond is not in list)

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -1,8 +1,17 @@
 import { isObject } from "./common-helpers";
 
+export const severity = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+} satisfies Record<string, number>;
+
+export type Severity = keyof typeof severity;
+
 /** @desc You can use any logger compatible with this type. */
 export type AbstractLogger = Record<
-  "info" | "debug" | "warn" | "error",
+  Severity,
   (message: string, meta?: any) => any // eslint-disable-line @typescript-eslint/no-explicit-any -- for compatibility
 >;
 
@@ -14,13 +23,6 @@ export type AbstractLogger = Record<
 export interface LoggerOverrides {} // eslint-disable-line @typescript-eslint/no-empty-object-type -- for augmentation
 
 export type ActualLogger = AbstractLogger & LoggerOverrides;
-
-export const severity: Record<keyof AbstractLogger, number> = {
-  debug: 10,
-  info: 20,
-  warn: 30,
-  error: 40,
-};
 
 export const isLoggerInstance = (subject: unknown): subject is AbstractLogger =>
   isObject(subject) &&

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -5,8 +5,8 @@ import { AbstractEndpoint } from "./endpoint";
 import {
   AbstractLogger,
   ActualLogger,
+  isSeverity,
   Severity,
-  severity,
 } from "./logger-helpers";
 import { contentTypes } from "./content-type";
 import {
@@ -40,12 +40,9 @@ export const makeLoggerMock = <LOG extends FlatObject>(loggerProps?: LOG) => {
       LOG & { _getLogs: () => typeof logs },
     {
       get(target, prop, recv) {
-        if (prop === "_getLogs") {
-          return () => logs;
-        }
-        if (prop in severity) {
-          return (...args: unknown[]) => logs[prop as Severity].push(args);
-        }
+        if (prop === "_getLogs") return () => logs;
+        if (isSeverity(prop))
+          return (...args: unknown[]) => logs[prop].push(args);
         return Reflect.get(target, prop, recv);
       },
     },

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -2,7 +2,12 @@ import { Request, Response } from "express";
 import { FlatObject, getInput } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { AbstractEndpoint } from "./endpoint";
-import { AbstractLogger, ActualLogger, severity } from "./logger-helpers";
+import {
+  AbstractLogger,
+  ActualLogger,
+  Severity,
+  severity,
+} from "./logger-helpers";
 import { contentTypes } from "./content-type";
 import {
   createRequest,
@@ -24,7 +29,7 @@ export const makeResponseMock = (opt?: ResponseOptions) =>
   createResponse<Response>(opt);
 
 export const makeLoggerMock = <LOG extends FlatObject>(loggerProps?: LOG) => {
-  const logs: Record<keyof AbstractLogger, unknown[]> = {
+  const logs: Record<Severity, unknown[]> = {
     warn: [],
     error: [],
     info: [],
@@ -39,8 +44,7 @@ export const makeLoggerMock = <LOG extends FlatObject>(loggerProps?: LOG) => {
           return () => logs;
         }
         if (prop in severity) {
-          return (...args: unknown[]) =>
-            logs[prop as keyof AbstractLogger].push(args);
+          return (...args: unknown[]) => logs[prop as Severity].push(args);
         }
         return Reflect.get(target, prop, recv);
       },

--- a/tests/unit/__snapshots__/logger-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger-helpers.spec.ts.snap
@@ -39,3 +39,12 @@ exports[`Logger helpers > formatDuration() > 17 should format 10000000 ms 1`] = 
 exports[`Logger helpers > formatDuration() > 18 should format 100000000 ms 1`] = `"1666.67 minutes"`;
 
 exports[`Logger helpers > formatDuration() > 19 should format 1000000000 ms 1`] = `"16666.67 minutes"`;
+
+exports[`Logger helpers > severity > should have the specific arrangement 1`] = `
+{
+  "debug": 10,
+  "error": 40,
+  "info": 20,
+  "warn": 30,
+}
+`;

--- a/tests/unit/__snapshots__/logger-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/logger-helpers.spec.ts.snap
@@ -39,12 +39,3 @@ exports[`Logger helpers > formatDuration() > 17 should format 10000000 ms 1`] = 
 exports[`Logger helpers > formatDuration() > 18 should format 100000000 ms 1`] = `"1666.67 minutes"`;
 
 exports[`Logger helpers > formatDuration() > 19 should format 1000000000 ms 1`] = `"16666.67 minutes"`;
-
-exports[`Logger helpers > severity > should have the specific arrangement 1`] = `
-{
-  "debug": 10,
-  "error": 40,
-  "info": 20,
-  "warn": 30,
-}
-`;

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -5,7 +5,7 @@ import {
   formatDuration,
   isLoggerInstance,
   isSeverity,
-  sevCompare,
+  isHidden,
 } from "../../src/logger-helpers";
 
 describe("Logger helpers", () => {
@@ -24,28 +24,28 @@ describe("Logger helpers", () => {
     );
   });
 
-  describe("sevCompare", () => {
+  describe("isHidden", () => {
     test.each([
-      ["debug", "debug", 0],
-      ["debug", "info", -10],
-      ["debug", "warn", -20],
-      ["debug", "error", -30],
-      ["info", "debug", 10],
-      ["info", "info", 0],
-      ["info", "warn", -10],
-      ["info", "error", -20],
-      ["warn", "debug", 20],
-      ["warn", "info", 10],
-      ["warn", "warn", 0],
-      ["warn", "error", -10],
-      ["error", "debug", 30],
-      ["error", "info", 20],
-      ["error", "warn", 10],
-      ["error", "error", 0],
+      ["debug", "debug", false],
+      ["debug", "info", true],
+      ["debug", "warn", true],
+      ["debug", "error", true],
+      ["info", "debug", false],
+      ["info", "info", false],
+      ["info", "warn", true],
+      ["info", "error", true],
+      ["warn", "debug", false],
+      ["warn", "info", false],
+      ["warn", "warn", false],
+      ["warn", "error", true],
+      ["error", "debug", false],
+      ["error", "info", false],
+      ["error", "warn", false],
+      ["error", "error", false],
     ] as const)(
-      "should compare %s to %s with %i result",
-      (subject, reference, result) => {
-        expect(sevCompare(subject, reference)).toBe(result);
+      "should compare %s to %s with %s result",
+      (subject, gate, result) => {
+        expect(isHidden(subject, gate)).toBe(result);
       },
     );
   });

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   formatDuration,
   isLoggerInstance,
   severity,
+  isSeverity,
 } from "../../src/logger-helpers";
 
 describe("Logger helpers", () => {
@@ -12,6 +13,21 @@ describe("Logger helpers", () => {
     test("should have the specific arrangement", () => {
       expect(severity).toMatchSnapshot();
     });
+  });
+
+  describe("isSeverity()", () => {
+    test.each(["debug", "info", "warn", "error"])(
+      "should recognize %s",
+      (subject) => {
+        expect(isSeverity(subject)).toBeTruthy();
+      },
+    );
+    test.each(["something", "", 123, Symbol.dispose])(
+      "should reject others %#",
+      (subject) => {
+        expect(isSeverity(subject)).toBeFalsy();
+      },
+    );
   });
 
   describe("isLoggerInstance()", () => {

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -4,17 +4,11 @@ import {
   AbstractLogger,
   formatDuration,
   isLoggerInstance,
-  severity,
   isSeverity,
+  sevCompare,
 } from "../../src/logger-helpers";
 
 describe("Logger helpers", () => {
-  describe("severity", () => {
-    test("should have the specific arrangement", () => {
-      expect(severity).toMatchSnapshot();
-    });
-  });
-
   describe("isSeverity()", () => {
     test.each(["debug", "info", "warn", "error"])(
       "should recognize %s",
@@ -26,6 +20,32 @@ describe("Logger helpers", () => {
       "should reject others %#",
       (subject) => {
         expect(isSeverity(subject)).toBeFalsy();
+      },
+    );
+  });
+
+  describe("sevCompare", () => {
+    test.each([
+      ["debug", "debug", 0],
+      ["debug", "info", -10],
+      ["debug", "warn", -20],
+      ["debug", "error", -30],
+      ["info", "debug", 10],
+      ["info", "info", 0],
+      ["info", "warn", -10],
+      ["info", "error", -20],
+      ["warn", "debug", 20],
+      ["warn", "info", 10],
+      ["warn", "warn", 0],
+      ["warn", "error", -10],
+      ["error", "debug", 30],
+      ["error", "info", 20],
+      ["error", "warn", 10],
+      ["error", "error", 0],
+    ] as const)(
+      "should compare %s to %s with %i result",
+      (subject, reference, result) => {
+        expect(sevCompare(subject, reference)).toBe(result);
       },
     );
   });

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -4,9 +4,16 @@ import {
   AbstractLogger,
   formatDuration,
   isLoggerInstance,
+  severity,
 } from "../../src/logger-helpers";
 
 describe("Logger helpers", () => {
+  describe("severity", () => {
+    test("should have the specific arrangement", () => {
+      expect(severity).toMatchSnapshot();
+    });
+  });
+
   describe("isLoggerInstance()", () => {
     test.each<BuiltinLoggerConfig>([
       { level: "silent" },


### PR DESCRIPTION
Currently, `severity` is defined from `keyof AbstractLogger`.
I'd like an opposite arrangement.