### PR TITLE
Better error logging

### DIFF
--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -98,7 +98,8 @@ export const logInternalError = ({
   statusCode: number;
 }) => {
   if (statusCode === 500) {
-    logger.error(`Internal server error\n${error.stack}\n`, {
+    logger.error("Internal server error", {
+      error,
       url: request.url,
       payload: input,
     });

--- a/src/last-resort.ts
+++ b/src/last-resort.ts
@@ -13,7 +13,7 @@ export const lastResortHandler = ({
   logger,
   response,
 }: LastResortHandlerParams) => {
-  logger.error(`Result handler failure: ${error.message}.`);
+  logger.error("Result handler failure", error);
   response
     .status(500)
     .type("text/plain")

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -76,6 +76,21 @@ describe("BuiltinLogger", () => {
       expect(logSpy.mock.calls).toMatchSnapshot();
     });
 
+    test("should handle error including cause", () => {
+      const error = new Error("something", { cause: new Error("anything") });
+      const { logger, logSpy } = makeLogger({ level: "warn", color: false });
+      logger.error("Failure", error);
+      expect(logSpy).toHaveBeenCalledOnce();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /2022-01-01T00:00:00\.000Z error: Failure \{ Error: something/,
+        ),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/\[cause]: Error: anything/),
+      );
+    });
+
     test.each(["debug", "warn"] as const)(
       "Should handle circular references within subject %#",
       (level) => {

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -256,7 +256,7 @@ describe("Endpoint", () => {
         endpoint,
       });
       expect(loggerMock._getLogs().error).toEqual([
-        ["Result handler failure: Something unexpected happened."],
+        ["Result handler failure", new Error("Something unexpected happened")],
       ]);
       expect(spy).toHaveBeenCalledWith({
         error: null,
@@ -481,7 +481,7 @@ describe("Endpoint", () => {
       });
       const { loggerMock, responseMock } = await testEndpoint({ endpoint });
       expect(loggerMock._getLogs().error).toEqual([
-        ["Result handler failure: Something unexpected happened."],
+        ["Result handler failure", new Error("Something unexpected happened")],
       ]);
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getData()).toBe(

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -10,16 +10,13 @@ describe("Last Resort Handler", () => {
   test("should log the supplied error and respond with plain text", () => {
     const responseMock = makeResponseMock();
     const loggerMock = makeLoggerMock();
-    lastResortHandler({
-      logger: loggerMock,
-      response: responseMock,
-      error: new ResultHandlerError(
-        new Error("something went wrong"),
-        new Error("what went wrong before"),
-      ),
-    });
+    const error = new ResultHandlerError(
+      new Error("something went wrong"),
+      new Error("what went wrong before"),
+    );
+    lastResortHandler({ error, logger: loggerMock, response: responseMock });
     expect(loggerMock._getLogs().error).toEqual([
-      ["Result handler failure: something went wrong."],
+      ["Result handler failure", error],
     ]);
     expect(responseMock._getStatusCode()).toBe(500);
     expect(responseMock._getHeaders()).toHaveProperty(

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -84,8 +84,9 @@ describe("ResultHandler", () => {
     test("Should handle generic error", () => {
       const responseMock = makeResponseMock();
       const loggerMock = makeLoggerMock();
+      const error = new Error("Some error");
       subject.execute({
-        error: new Error("Some error"),
+        error,
         input: { something: 453 },
         output: { anything: 118 },
         request: requestMock,
@@ -95,8 +96,9 @@ describe("ResultHandler", () => {
       });
       expect(loggerMock._getLogs().error).toEqual([
         [
-          expect.stringMatching(/^Internal server error\nError: Some error/),
+          "Internal server error",
           {
+            error,
             payload: { something: 453 },
             url: "http://something/v1/anything",
           },


### PR DESCRIPTION
Complete error objects in logs instead of only `message`.

Cherry-picked from #2136 