### PR TITLE
Replacing `originalError` with `cause` on validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Those error classes are publicly exposed for developers making custom Result Handlers.
 
 ```diff
-  const error = new OutputValidationError(new z.ZodError([]));
+  const error = new InputValidationError(new z.ZodError([]));
 - logger.error(error.originalError.message);
 + logger.error(error.cause.message);
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Version 20
 
+### v20.16.0
+
+- Deprecating `originalError` property on both `InputValidationError` and `OutputValidationError`:
+  - Use `cause` property instead;
+  - Those error classes are publicly exposed for developers making custom Result Handlers.
+
+```diff
+  const error = new OutputValidationError(new z.ZodError([]));
+- logger.error(error.originalError.message);
++ logger.error(error.cause.message);
+```
+
 ### v20.15.3
 
 - Merge intersected object types in generated client:

--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ origins of errors that could happen in runtime and be handled the following way:
 - Ones related to `Endpoint` execution — handled by a `ResultHandler` assigned to the `EndpointsFactory` produced it:
   - Proprietary classes (available to you for your custom handling):
     - `InputValidationError` — when request payload does not match the `input` schema of the endpoint.
-      The default response status code is `400`;
+      The default response status code is `400`, `cause` property contains the original `ZodError`;
     - `OutputValidationError` — when returns of the endpoint's `handler` does not match its `output` schema (`500`);
   - Errors thrown within endpoint's `handler`:
     - `HttpError`, made by `createHttpError()` method of `http-errors` (required peer dependency). The default response

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -68,7 +68,7 @@ export const getMessageFromError = (error: Error): string => {
       .join("; ");
   }
   if (error instanceof OutputValidationError) {
-    const hasFirstField = error.originalError.issues[0]?.path.length > 0;
+    const hasFirstField = error.cause.issues[0]?.path.length > 0;
     return `output${hasFirstField ? "/" : ": "}${error.message}`;
   }
   return error.message;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,8 +38,16 @@ export class IOSchemaError extends Error {
 export class OutputValidationError extends IOSchemaError {
   public override name = "OutputValidationError";
 
-  constructor(public readonly originalError: z.ZodError) {
-    super(getMessageFromError(originalError));
+  constructor(public override readonly cause: z.ZodError) {
+    super(getMessageFromError(cause), { cause });
+  }
+
+  /**
+   * @deprecated use the cause property instead
+   * @todo remove in v21
+   * */
+  public get originalError() {
+    return this.cause;
   }
 }
 
@@ -47,8 +55,16 @@ export class OutputValidationError extends IOSchemaError {
 export class InputValidationError extends IOSchemaError {
   public override name = "InputValidationError";
 
-  constructor(public readonly originalError: z.ZodError) {
-    super(getMessageFromError(originalError));
+  constructor(public override readonly cause: z.ZodError) {
+    super(getMessageFromError(cause), { cause });
+  }
+
+  /**
+   * @deprecated use the cause property instead
+   * @todo remove in v21
+   * */
+  public get originalError() {
+    return this.cause;
   }
 }
 
@@ -58,9 +74,9 @@ export class ResultHandlerError extends Error {
 
   constructor(
     message: string,
-    public readonly originalError?: Error,
+    public override readonly cause?: Error,
   ) {
-    super(message);
+    super(message, { cause });
   }
 }
 

--- a/src/last-resort.ts
+++ b/src/last-resort.ts
@@ -19,8 +19,6 @@ export const lastResortHandler = ({
     .type("text/plain")
     .end(
       `An error occurred while serving the result: ${error.message}.` +
-        (error.originalError
-          ? `\nOriginal error: ${error.originalError.message}.`
-          : ""),
+        (error.cause ? `\nOriginal error: ${error.cause.message}.` : ""),
     );
 };

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -67,7 +67,8 @@ describe("Errors", () => {
       expect(error.name).toBe("OutputValidationError");
     });
 
-    test("should have .originalError property matching the one used for constructing", () => {
+    test("should have .cause property matching the one used for constructing", () => {
+      expect(error.cause).toEqual(zodError);
       expect(error.originalError).toEqual(zodError);
     });
   });
@@ -86,6 +87,7 @@ describe("Errors", () => {
     });
 
     test("should have .originalError property matching the one used for constructing", () => {
+      expect(error.cause).toEqual(zodError);
       expect(error.originalError).toEqual(zodError);
     });
   });
@@ -103,8 +105,8 @@ describe("Errors", () => {
         expect(error.name).toBe("ResultHandlerError");
       });
 
-      test(".originalError should be the original error", () => {
-        expect(error.originalError).toEqual(originalError);
+      test(".cause should be the original error", () => {
+        expect(error.cause).toEqual(originalError);
       });
     },
   );

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -94,8 +94,8 @@ describe("Errors", () => {
 
   describe.each([new Error("test2"), undefined])(
     "ResultHandlerError",
-    (originalError) => {
-      const error = new ResultHandlerError("test", originalError);
+    (cause) => {
+      const error = new ResultHandlerError("test", cause);
 
       test("should be an instance of Error", () => {
         expect(error).toBeInstanceOf(Error);
@@ -106,7 +106,7 @@ describe("Errors", () => {
       });
 
       test(".cause should be the original error", () => {
-        expect(error.cause).toEqual(originalError);
+        expect(error.cause).toEqual(cause);
       });
     },
   );

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -86,7 +86,7 @@ describe("Errors", () => {
       expect(error.name).toBe("InputValidationError");
     });
 
-    test("should have .originalError property matching the one used for constructing", () => {
+    test("should have .cause property matching the one used for constructing", () => {
       expect(error.cause).toEqual(zodError);
       expect(error.originalError).toEqual(zodError);
     });

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -1,3 +1,4 @@
+import { ResultHandlerError } from "../../src/errors";
 import { lastResortHandler } from "../../src/last-resort";
 import { makeLoggerMock, makeResponseMock } from "../../src/testing";
 
@@ -12,7 +13,10 @@ describe("Last Resort Handler", () => {
     lastResortHandler({
       logger: loggerMock,
       response: responseMock,
-      error: new Error("something went wrong"),
+      error: new ResultHandlerError(
+        "something went wrong",
+        new Error("what exactly"),
+      ),
     });
     expect(loggerMock._getLogs().error).toEqual([
       ["Result handler failure: something went wrong."],
@@ -23,7 +27,7 @@ describe("Last Resort Handler", () => {
       "text/plain",
     );
     expect(responseMock._getData()).toBe(
-      "An error occurred while serving the result: something went wrong.",
+      "An error occurred while serving the result: something went wrong.\nOriginal error: what exactly.",
     );
   });
 });


### PR DESCRIPTION
Cherry-picked from #2136 

`cause` is ES2022 feature, its support introduced in Node.js 16.9 

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility
- https://nodejs.org/api/errors.html#errorcause