### PR TITLE
Merge intersected objects types in generated client

### DIFF
--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -3,7 +3,7 @@ type Type1 = {
   features: Type1;
 }[];
 
-type GetV1UserRetrieveInput = {} & {
+type GetV1UserRetrieveInput = {
   /** a numeric string containing the id of the user */
   id: string;
 };
@@ -29,7 +29,6 @@ type GetV1UserRetrieveResponse =
 
 type PatchV1UserIdInput = {
   key: string;
-} & {
   id: string;
   name: string;
   birthday: string;

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -173,7 +173,12 @@ const onRecord: Producer = (
 const onIntersection: Producer = (
   { _def }: z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>,
   { next },
-) => f.createIntersectionTypeNode([_def.left, _def.right].map(next));
+) => {
+  if (_def.left instanceof z.ZodObject && _def.right instanceof z.ZodObject) {
+    return next(_def.left.merge(_def.right));
+  }
+  return f.createIntersectionTypeNode([_def.left, _def.right].map(next));
+};
 
 const onDefault: Producer = ({ _def }: z.ZodDefault<z.ZodTypeAny>, { next }) =>
   next(_def.innerType);

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -1,4 +1,3 @@
-import { pluck } from "ramda";
 import ts from "typescript";
 import { z } from "zod";
 import { hasCoercion, tryToTransform } from "./common-helpers";
@@ -178,7 +177,7 @@ const onIntersection: Producer = (
   const nodes = [left, right].map(next);
   const areObjects = nodes.every(ts.isTypeLiteralNode);
   return areObjects
-    ? f.createTypeLiteralNode(pluck("members", nodes).flat())
+    ? f.createTypeLiteralNode(nodes.flatMap(({ members }) => members))
     : f.createIntersectionTypeNode(nodes);
 };
 

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -172,10 +172,10 @@ const onRecord: Producer = (
   );
 
 const onIntersection: Producer = (
-  { _def }: z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>,
+  { _def: { left, right } }: z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>,
   { next },
 ) => {
-  const nodes = [_def.left, _def.right].map(next);
+  const nodes = [left, right].map(next);
   const areObjects = nodes.every(ts.isTypeLiteralNode);
   return areObjects
     ? f.createTypeLiteralNode(pluck("members", nodes).flat())

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -430,7 +430,7 @@ exports[`Integration > Should generate a client for example API 1`] = `
   features: Type1;
 }[];
 
-type GetV1UserRetrieveInput = {} & {
+type GetV1UserRetrieveInput = {
   /** a numeric string containing the id of the user */
   id: string;
 };
@@ -456,7 +456,6 @@ type GetV1UserRetrieveResponse =
 
 type PatchV1UserIdInput = {
   key: string;
-} & {
   id: string;
   name: string;
   birthday: string;
@@ -673,7 +672,7 @@ exports[`Integration > Should generate a types for example API 1`] = `
   features: Type1;
 }[];
 
-type GetV1UserRetrieveInput = {} & {
+type GetV1UserRetrieveInput = {
   /** a numeric string containing the id of the user */
   id: string;
 };
@@ -699,7 +698,6 @@ type GetV1UserRetrieveResponse =
 
 type PatchV1UserIdInput = {
   key: string;
-} & {
   id: string;
   name: string;
   birthday: string;


### PR DESCRIPTION
This should prevent the "empty object type" in the generated client, which is not really a good type.
`Record<string, never>` can not be used in this case, so I'm trying to eliminate the root cause.