### PR TITLE
Changing the `cause` on `ResultHandlerError`

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -301,7 +301,7 @@ export class Endpoint<
         logger,
         response,
         error: new ResultHandlerError(
-          makeErrorFromAnything(e).message,
+          makeErrorFromAnything(e),
           error || undefined,
         ),
       });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -74,6 +74,7 @@ export class ResultHandlerError extends Error {
   public override name = "ResultHandlerError";
 
   constructor(
+    /** @desc The error thrown from ResultHandler */
     public override readonly cause: Error,
     /** @desc The error being processed by ResultHandler when it failed */
     public readonly handled?: Error,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -74,10 +74,11 @@ export class ResultHandlerError extends Error {
   public override name = "ResultHandlerError";
 
   constructor(
-    message: string,
-    public override readonly cause?: Error,
+    public override readonly cause: Error,
+    /** @desc The error being processed by ResultHandler when it failed */
+    public readonly processed?: Error,
   ) {
-    super(message, { cause });
+    super(getMessageFromError(cause), { cause });
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -76,7 +76,7 @@ export class ResultHandlerError extends Error {
   constructor(
     public override readonly cause: Error,
     /** @desc The error being processed by ResultHandler when it failed */
-    public readonly processed?: Error,
+    public readonly handled?: Error,
   ) {
     super(getMessageFromError(cause), { cause });
   }

--- a/src/last-resort.ts
+++ b/src/last-resort.ts
@@ -19,6 +19,8 @@ export const lastResortHandler = ({
     .type("text/plain")
     .end(
       `An error occurred while serving the result: ${error.message}.` +
-        (error.cause ? `\nOriginal error: ${error.cause.message}.` : ""),
+        (error.processed
+          ? `\nOriginal error: ${error.processed.message}.`
+          : ""),
     );
 };

--- a/src/last-resort.ts
+++ b/src/last-resort.ts
@@ -19,8 +19,6 @@ export const lastResortHandler = ({
     .type("text/plain")
     .end(
       `An error occurred while serving the result: ${error.message}.` +
-        (error.processed
-          ? `\nOriginal error: ${error.processed.message}.`
-          : ""),
+        (error.handled ? `\nOriginal error: ${error.handled.message}.` : ""),
     );
 };

--- a/src/result-helpers.ts
+++ b/src/result-helpers.ts
@@ -27,7 +27,7 @@ export const normalize = <A extends unknown[]>(
     assert(
       subject.length,
       new ResultHandlerError(
-        `At least one ${features.variant} response schema required.`,
+        new Error(`At least one ${features.variant} response schema required.`),
       ),
     );
   }

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -70,7 +70,7 @@ export const createNotFoundHandler =
       lastResortHandler({
         response,
         logger,
-        error: new ResultHandlerError(makeErrorFromAnything(e).message, error),
+        error: new ResultHandlerError(makeErrorFromAnything(e), error),
       });
     }
   };

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -100,8 +100,8 @@ describe("Errors", () => {
 
   describe.each([new Error("test2"), undefined])(
     "ResultHandlerError",
-    (processed) => {
-      const error = new ResultHandlerError(new Error("test"), processed);
+    (handled) => {
+      const error = new ResultHandlerError(new Error("test"), handled);
 
       test("should be an instance of Error", () => {
         expect(error).toBeInstanceOf(Error);
@@ -115,8 +115,8 @@ describe("Errors", () => {
         expect(error.cause).toEqual(new Error("test"));
       });
 
-      test(".processed should be the processed error", () => {
-        expect(error.processed).toEqual(processed);
+      test(".handled should be the error handled by ResultHandler", () => {
+        expect(error.handled).toEqual(handled);
       });
     },
   );

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -100,8 +100,8 @@ describe("Errors", () => {
 
   describe.each([new Error("test2"), undefined])(
     "ResultHandlerError",
-    (cause) => {
-      const error = new ResultHandlerError("test", cause);
+    (processed) => {
+      const error = new ResultHandlerError(new Error("test"), processed);
 
       test("should be an instance of Error", () => {
         expect(error).toBeInstanceOf(Error);
@@ -111,8 +111,12 @@ describe("Errors", () => {
         expect(error.name).toBe("ResultHandlerError");
       });
 
-      test(".cause should be the original error", () => {
-        expect(error.cause).toEqual(cause);
+      test(".cause should be the originally thrown error", () => {
+        expect(error.cause).toEqual(new Error("test"));
+      });
+
+      test(".processed should be the processed error", () => {
+        expect(error.processed).toEqual(processed);
       });
     },
   );

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -14,7 +14,7 @@ describe("Last Resort Handler", () => {
       logger: loggerMock,
       response: responseMock,
       error: new ResultHandlerError(
-        "something went wrong",
+        new Error("something went wrong"),
         new Error("what exactly"),
       ),
     });

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -15,7 +15,7 @@ describe("Last Resort Handler", () => {
       response: responseMock,
       error: new ResultHandlerError(
         new Error("something went wrong"),
-        new Error("what exactly"),
+        new Error("what went wrong before"),
       ),
     });
     expect(loggerMock._getLogs().error).toEqual([
@@ -27,7 +27,7 @@ describe("Last Resort Handler", () => {
       "text/plain",
     );
     expect(responseMock._getData()).toBe(
-      "An error occurred while serving the result: something went wrong.\nOriginal error: what exactly.",
+      "An error occurred while serving the result: something went wrong.\nOriginal error: what went wrong before.",
     );
   });
 });

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -49,7 +49,7 @@ describe("ResultHandler", () => {
         }).getPositiveResponse(z.object({})),
       ).toThrow(
         new ResultHandlerError(
-          "At least one positive response schema required.",
+          new Error("At least one positive response schema required."),
         ),
       );
       expect(() =>
@@ -60,7 +60,7 @@ describe("ResultHandler", () => {
         }).getNegativeResponse(),
       ).toThrow(
         new ResultHandlerError(
-          "At least one negative response schema required.",
+          new Error("At least one negative response schema required."),
         ),
       );
     });


### PR DESCRIPTION
Adding another prop to hold the error that was processed by the ResultHandler when it failed.
Partially cherry-picked from #2136 , but this one has no regression