### PR TITLE
Fix: Duplicated client types in unions

### DIFF
--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -84,7 +84,7 @@ type GetV1AvatarSendInput = {
   userId: string;
 };
 
-type GetV1AvatarSendResponse = string | string;
+type GetV1AvatarSendResponse = string;
 
 type GetV1AvatarStreamInput = {
   userId: string;

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -65,3 +65,20 @@ export const makePropertyIdentifier = (name: string) => {
   }
   return f.createStringLiteral(name);
 };
+
+const primitives: ts.KeywordTypeSyntaxKind[] = [
+  ts.SyntaxKind.AnyKeyword,
+  ts.SyntaxKind.BigIntKeyword,
+  ts.SyntaxKind.BooleanKeyword,
+  ts.SyntaxKind.NeverKeyword,
+  ts.SyntaxKind.NumberKeyword,
+  ts.SyntaxKind.ObjectKeyword,
+  ts.SyntaxKind.StringKeyword,
+  ts.SyntaxKind.SymbolKeyword,
+  ts.SyntaxKind.UndefinedKeyword,
+  ts.SyntaxKind.UnknownKeyword,
+  ts.SyntaxKind.VoidKeyword,
+];
+
+export const isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
+  (primitives as ts.SyntaxKind[]).includes(node.kind);

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -3,36 +3,20 @@ import { z } from "zod";
 import { hasCoercion, tryToTransform } from "./common-helpers";
 import { ezDateInBrand } from "./date-in-schema";
 import { ezDateOutBrand } from "./date-out-schema";
-import { FileSchema, ezFileBrand } from "./file-schema";
+import { ezFileBrand, FileSchema } from "./file-schema";
 import { ProprietaryBrand } from "./proprietary-schemas";
-import { RawSchema, ezRawBrand } from "./raw-schema";
+import { ezRawBrand, RawSchema } from "./raw-schema";
 import { HandlingRules, walkSchema } from "./schema-walker";
 import {
+  addJsDocComment,
+  isPrimitive,
   LiteralType,
+  makePropertyIdentifier,
   Producer,
   ZTSContext,
-  addJsDocComment,
-  makePropertyIdentifier,
 } from "./zts-helpers";
 
 const { factory: f } = ts;
-
-const primitives: ts.KeywordTypeSyntaxKind[] = [
-  ts.SyntaxKind.AnyKeyword,
-  ts.SyntaxKind.BigIntKeyword,
-  ts.SyntaxKind.BooleanKeyword,
-  ts.SyntaxKind.NeverKeyword,
-  ts.SyntaxKind.NumberKeyword,
-  ts.SyntaxKind.ObjectKeyword,
-  ts.SyntaxKind.StringKeyword,
-  ts.SyntaxKind.SymbolKeyword,
-  ts.SyntaxKind.UndefinedKeyword,
-  ts.SyntaxKind.UnknownKeyword,
-  ts.SyntaxKind.VoidKeyword,
-];
-
-const isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
-  (primitives as ts.SyntaxKind[]).includes(node.kind);
 
 const samples = {
   [ts.SyntaxKind.AnyKeyword]: "",

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -511,7 +511,7 @@ type GetV1AvatarSendInput = {
   userId: string;
 };
 
-type GetV1AvatarSendResponse = string | string;
+type GetV1AvatarSendResponse = string;
 
 type GetV1AvatarStreamInput = {
   userId: string;
@@ -754,7 +754,7 @@ type GetV1AvatarSendInput = {
   userId: string;
 };
 
-type GetV1AvatarSendResponse = string | string;
+type GetV1AvatarSendResponse = string;
 
 type GetV1AvatarStreamInput = {
   userId: string;


### PR DESCRIPTION
```diff
- type GetV1AvatarSendResponse = string | string;
+ type GetV1AvatarSendResponse = string;
```