### PR TITLE
Making `input` schema optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Version 20
 
+### v20.21.0
+
+- Feat: input schema made optional:
+  - The `input` property can be now omitted on the argument of the following methods:
+    `Middlware::constructor`, `EndpointsFactory::build()`, `EndpointsFactory::addMiddleware()`;
+  - When the input schema is not specified `z.object({})` is used;
+  - This feature aims to simplify the implementation for Endpoints and Middlwares having no inputs.
+
 ### v20.20.1
 
 - Minor code style refactoring and performance tuning;

--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ import { z } from "zod";
 const helloWorldEndpoint = defaultEndpointsFactory.build({
   method: "get", // or methods: ["get", "post", ...]
   input: z.object({
-    // for empty input use z.object({})
     name: z.string().optional(),
   }),
   output: z.object({
@@ -320,7 +319,6 @@ import { defaultEndpointsFactory } from "express-zod-api";
 const factory = defaultEndpointsFactory
   .addMiddleware(authMiddleware) // add Middleware instance or use shorter syntax:
   .addMiddleware({
-    input: z.object({}),
     handler: async ({ options: { user } }) => ({}), // options.user from authMiddleware
   });
 ```

--- a/example/endpoints/list-users.ts
+++ b/example/endpoints/list-users.ts
@@ -8,7 +8,6 @@ import { arrayRespondingFactory } from "../factories";
 export const listUsersEndpoint = arrayRespondingFactory.build({
   method: "get",
   tag: "users",
-  input: z.object({}),
   output: z
     .object({
       // the arrayResultHandler will take the "items" prop as the response

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Example API
-  version: 20.20.1
+  version: 20.21.0-beta.1
 paths:
   /v1/user/retrieve:
     get:

--- a/example/middlewares.ts
+++ b/example/middlewares.ts
@@ -30,7 +30,6 @@ export const authMiddleware = new Middleware({
 });
 
 export const methodProviderMiddleware = new Middleware({
-  input: z.object({}),
   handler: async ({ request }) => ({
     method: request.method.toLowerCase() as Method,
   }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-zod-api",
-  "version": "20.20.1",
+  "version": "20.21.0-beta.1",
   "description": "A Typescript framework to help you get an API server up and running with I/O schema validation and custom middlewares in minutes.",
   "license": "MIT",
   "repository": {

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -9,6 +9,7 @@ import { AuxMethod, Method } from "./method";
 
 /** @desc this type does not allow props assignment, but it works for reading them when merged with another interface */
 export type EmptyObject = Record<string, never>;
+export type EmptySchema = z.ZodObject<EmptyObject, "strip">;
 export type FlatObject = Record<string, unknown>;
 
 const areFilesAvailable = (request: Request): boolean => {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -60,11 +60,11 @@ export abstract class AbstractEndpoint {
 }
 
 export class Endpoint<
+  IN extends IOSchema,
   OUT extends IOSchema,
   OPT extends FlatObject,
   SCO extends string,
   TAG extends string,
-  IN extends IOSchema,
 > extends AbstractEndpoint {
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
   readonly #methods: ReadonlyArray<Method>;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -60,11 +60,11 @@ export abstract class AbstractEndpoint {
 }
 
 export class Endpoint<
-  IN extends IOSchema,
   OUT extends IOSchema,
   OPT extends FlatObject,
   SCO extends string,
   TAG extends string,
+  IN extends IOSchema,
 > extends AbstractEndpoint {
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
   readonly #methods: ReadonlyArray<Method>;

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -78,8 +78,8 @@ export class EndpointsFactory<
     ASCO extends string,
   >(
     subject:
-      | Middleware<AIN, OUT, AOUT, ASCO>
-      | ConstructorParameters<typeof Middleware<AIN, OUT, AOUT, ASCO>>[0],
+      | Middleware<OUT, AOUT, ASCO, AIN>
+      | ConstructorParameters<typeof Middleware<OUT, AOUT, ASCO, AIN>>[0],
   ) {
     return EndpointsFactory.#create<
       z.ZodIntersection<IN, AIN>,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -123,11 +123,11 @@ export class EndpointsFactory<
     operationId,
     ...rest
   }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
-    z.ZodIntersection<IN, BIN>,
     BOUT,
     OUT,
     SCO,
-    TAG
+    TAG,
+    z.ZodIntersection<IN, BIN>
   > {
     const { middlewares, resultHandler } = this;
     const methods = "methods" in rest ? rest.methods : [rest.method];

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -17,12 +17,12 @@ import {
 } from "./result-handler";
 
 type BuildProps<
+  IN extends IOSchema,
   OUT extends IOSchema,
   MIN extends IOSchema<"strip">,
   OPT extends FlatObject,
   SCO extends string,
   TAG extends string,
-  IN extends IOSchema = z.ZodObject<EmptyObject>,
 > = {
   input?: IN;
   output: OUT;
@@ -114,7 +114,10 @@ export class EndpointsFactory<
     );
   }
 
-  public build<BIN extends IOSchema, BOUT extends IOSchema>({
+  public build<
+    BOUT extends IOSchema,
+    BIN extends IOSchema = z.ZodObject<EmptyObject>,
+  >({
     input = z.object({}) as BIN,
     handler,
     output: outputSchema,
@@ -122,7 +125,7 @@ export class EndpointsFactory<
     shortDescription,
     operationId,
     ...rest
-  }: BuildProps<BOUT, IN, OUT, SCO, TAG, BIN>): Endpoint<
+  }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
     z.ZodIntersection<IN, BIN>,
     BOUT,
     OUT,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -73,9 +73,9 @@ export class EndpointsFactory<
   }
 
   public addMiddleware<
-    AIN extends IOSchema<"strip">,
     AOUT extends FlatObject,
     ASCO extends string,
+    AIN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
   >(
     subject:
       | Middleware<OUT, AOUT, ASCO, AIN>

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -123,11 +123,11 @@ export class EndpointsFactory<
     operationId,
     ...rest
   }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
+    z.ZodIntersection<IN, BIN>,
     BOUT,
     OUT,
     SCO,
-    TAG,
-    z.ZodIntersection<IN, BIN>
+    TAG
   > {
     const { middlewares, resultHandler } = this;
     const methods = "methods" in rest ? rest.methods : [rest.method];

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -116,7 +116,7 @@ export class EndpointsFactory<
 
   public build<
     BOUT extends IOSchema,
-    BIN extends IOSchema = z.ZodObject<EmptyObject>,
+    BIN extends IOSchema = z.ZodObject<EmptyObject, "strip">,
   >({
     input = z.object({}) as BIN,
     handler,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { z } from "zod";
-import { EmptyObject, FlatObject } from "./common-helpers";
+import { EmptyObject, EmptySchema, FlatObject } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { Endpoint, Handler } from "./endpoint";
 import { IOSchema, getFinalEndpointInputSchema } from "./io-schema";
@@ -35,7 +35,7 @@ type BuildProps<
   ({ tags?: TAG[] } | { tag?: TAG });
 
 export class EndpointsFactory<
-  IN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
+  IN extends IOSchema<"strip"> = EmptySchema,
   OUT extends FlatObject = EmptyObject,
   SCO extends string = string,
   TAG extends string = string,
@@ -75,7 +75,7 @@ export class EndpointsFactory<
   public addMiddleware<
     AOUT extends FlatObject,
     ASCO extends string,
-    AIN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
+    AIN extends IOSchema<"strip"> = EmptySchema,
   >(
     subject:
       | Middleware<OUT, AOUT, ASCO, AIN>
@@ -114,10 +114,7 @@ export class EndpointsFactory<
     );
   }
 
-  public build<
-    BOUT extends IOSchema,
-    BIN extends IOSchema = z.ZodObject<EmptyObject, "strip">,
-  >({
+  public build<BOUT extends IOSchema, BIN extends IOSchema = EmptySchema>({
     input = z.object({}) as BIN,
     handler,
     output: outputSchema,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -17,14 +17,14 @@ import {
 } from "./result-handler";
 
 type BuildProps<
-  IN extends IOSchema,
   OUT extends IOSchema,
   MIN extends IOSchema<"strip">,
   OPT extends FlatObject,
   SCO extends string,
   TAG extends string,
+  IN extends IOSchema = z.ZodObject<EmptyObject>,
 > = {
-  input: IN;
+  input?: IN;
   output: OUT;
   handler: Handler<z.output<z.ZodIntersection<MIN, IN>>, z.input<OUT>, OPT>;
   description?: string;
@@ -115,14 +115,14 @@ export class EndpointsFactory<
   }
 
   public build<BIN extends IOSchema, BOUT extends IOSchema>({
-    input,
+    input = z.object({}) as BIN,
     handler,
     output: outputSchema,
     description,
     shortDescription,
     operationId,
     ...rest
-  }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
+  }: BuildProps<BOUT, IN, OUT, SCO, TAG, BIN>): Endpoint<
     z.ZodIntersection<IN, BIN>,
     BOUT,
     OUT,

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -109,12 +109,7 @@ export class EndpointsFactory<
 
   public addOptions<AOUT extends FlatObject>(getOptions: () => Promise<AOUT>) {
     return EndpointsFactory.#create<IN, OUT & AOUT, SCO, TAG>(
-      this.middlewares.concat(
-        new Middleware({
-          input: z.object({}),
-          handler: getOptions,
-        }),
-      ),
+      this.middlewares.concat(new Middleware({ handler: getOptions })),
       this.resultHandler,
     );
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,10 +28,10 @@ export abstract class AbstractMiddleware {
 }
 
 export class Middleware<
-  IN extends IOSchema<"strip">,
   OPT extends FlatObject,
   OUT extends FlatObject,
   SCO extends string,
+  IN extends IOSchema<"strip">,
 > extends AbstractMiddleware {
   readonly #schema: IN;
   readonly #security?: LogicalContainer<
@@ -89,10 +89,10 @@ export class ExpressMiddleware<
   S extends Response,
   OUT extends FlatObject,
 > extends Middleware<
-  z.ZodObject<EmptyObject, "strip">,
   FlatObject,
   OUT,
-  string
+  string,
+  z.ZodObject<EmptyObject, "strip">
 > {
   constructor(
     nativeMw: (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { z } from "zod";
-import { EmptyObject, FlatObject } from "./common-helpers";
+import { EmptySchema, FlatObject } from "./common-helpers";
 import { InputValidationError } from "./errors";
 import { IOSchema } from "./io-schema";
 import { LogicalContainer } from "./logical-container";
@@ -31,7 +31,7 @@ export class Middleware<
   OPT extends FlatObject,
   OUT extends FlatObject,
   SCO extends string,
-  IN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
+  IN extends IOSchema<"strip"> = EmptySchema,
 > extends AbstractMiddleware {
   readonly #schema: IN;
   readonly #security?: LogicalContainer<

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,7 +31,7 @@ export class Middleware<
   OPT extends FlatObject,
   OUT extends FlatObject,
   SCO extends string,
-  IN extends IOSchema<"strip">,
+  IN extends IOSchema<"strip"> = z.ZodObject<EmptyObject, "strip">,
 > extends AbstractMiddleware {
   readonly #schema: IN;
   readonly #security?: LogicalContainer<
@@ -40,11 +40,11 @@ export class Middleware<
   readonly #handler: Handler<z.output<IN>, OPT, OUT>;
 
   constructor({
-    input,
+    input = z.object({}) as IN,
     security,
     handler,
   }: {
-    input: IN;
+    input?: IN;
     security?: LogicalContainer<
       Security<Extract<keyof z.input<IN>, string>, SCO>
     >;
@@ -88,12 +88,7 @@ export class ExpressMiddleware<
   R extends Request,
   S extends Response,
   OUT extends FlatObject,
-> extends Middleware<
-  FlatObject,
-  OUT,
-  string,
-  z.ZodObject<EmptyObject, "strip">
-> {
+> extends Middleware<FlatObject, OUT, string> {
   constructor(
     nativeMw: (
       request: R,
@@ -109,7 +104,6 @@ export class ExpressMiddleware<
     } = {},
   ) {
     super({
-      input: z.object({}),
       handler: async ({ request, response }) =>
         new Promise<OUT>((resolve, reject) => {
           const next = (err?: unknown) => {

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -28,7 +28,6 @@ describe("App", async () => {
     )
     .build({
       method: "get",
-      input: z.object({}),
       output: z.object({ corsDone: z.boolean() }),
       handler: async ({ options: { corsDone } }) => ({ corsDone }),
     });
@@ -71,7 +70,6 @@ describe("App", async () => {
       handler: async () => ({ user: { id: 354 } }),
     })
     .addMiddleware({
-      input: z.object({}),
       handler: async ({ request, options: { user } }) => ({
         method: request.method.toLowerCase() as Method,
         permissions: user.id === 354 ? ["any"] : [],
@@ -100,7 +98,6 @@ describe("App", async () => {
     });
   const longEndpoint = new EndpointsFactory(defaultResultHandler).build({
     method: "get",
-    input: z.object({}),
     output: z.object({}),
     handler: async () => setTimeout(5000, {}),
   });

--- a/tests/unit/depends-on-method.spec.ts
+++ b/tests/unit/depends-on-method.spec.ts
@@ -19,7 +19,6 @@ describe("DependsOnMethod", () => {
     const instance = new DependsOnMethod({
       post: new EndpointsFactory(defaultResultHandler).build({
         method: "post",
-        input: z.object({}),
         output: z.object({}),
         handler: async () => ({}),
       }),
@@ -33,7 +32,6 @@ describe("DependsOnMethod", () => {
   test("should accept an endpoint with additional methods", () => {
     const endpoint = new EndpointsFactory(defaultResultHandler).build({
       methods: ["get", "post"],
-      input: z.object({}),
       output: z.object({}),
       handler: async () => ({}),
     });

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -620,12 +620,10 @@ describe("Documentation", () => {
             },
           ],
         },
-        input: z.object({}),
         handler: vi.fn<any>(),
       });
       const mw3 = new Middleware({
         security: { type: "bearer", format: "JWT" },
-        input: z.object({}),
         handler: vi.fn<any>(),
       });
       const spec = new Documentation({

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -49,7 +49,6 @@ describe("Documentation", () => {
           v1: {
             deleteSomething: defaultEndpointsFactory.build({
               methods: ["delete"],
-              input: z.object({}),
               output: z.object({
                 whatever: z.number(),
               }),
@@ -302,7 +301,6 @@ describe("Documentation", () => {
           v1: {
             getSomething: defaultEndpointsFactory.build({
               method: "post",
-              input: z.object({}),
               output: z.object({
                 simple: z.record(z.number().int()),
                 stringy: z.record(z.string().regex(/[A-Z]+/), z.boolean()),
@@ -644,14 +642,12 @@ describe("Documentation", () => {
             setSomething: defaultEndpointsFactory.addMiddleware(mw2).build({
               scope: "write",
               method: "post",
-              input: z.object({}),
               output: z.object({}),
               handler: async () => ({}),
             }),
             updateSomething: defaultEndpointsFactory.addMiddleware(mw3).build({
               scopes: ["this should be omitted"],
               method: "put",
-              input: z.object({}),
               output: z.object({}),
               handler: async () => ({}),
             }),
@@ -673,14 +669,12 @@ describe("Documentation", () => {
               thing: defaultEndpointsFactory.build({
                 description: "thing is the path segment",
                 method: "get",
-                input: z.object({}),
                 output: z.object({}),
                 handler: async () => ({}),
               }),
               ":thing": defaultEndpointsFactory.build({
                 description: "thing is the path parameter",
                 method: "get",
-                input: z.object({}),
                 output: z.object({}),
                 handler: async () => ({}),
               }),
@@ -705,7 +699,6 @@ describe("Documentation", () => {
                 description: "thing is the path segment",
                 method: "get",
                 operationId,
-                input: z.object({}),
                 output: z.object({}),
                 handler: async () => ({}),
               }),
@@ -731,7 +724,6 @@ describe("Documentation", () => {
                 description: "thing is the path segment",
                 methods: ["get", "post"],
                 operationId: (method) => `${method}${operationId}`,
-                input: z.object({}),
                 output: z.object({}),
                 handler: async () => ({}),
               }),
@@ -765,7 +757,6 @@ describe("Documentation", () => {
                     description: "thing is the path segment",
                     method: "get",
                     operationId,
-                    input: z.object({}),
                     output: z.object({}),
                     handler: async () => ({}),
                   }),
@@ -775,7 +766,6 @@ describe("Documentation", () => {
                     description: "thing is the path segment",
                     method: "get",
                     operationId,
-                    input: z.object({}),
                     output: z.object({}),
                     handler: async () => ({}),
                   }),
@@ -810,7 +800,6 @@ describe("Documentation", () => {
           v1: {
             getSomething: factory.build({
               method: "get",
-              input: z.object({}),
               output: z.object({}),
               handler: async () => ({}),
             }),

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -127,7 +127,6 @@ describe("Endpoint", () => {
       const handlerMock = vi.fn();
       const endpoint = defaultEndpointsFactory.build({
         method: "get",
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -159,7 +158,6 @@ describe("Endpoint", () => {
     test("Should throw on output validation failure", async () => {
       const endpoint = defaultEndpointsFactory.build({
         method: "post",
-        input: z.object({}),
         output: z.object({ email: z.string().email() }),
         handler: async () => ({ email: "not email" }),
       });
@@ -175,7 +173,6 @@ describe("Endpoint", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const endpoint = factory.build({
         method: "post",
-        input: z.object({}),
         output: z.object({
           test: z.number().transform(() => assert.fail("Something unexpected")),
         }),
@@ -210,7 +207,6 @@ describe("Endpoint", () => {
       const handlerMock = vi.fn();
       const endpoint = factory.build({
         method: "post",
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -246,7 +242,6 @@ describe("Endpoint", () => {
       const factory = new EndpointsFactory(resultHandler);
       const endpoint = factory.build({
         method: "get",
-        input: z.object({}),
         output: z.object({
           test: z.string(),
         }),
@@ -307,7 +302,6 @@ describe("Endpoint", () => {
         const factory = new EndpointsFactory(defaultResultHandler);
         const endpoint = factory.build({
           method: "get",
-          input: z.object({}),
           output: z.object({ something: z.number() }),
           handler: vi.fn(),
         });
@@ -325,7 +319,6 @@ describe("Endpoint", () => {
         const factory = new EndpointsFactory(defaultResultHandler);
         const endpoint = factory.build({
           method: "get",
-          input: z.object({}),
           output: z.object({ something: z.number() }),
           handler: vi.fn(),
         });
@@ -446,7 +439,6 @@ describe("Endpoint", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const endpoint = factory.build({
         method: "post",
-        input: z.object({}),
         output: z.object({
           test: z.number().transform(() => assert.fail("Something unexpected")),
         }),
@@ -473,7 +465,6 @@ describe("Endpoint", () => {
       );
       const endpoint = factory.build({
         method: "get",
-        input: z.object({}),
         output: z.object({
           test: z.string(),
         }),
@@ -491,12 +482,10 @@ describe("Endpoint", () => {
 
     test("thrown in middleware and caught in execute()", async () => {
       const factory = new EndpointsFactory(defaultResultHandler).addMiddleware({
-        input: z.object({}),
         handler: async () => assert.fail("Something went wrong"),
       });
       const endpoint = factory.build({
         methods: ["post"],
-        input: z.object({}),
         output: z.object({}),
         handler: async () => ({}),
       });
@@ -676,7 +665,6 @@ describe("Endpoint", () => {
         .addMiddleware(dateInputMiddleware)
         .build({
           method: "get",
-          input: z.object({}),
           output: z.object({}),
           handler: async ({ input: { middleware_date_input }, logger }) => {
             logger.debug(

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -7,6 +7,7 @@ import {
   ResultHandler,
   testMiddleware,
 } from "../../src";
+import { EmptyObject } from "../../src/common-helpers";
 import { Endpoint } from "../../src/endpoint";
 import { serializeSchemaForTest } from "../helpers";
 import { z } from "zod";
@@ -343,6 +344,18 @@ describe("EndpointsFactory", () => {
       expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<
         { s: string } & ({ n1: number } | { n2: number })
       >();
+    });
+
+    test("should create an endpoint without input schema", () => {
+      const factory = new EndpointsFactory(resultHandlerMock);
+      const endpoint = factory.build({
+        method: "get",
+        output: z.object({}),
+        handler: vi.fn(),
+      });
+      expectTypeOf(
+        endpoint.getSchema("input")._output,
+      ).toEqualTypeOf<EmptyObject>();
     });
   });
 });

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -5,9 +5,9 @@ import {
   Middleware,
   defaultEndpointsFactory,
   ResultHandler,
+  testMiddleware,
 } from "../../src";
 import { Endpoint } from "../../src/endpoint";
-import { testMiddleware } from "../../src/testing";
 import { serializeSchemaForTest } from "../helpers";
 import { z } from "zod";
 

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -71,17 +71,19 @@ describe("EndpointsFactory", () => {
         );
     });
 
-    test("Should accept creation props", () => {
-      defaultEndpointsFactory
-        .addMiddleware({
-          handler: async () => ({ test: "fist option" }),
-        })
-        .addMiddleware({
-          handler: async ({ options }) => {
-            expectTypeOf(options.test).toEqualTypeOf<string>();
-            return { second: `another option, ${options.test}` };
-          },
-        });
+    test("Should accept creation props without input schema", () => {
+      const factory = defaultEndpointsFactory.addMiddleware({
+        handler: async () => ({ test: "fist option" }),
+      });
+      expectTypeOf(factory).toMatchTypeOf<
+        EndpointsFactory<
+          z.ZodIntersection<
+            z.ZodObject<EmptyObject, "strip">,
+            z.ZodObject<EmptyObject, "strip">
+          >,
+          EmptyObject & { test: string }
+        >
+      >();
     });
   });
 

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -7,7 +7,7 @@ import {
   ResultHandler,
   testMiddleware,
 } from "../../src";
-import { EmptyObject } from "../../src/common-helpers";
+import { EmptyObject, EmptySchema } from "../../src/common-helpers";
 import { Endpoint } from "../../src/endpoint";
 import { serializeSchemaForTest } from "../helpers";
 import { z } from "zod";
@@ -77,10 +77,7 @@ describe("EndpointsFactory", () => {
       });
       expectTypeOf(factory).toMatchTypeOf<
         EndpointsFactory<
-          z.ZodIntersection<
-            z.ZodObject<EmptyObject, "strip">,
-            z.ZodObject<EmptyObject, "strip">
-          >,
+          z.ZodIntersection<EmptySchema, EmptySchema>,
           EmptyObject & { test: string }
         >
       >();
@@ -96,7 +93,7 @@ describe("EndpointsFactory", () => {
       }));
       expectTypeOf(newFactory).toEqualTypeOf<
         EndpointsFactory<
-          z.ZodObject<EmptyObject, "strip">,
+          EmptySchema,
           EmptyObject & { option1: string; option2: string }
         >
       >();

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -73,11 +73,9 @@ describe("EndpointsFactory", () => {
     test("Should accept creation props", () => {
       defaultEndpointsFactory
         .addMiddleware({
-          input: z.object({}),
           handler: async () => ({ test: "fist option" }),
         })
         .addMiddleware({
-          input: z.object({}),
           handler: async ({ options }) => {
             expectTypeOf(options.test).toEqualTypeOf<string>();
             return { second: `another option, ${options.test}` };

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -92,6 +92,12 @@ describe("EndpointsFactory", () => {
         option1: "some value",
         option2: "other value",
       }));
+      expectTypeOf(newFactory).toEqualTypeOf<
+        EndpointsFactory<
+          z.ZodObject<EmptyObject, "strip">,
+          EmptyObject & { option1: string; option2: string }
+        >
+      >();
       expect(factory["middlewares"]).toStrictEqual([]);
       expect(factory["resultHandler"]).toStrictEqual(resultHandlerMock);
       expect(newFactory["middlewares"].length).toBe(1);

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -57,13 +57,11 @@ describe("EndpointsFactory", () => {
       defaultEndpointsFactory
         .addMiddleware(
           new Middleware({
-            input: z.object({}),
             handler: async () => ({ test: "fist option" }),
           }),
         )
         .addMiddleware(
           new Middleware({
-            input: z.object({}),
             handler: async ({ options }) => {
               expectTypeOf(options.test).toEqualTypeOf<string>();
               return { second: `another option, ${options.test}` };

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { InputValidationError, Middleware } from "../../src";
 import { EmptyObject } from "../../src/common-helpers";
-import { AbstractMiddleware } from "../../src/middleware";
+import { AbstractMiddleware, ExpressMiddleware } from "../../src/middleware";
 import {
   makeLoggerMock,
   makeRequestMock,
@@ -80,5 +80,13 @@ describe("Middleware", () => {
         response: responseMock,
       });
     });
+  });
+});
+
+describe("ExpressMiddleware", () => {
+  test("should inherit from Middleware", () => {
+    const mw = new ExpressMiddleware(vi.fn());
+    expect(mw).toBeInstanceOf(Middleware);
+    expectTypeOf(mw.getSchema()._output).toEqualTypeOf<EmptyObject>();
   });
 });

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { InputValidationError, Middleware } from "../../src";
+import { EmptyObject } from "../../src/common-helpers";
 import { AbstractMiddleware } from "../../src/middleware";
 import {
   makeLoggerMock,
@@ -9,25 +10,27 @@ import {
 
 describe("Middleware", () => {
   describe("constructor()", () => {
-    test("Should inherit from AbstractMiddleware", () => {
-      const middleware = new Middleware({
-        input: z.object({
-          something: z.number(),
-        }),
-        handler: vi.fn<any>(),
+    test("should inherit from AbstractMiddleware", () => {
+      const mw = new Middleware({
+        input: z.object({ something: z.number() }),
+        handler: vi.fn(),
       });
-      expect(middleware).toBeInstanceOf(AbstractMiddleware);
+      expect(mw).toBeInstanceOf(AbstractMiddleware);
+      expectTypeOf(mw.getSchema()._output).toEqualTypeOf<{
+        something: number;
+      }>();
+    });
+
+    test("should allow to omit input schema", () => {
+      const mw = new Middleware({ handler: vi.fn() });
+      expectTypeOf(mw.getSchema()._output).toEqualTypeOf<EmptyObject>();
     });
 
     describe("#600: Top level refinements", () => {
       test("should allow refinement", () => {
         const mw = new Middleware({
-          input: z
-            .object({
-              something: z.number(),
-            })
-            .refine(() => true),
-          handler: vi.fn<any>(),
+          input: z.object({ something: z.number() }).refine(() => true),
+          handler: vi.fn(),
         });
         expect(mw.getSchema()).toBeInstanceOf(z.ZodEffects);
       });

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -42,19 +42,16 @@ describe("Routing", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const getEndpoint = factory.build({
         methods: ["get"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
       const postEndpoint = factory.build({
         methods: ["post"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
       const getAndPostEndpoint = factory.build({
         methods: ["get", "post"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -120,19 +117,16 @@ describe("Routing", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const getEndpoint = factory.build({
         methods: ["get"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
       const postEndpoint = factory.build({
         methods: ["post"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
       const putAndPatchEndpoint = factory.build({
         methods: ["put", "patch"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -172,7 +166,6 @@ describe("Routing", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
       const putAndPatchEndpoint = factory.build({
         methods: ["put", "patch"],
-        input: z.object({}),
         output: z.object({}),
         handler: vi.fn(),
       });
@@ -259,7 +252,6 @@ describe("Routing", () => {
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
         methods: ["get"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -287,7 +279,6 @@ describe("Routing", () => {
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
         methods: ["get"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });
@@ -319,7 +310,6 @@ describe("Routing", () => {
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
         methods: ["get"],
-        input: z.object({}),
         output: z.object({}),
         handler: handlerMock,
       });

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -200,7 +200,6 @@ describe("Server", () => {
         v1: {
           test: new EndpointsFactory(defaultResultHandler).build({
             method: "get",
-            input: z.object({}),
             output: z.object({}),
             handler: vi.fn(),
           }),
@@ -234,7 +233,6 @@ describe("Server", () => {
         v1: {
           test: new EndpointsFactory(defaultResultHandler).build({
             method: "get",
-            input: z.object({}),
             output: z.object({}),
             handler: vi.fn(),
           }),

--- a/tests/unit/testing.spec.ts
+++ b/tests/unit/testing.spec.ts
@@ -8,7 +8,6 @@ describe("Testing", () => {
     test("Should test an endpoint", async () => {
       const endpoint = defaultEndpointsFactory
         .addMiddleware({
-          input: z.object({}),
           handler: async ({ response }) => {
             response
               .setHeader("X-Some", "header")
@@ -19,7 +18,6 @@ describe("Testing", () => {
         })
         .build({
           method: "get",
-          input: z.object({}),
           output: z.object({}),
           handler: async () => ({}),
         });


### PR DESCRIPTION
The most basic case — no inputs at all and I'd like to simplify the way it's addressed