### PR TITLE
Getting rid of serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 20
 
+### v20.15.1
+
+- Deprecating `serializer` property on `Documentation` and `Integration` constructor argument:
+  - That property was introduced in v9.3.0 and utilized for comparing schemas in order to handle possible circular
+    references within `z.lazy()`;
+  - The property is no longer in use and will be removed in version 21.
+
 ### v20.15.0
 
 - Feat: warn about potentially unserializable schema used for JSON operating endpoints:

--- a/README.md
+++ b/README.md
@@ -1357,7 +1357,7 @@ const ruleForDocs: Depicter = (
 
 const ruleForClient: Producer = (
   schema: typeof myBrandedSchema, // you should assign type yourself
-  { next, isResponse, serializer }, // handle a nested schema using next()
+  { next, isResponse }, // handle a nested schema using next()
 ) => ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
 
 new Documentation({

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -1,6 +1,6 @@
-type Type0 = {
+type Type1 = {
   title: string;
-  features: Type0;
+  features: Type1;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -16,7 +16,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type0;
+          features: Type1;
         }[];
       };
     }

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -1,6 +1,6 @@
-type Type2048581c137c5b2130eb860e3ae37da196dfc25b = {
+type Type0 = {
   title: string;
-  features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+  features: Type0;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -16,7 +16,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+          features: Type0;
         }[];
       };
     }

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -48,7 +48,7 @@ paths:
                             title:
                               type: string
                             features:
-                              $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+                              $ref: "#/components/schemas/Schema0"
                           required:
                             - title
                             - features
@@ -549,7 +549,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    2048581c137c5b2130eb860e3ae37da196dfc25b:
+    Schema0:
       type: array
       items:
         type: object
@@ -557,7 +557,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+            $ref: "#/components/schemas/Schema0"
         required:
           - title
           - features

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -48,7 +48,7 @@ paths:
                             title:
                               type: string
                             features:
-                              $ref: "#/components/schemas/Schema0"
+                              $ref: "#/components/schemas/Schema1"
                           required:
                             - title
                             - features
@@ -549,7 +549,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    Schema0:
+    Schema1:
       type: array
       items:
         type: object
@@ -557,7 +557,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/Schema0"
+            $ref: "#/components/schemas/Schema1"
         required:
           - title
           - features

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -170,6 +170,7 @@ export const makeCleanId = (...args: string[]) =>
     .map(ucFirst)
     .join("");
 
+/** @todo remove */
 export const defaultSerializer = (schema: z.ZodTypeAny): string =>
   createHash("sha1").update(JSON.stringify(schema), "utf8").digest("hex");
 

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -1,6 +1,5 @@
 import { Request } from "express";
 import { isHttpError } from "http-errors";
-import { createHash } from "node:crypto";
 import { pickBy, xprod } from "ramda";
 import { z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
@@ -169,10 +168,6 @@ export const makeCleanId = (...args: string[]) =>
     )
     .map(ucFirst)
     .join("");
-
-/** @todo remove */
-export const defaultSerializer = (schema: z.ZodTypeAny): string =>
-  createHash("sha1").update(JSON.stringify(schema), "utf8").digest("hex");
 
 export const tryToTransform = <T>(
   schema: z.ZodEffects<z.ZodTypeAny, T>,

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -74,7 +74,7 @@ export interface OpenAPIContext extends FlatObject {
   isResponse: boolean;
   makeRef: (
     schema: z.ZodTypeAny,
-    image:
+    subject:
       | SchemaObject
       | ReferenceObject
       | (() => SchemaObject | ReferenceObject),

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -60,7 +60,7 @@ interface DocumentationParams {
   /** @default inline */
   composition?: "inline" | "components";
   /**
-   * @deprecated
+   * @deprecated no longer used
    * @todo remove in v21
    * */
   serializer?: (schema: z.ZodTypeAny) => string;

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -77,22 +77,21 @@ export class Documentation extends OpenApiBuilder {
   protected lastSecuritySchemaIds = new Map<SecuritySchemeType, number>();
   protected lastOperationIdSuffixes = new Map<string, number>();
   protected responseVariants = keys(defaultStatusCodes);
-  protected references = new Map<z.ZodTypeAny, ReferenceObject>();
+  protected references = new Map<z.ZodTypeAny, string>();
 
   protected makeRef(
     schema: z.ZodTypeAny,
     depicted: SchemaObject | ReferenceObject,
-    name = this.references.get(schema)?.$ref.split("/").pop() ??
-      `Schema${this.references.size}`,
+    name = this.references.get(schema) ?? `Schema${this.references.size}`,
   ): ReferenceObject {
-    const reference: ReferenceObject = { $ref: `#/components/schemas/${name}` };
     this.addSchema(name, depicted);
-    this.references.set(schema, reference);
-    return reference;
+    this.references.set(schema, name);
+    return this.getRef(schema)!;
   }
 
   protected getRef(schema: z.ZodTypeAny): ReferenceObject | undefined {
-    return this.references.get(schema);
+    const name = this.references.get(schema);
+    return name ? { $ref: `#/components/schemas/${name}` } : undefined;
   }
 
   protected ensureUniqOperationId(

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -88,7 +88,7 @@ export class Documentation extends OpenApiBuilder {
     name = this.references.get(schema),
   ): ReferenceObject {
     if (!name) {
-      name = `Schema${this.references.size}`;
+      name = `Schema${this.references.size + 1}`;
       this.references.set(schema, name);
       if (typeof subject === "function") subject = subject();
     }

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -81,7 +81,7 @@ export class Documentation extends OpenApiBuilder {
 
   protected makeRef(
     schema: z.ZodTypeAny,
-    image:
+    subject:
       | SchemaObject
       | ReferenceObject
       | (() => SchemaObject | ReferenceObject),
@@ -90,9 +90,9 @@ export class Documentation extends OpenApiBuilder {
     if (!name) {
       name = `Schema${this.references.size}`;
       this.references.set(schema, name);
-      if (typeof image === "function") image = image();
+      if (typeof subject === "function") subject = subject();
     }
-    if (typeof image === "object") this.addSchema(name, image);
+    if (typeof subject === "object") this.addSchema(name, subject);
     return { $ref: `#/components/schemas/${name}` };
   }
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -149,10 +149,8 @@ export class Integration {
     let name = this.aliases.get(schema)?.name?.text;
     if (!name) {
       name = `Type${this.aliases.size}`;
-      this.aliases.set(
-        schema,
-        createTypeAlias(f.createLiteralTypeNode(f.createNull()), name),
-      );
+      const temp = f.createLiteralTypeNode(f.createNull());
+      this.aliases.set(schema, createTypeAlias(temp, name));
       this.aliases.set(schema, createTypeAlias(produce(), name));
     }
     return f.createTypeReferenceNode(name);

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -148,7 +148,7 @@ export class Integration {
   ): ts.TypeReferenceNode {
     let name = this.aliases.get(schema)?.name?.text;
     if (!name) {
-      name = `Type${this.aliases.size}`;
+      name = `Type${this.aliases.size + 1}`;
       const temp = f.createLiteralTypeNode(f.createNull());
       this.aliases.set(schema, createTypeAlias(temp, name));
       this.aliases.set(schema, createTypeAlias(produce(), name));

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -144,7 +144,7 @@ export class Integration {
 
   protected makeAlias(
     schema: z.ZodTypeAny,
-    image: () => ts.TypeNode,
+    produce: () => ts.TypeNode,
   ): ts.TypeReferenceNode {
     let name = this.aliases.get(schema)?.name?.text;
     if (!name) {
@@ -153,7 +153,7 @@ export class Integration {
         schema,
         createTypeAlias(f.createLiteralTypeNode(f.createNull()), name),
       );
-      this.aliases.set(schema, createTypeAlias(image(), name));
+      this.aliases.set(schema, createTypeAlias(produce(), name));
     }
     return f.createTypeReferenceNode(name);
   }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -145,8 +145,8 @@ export class Integration {
   protected makeAlias(
     schema: z.ZodTypeAny,
     image: () => ts.TypeNode,
-    name = this.aliases.get(schema)?.name?.text,
   ): ts.TypeReferenceNode {
+    let name = this.aliases.get(schema)?.name?.text;
     if (!name) {
       name = `Type${this.aliases.size}`;
       this.aliases.set(

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -30,18 +30,16 @@ export const addJsDocComment = (node: ts.Node, text: string) => {
 
 export const createTypeAlias = (
   node: ts.TypeNode,
-  identifier: string,
+  name: string,
   comment?: string,
 ) => {
   const typeAlias = f.createTypeAliasDeclaration(
     undefined,
-    f.createIdentifier(identifier),
+    f.createIdentifier(name),
     undefined,
     node,
   );
-  if (comment) {
-    addJsDocComment(typeAlias, comment);
-  }
+  if (comment) addJsDocComment(typeAlias, comment);
   return typeAlias;
 };
 

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -12,7 +12,6 @@ export interface ZTSContext extends FlatObject {
   makeAlias: (
     schema: z.ZodTypeAny,
     image: () => ts.TypeNode,
-    name?: string,
   ) => ts.TypeReferenceNode;
   optionalPropStyle: { withQuestionMark?: boolean; withUndefined?: boolean };
 }

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -11,7 +11,7 @@ export interface ZTSContext extends FlatObject {
   isResponse: boolean;
   makeAlias: (
     schema: z.ZodTypeAny,
-    image: () => ts.TypeNode,
+    produce: () => ts.TypeNode,
   ) => ts.TypeReferenceNode;
   optionalPropStyle: { withQuestionMark?: boolean; withUndefined?: boolean };
 }

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -9,9 +9,11 @@ export type LiteralType = string | number | boolean;
 
 export interface ZTSContext extends FlatObject {
   isResponse: boolean;
-  getAlias: (name: string) => ts.TypeReferenceNode | undefined;
-  makeAlias: (name: string, type: ts.TypeNode) => ts.TypeReferenceNode;
-  serializer: (schema: z.ZodTypeAny) => string;
+  makeAlias: (
+    schema: z.ZodTypeAny,
+    image: () => ts.TypeNode,
+    name?: string,
+  ) => ts.TypeReferenceNode;
   optionalPropStyle: { withQuestionMark?: boolean; withUndefined?: boolean };
 }
 

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -193,19 +193,8 @@ const onPipeline: Producer = (
 
 const onNull: Producer = () => f.createLiteralTypeNode(f.createNull());
 
-const onLazy: Producer = (
-  { schema }: z.ZodLazy<z.ZodTypeAny>,
-  { getAlias, makeAlias, next, serializer: serialize },
-) => {
-  const name = `Type${serialize(schema)}`;
-  return (
-    getAlias(name) ||
-    (() => {
-      makeAlias(name, f.createLiteralTypeNode(f.createNull())); // make empty type first
-      return makeAlias(name, next(schema)); // update
-    })()
-  );
-};
+const onLazy: Producer = (lazy: z.ZodLazy<z.ZodTypeAny>, { makeAlias, next }) =>
+  makeAlias(lazy, () => next(lazy.schema));
 
 const onFile: Producer = (schema: FileSchema) => {
   const subject = schema.unwrap();

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -451,14 +451,14 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
 
 exports[`Documentation helpers > depictLazy > should handle circular references 0 1`] = `
 {
-  "$ref": "#/components/schemas/6cbbd837811754902ea1e68d3e5c75e36250b880",
+  "$ref": "#/components/schemas/SomeSchema",
 }
 `;
 
 exports[`Documentation helpers > depictLazy > should handle circular references 0 2`] = `
 {
   "items": {
-    "$ref": "#/components/schemas/6cbbd837811754902ea1e68d3e5c75e36250b880",
+    "$ref": "#/components/schemas/SomeSchema",
   },
   "type": "array",
 }
@@ -466,19 +466,19 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 
 exports[`Documentation helpers > depictLazy > should handle circular references 1 1`] = `
 {
-  "$ref": "#/components/schemas/7a225c55e65ab4a2fd3ce390265b255ee6747049",
+  "$ref": "#/components/schemas/SomeSchema",
 }
 `;
 
 exports[`Documentation helpers > depictLazy > should handle circular references 1 2`] = `
 {
-  "$ref": "#/components/schemas/7a225c55e65ab4a2fd3ce390265b255ee6747049",
+  "$ref": "#/components/schemas/SomeSchema",
 }
 `;
 
 exports[`Documentation helpers > depictLazy > should handle circular references 2 1`] = `
 {
-  "$ref": "#/components/schemas/118cb3b11b8a1f3b6b1e60a89f96a8be9da32a0f",
+  "$ref": "#/components/schemas/SomeSchema",
 }
 `;
 
@@ -486,7 +486,7 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 {
   "properties": {
     "prop": {
-      "$ref": "#/components/schemas/118cb3b11b8a1f3b6b1e60a89f96a8be9da32a0f",
+      "$ref": "#/components/schemas/SomeSchema",
     },
   },
   "required": [

--- a/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation-helpers.spec.ts.snap
@@ -455,22 +455,7 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 }
 `;
 
-exports[`Documentation helpers > depictLazy > should handle circular references 0 2`] = `
-{
-  "items": {
-    "$ref": "#/components/schemas/SomeSchema",
-  },
-  "type": "array",
-}
-`;
-
 exports[`Documentation helpers > depictLazy > should handle circular references 1 1`] = `
-{
-  "$ref": "#/components/schemas/SomeSchema",
-}
-`;
-
-exports[`Documentation helpers > depictLazy > should handle circular references 1 2`] = `
 {
   "$ref": "#/components/schemas/SomeSchema",
 }
@@ -479,20 +464,6 @@ exports[`Documentation helpers > depictLazy > should handle circular references 
 exports[`Documentation helpers > depictLazy > should handle circular references 2 1`] = `
 {
   "$ref": "#/components/schemas/SomeSchema",
-}
-`;
-
-exports[`Documentation helpers > depictLazy > should handle circular references 2 2`] = `
-{
-  "properties": {
-    "prop": {
-      "$ref": "#/components/schemas/SomeSchema",
-    },
-  },
-  "required": [
-    "prop",
-  ],
-  "type": "object",
 }
 `;
 

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -2029,7 +2029,7 @@ components:
       type: string
       pattern: \\d+
       description: a numeric string containing the id of the user
-    Schema1:
+    Schema0:
       type: array
       items:
         type: object
@@ -2037,7 +2037,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/Schema1"
+            $ref: "#/components/schemas/Schema0"
         required:
           - title
           - features
@@ -2065,7 +2065,7 @@ components:
                   title:
                     type: string
                   features:
-                    $ref: "#/components/schemas/Schema1"
+                    $ref: "#/components/schemas/Schema0"
                 required:
                   - title
                   - features

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -1200,7 +1200,7 @@ paths:
                             title:
                               type: string
                             features:
-                              $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+                              $ref: "#/components/schemas/Schema0"
                           required:
                             - title
                             - features
@@ -1701,7 +1701,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    2048581c137c5b2130eb860e3ae37da196dfc25b:
+    Schema0:
       type: array
       items:
         type: object
@@ -1709,7 +1709,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+            $ref: "#/components/schemas/Schema0"
         required:
           - title
           - features
@@ -2029,7 +2029,7 @@ components:
       type: string
       pattern: \\d+
       description: a numeric string containing the id of the user
-    2048581c137c5b2130eb860e3ae37da196dfc25b:
+    Schema1:
       type: array
       items:
         type: object
@@ -2037,7 +2037,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+            $ref: "#/components/schemas/Schema1"
         required:
           - title
           - features
@@ -2065,7 +2065,7 @@ components:
                   title:
                     type: string
                   features:
-                    $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+                    $ref: "#/components/schemas/Schema1"
                 required:
                   - title
                   - features
@@ -2530,7 +2530,7 @@ paths:
                           name:
                             type: string
                           subcategories:
-                            $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+                            $ref: "#/components/schemas/Schema0"
                         required:
                           - name
                           - subcategories
@@ -2567,7 +2567,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    2048581c137c5b2130eb860e3ae37da196dfc25b:
+    Schema0:
       type: array
       items:
         type: object
@@ -2575,7 +2575,7 @@ components:
           name:
             type: string
           subcategories:
-            $ref: "#/components/schemas/2048581c137c5b2130eb860e3ae37da196dfc25b"
+            $ref: "#/components/schemas/Schema0"
         required:
           - name
           - subcategories

--- a/tests/unit/__snapshots__/documentation.spec.ts.snap
+++ b/tests/unit/__snapshots__/documentation.spec.ts.snap
@@ -1200,7 +1200,7 @@ paths:
                             title:
                               type: string
                             features:
-                              $ref: "#/components/schemas/Schema0"
+                              $ref: "#/components/schemas/Schema1"
                           required:
                             - title
                             - features
@@ -1701,7 +1701,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    Schema0:
+    Schema1:
       type: array
       items:
         type: object
@@ -1709,7 +1709,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/Schema0"
+            $ref: "#/components/schemas/Schema1"
         required:
           - title
           - features
@@ -2029,7 +2029,7 @@ components:
       type: string
       pattern: \\d+
       description: a numeric string containing the id of the user
-    Schema0:
+    Schema1:
       type: array
       items:
         type: object
@@ -2037,7 +2037,7 @@ components:
           title:
             type: string
           features:
-            $ref: "#/components/schemas/Schema0"
+            $ref: "#/components/schemas/Schema1"
         required:
           - title
           - features
@@ -2065,7 +2065,7 @@ components:
                   title:
                     type: string
                   features:
-                    $ref: "#/components/schemas/Schema0"
+                    $ref: "#/components/schemas/Schema1"
                 required:
                   - title
                   - features
@@ -2530,7 +2530,7 @@ paths:
                           name:
                             type: string
                           subcategories:
-                            $ref: "#/components/schemas/Schema0"
+                            $ref: "#/components/schemas/Schema1"
                         required:
                           - name
                           - subcategories
@@ -2567,7 +2567,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    Schema0:
+    Schema1:
       type: array
       items:
         type: object
@@ -2575,7 +2575,7 @@ components:
           name:
             type: string
           subcategories:
-            $ref: "#/components/schemas/Schema0"
+            $ref: "#/components/schemas/Schema1"
         required:
           - name
           - subcategories

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -425,9 +425,9 @@ export interface Response extends Record<MethodPath, any> {
 `;
 
 exports[`Integration > Should generate a client for example API 1`] = `
-"type Type0 = {
+"type Type1 = {
   title: string;
-  features: Type0;
+  features: Type1;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -443,7 +443,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type0;
+          features: Type1;
         }[];
       };
     }
@@ -668,9 +668,9 @@ client.provide("get", "/v1/user/retrieve", { id: "10" });
 `;
 
 exports[`Integration > Should generate a types for example API 1`] = `
-"type Type0 = {
+"type Type1 = {
   title: string;
-  features: Type0;
+  features: Type1;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -686,7 +686,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type0;
+          features: Type1;
         }[];
       };
     }

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -425,9 +425,9 @@ export interface Response extends Record<MethodPath, any> {
 `;
 
 exports[`Integration > Should generate a client for example API 1`] = `
-"type Type2048581c137c5b2130eb860e3ae37da196dfc25b = {
+"type Type0 = {
   title: string;
-  features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+  features: Type0;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -443,7 +443,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+          features: Type0;
         }[];
       };
     }
@@ -668,9 +668,9 @@ client.provide("get", "/v1/user/retrieve", { id: "10" });
 `;
 
 exports[`Integration > Should generate a types for example API 1`] = `
-"type Type2048581c137c5b2130eb860e3ae37da196dfc25b = {
+"type Type0 = {
   title: string;
-  features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+  features: Type0;
 }[];
 
 type GetV1UserRetrieveInput = {} & {
@@ -686,7 +686,7 @@ type GetV1UserRetrieveResponse =
         name: string;
         features: {
           title: string;
-          features: Type2048581c137c5b2130eb860e3ae37da196dfc25b;
+          features: Type0;
         }[];
       };
     }

--- a/tests/unit/__snapshots__/zts.spec.ts.snap
+++ b/tests/unit/__snapshots__/zts.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`zod-to-ts > Example > should produce the expected results 1`] = `
         string: string;
     }[];
     boolean: boolean;
-    circular: Type118cb3b11b8a1f3b6b1e60a89f96a8be9da32a0f;
+    circular: SomeType;
     union: {
         number: number;
     } | "hi";
@@ -60,7 +60,7 @@ exports[`zod-to-ts > Example > should produce the expected results 1`] = `
     optDefaultString?: string | undefined;
     refinedStringWithSomeBullshit: (string | number) & ((bigint | null) | undefined);
     nativeEnum: "A" | "apple" | "banana" | "cantaloupe" | 5;
-    lazy: Type51497f7e879bae48c3fbad2fa68050d1e08bbf82;
+    lazy: SomeType;
     discUnion: {
         kind: "circle";
         radius: number;

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -1,6 +1,5 @@
 import { ReferenceObject } from "openapi3-ts/oas31";
 import { z } from "zod";
-import { defaultSerializer } from "../../src/common-helpers";
 import { DocumentationError, ez } from "../../src";
 import {
   OpenAPIContext,
@@ -60,7 +59,6 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
-    serializer: defaultSerializer,
     next: (schema: z.ZodTypeAny) =>
       walkSchema(schema, {
         rules: depicters,
@@ -74,7 +72,6 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
-    serializer: defaultSerializer,
     next: (schema: z.ZodTypeAny) =>
       walkSchema(schema, {
         rules: depicters,

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -777,7 +777,7 @@ describe("Documentation helpers", () => {
             $ref: "#/components/schemas/SomeSchema",
           }),
         );
-        expect(makeRefMock.mock.calls.length).toBe(0);
+        expect(makeRefMock).not.toHaveBeenCalled();
         expect(depictLazy(schema, responseCtx)).toMatchSnapshot();
         expect(makeRefMock).toHaveBeenCalledTimes(1);
         expect(makeRefMock).toHaveBeenCalledWith(schema, expect.any(Function));

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -780,10 +780,7 @@ describe("Documentation helpers", () => {
         expect(makeRefMock.mock.calls.length).toBe(0);
         expect(depictLazy(schema, responseCtx)).toMatchSnapshot();
         expect(makeRefMock).toHaveBeenCalledTimes(1);
-        expect(makeRefMock.mock.calls[0]).toEqual([
-          schema,
-          expect.any(Function),
-        ]);
+        expect(makeRefMock).toHaveBeenCalledWith(schema, expect.any(Function));
       },
     );
   });

--- a/tests/unit/zts.spec.ts
+++ b/tests/unit/zts.spec.ts
@@ -1,7 +1,6 @@
 import ts from "typescript";
 import { z } from "zod";
 import { f } from "../../src/integration-helpers";
-import { defaultSerializer } from "../../src/common-helpers";
 import { zodToTs } from "../../src/zts";
 import { ZTSContext, createTypeAlias, printNode } from "../../src/zts-helpers";
 
@@ -10,9 +9,7 @@ describe("zod-to-ts", () => {
     printNode(node, { newLine: ts.NewLineKind.LineFeed });
   const ctx: ZTSContext = {
     isResponse: false,
-    getAlias: vi.fn((name: string) => f.createTypeReferenceNode(name)),
-    makeAlias: vi.fn(),
-    serializer: defaultSerializer,
+    makeAlias: vi.fn(() => f.createTypeReferenceNode("SomeType")),
     optionalPropStyle: { withQuestionMark: true, withUndefined: true },
   };
 


### PR DESCRIPTION
Serializers used to be involved for comparing schemas in order to handle possible circular references of ZodLazy.
It's time to make it better, using the power of `Map`.