### PR TITLE
Exp(21): Operate `HttpError` in Result Handlers

### DIFF
--- a/example/factories.ts
+++ b/example/factories.ts
@@ -4,7 +4,6 @@ import {
   ResultHandler,
   defaultResultHandler,
   ez,
-  ensureHttpError,
 } from "../src";
 import { config } from "./config";
 import { authMiddleware } from "./middlewares";
@@ -95,17 +94,16 @@ export const statusDependingFactory = new EndpointsFactory({
     ],
     handler: ({ error, response, output }) => {
       if (error) {
-        const httpError = ensureHttpError(error);
         const doesExist =
-          httpError.statusCode === 409 &&
-          "id" in httpError &&
-          typeof httpError.id === "number";
+          error.statusCode === 409 &&
+          "id" in error &&
+          typeof error.id === "number";
         return void response
-          .status(httpError.statusCode)
+          .status(error.statusCode)
           .json(
             doesExist
-              ? { status: "exists", id: httpError.id }
-              : { status: "error", reason: httpError.message },
+              ? { status: "exists", id: error.id }
+              : { status: "error", reason: error.message },
           );
       }
       response.status(201).json({ status: "created", data: output });

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -49,6 +49,12 @@ export interface CommonConfig<TAG extends string = string> {
    */
   errorHandler?: AbstractResultHandler;
   /**
+   * @desc Interprets an error into a status code for HttpError handled by a ResultHandler
+   * @default error instanceof InputValidationError ? 400 : 500
+   * @todo naming
+   * */
+  getStatusCode?: (error: Error) => number;
+  /**
    * @desc Built-in logger configuration or an instance of any compatible logger.
    * @example { level: "debug", color: true }
    * */

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -278,6 +278,7 @@ export class Endpoint<
     input,
     output,
     options,
+    config: { getStatusCode },
   }: {
     error: Error | null;
     request: Request;
@@ -286,8 +287,9 @@ export class Endpoint<
     input: FlatObject;
     output: FlatObject | null;
     options: Partial<OPT>;
+    config: CommonConfig;
   }) {
-    const httpError = error && ensureHttpError(error);
+    const httpError = error && ensureHttpError(error, getStatusCode);
     try {
       await this.#resultHandler.execute({
         error: httpError,
@@ -348,13 +350,8 @@ export class Endpoint<
         logger,
         options,
       });
-      if (response.writableEnded) {
-        return;
-      }
-      if (method === "options") {
-        response.status(200).end();
-        return;
-      }
+      if (response.writableEnded) return;
+      if (method === "options") return void response.status(200).end();
       output = await this.#parseOutput(
         await this.#parseAndRunHandler({
           input,
@@ -373,6 +370,7 @@ export class Endpoint<
       error,
       logger,
       options,
+      config,
     });
   }
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -22,6 +22,7 @@ import { AuxMethod, Method } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import { ContentType, contentTypes } from "./content-type";
 import { AbstractResultHandler } from "./result-handler";
+import { ensureHttpError } from "./result-helpers";
 import { Security } from "./security";
 
 export type Handler<IN, OUT, OPT> = (params: {
@@ -286,9 +287,10 @@ export class Endpoint<
     output: FlatObject | null;
     options: Partial<OPT>;
   }) {
+    const httpError = error && ensureHttpError(error);
     try {
       await this.#resultHandler.execute({
-        error,
+        error: httpError,
         output,
         request,
         response,
@@ -300,7 +302,7 @@ export class Endpoint<
       lastResortHandler({
         logger,
         response,
-        error: new ResultHandlerError(ensureError(e), error || undefined),
+        error: new ResultHandlerError(ensureError(e), httpError || undefined),
       });
     }
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+import { HttpError } from "http-errors";
 import { z } from "zod";
 import { getMessageFromError } from "./common-helpers";
 import { OpenAPIContext } from "./documentation-helpers";
@@ -61,7 +62,7 @@ export class ResultHandlerError extends Error {
     /** @desc The error thrown from ResultHandler */
     public override readonly cause: Error,
     /** @desc The error being processed by ResultHandler when it failed */
-    public readonly handled?: Error,
+    public readonly handled?: HttpError,
   ) {
     super(getMessageFromError(cause), { cause });
   }

--- a/src/result-helpers.ts
+++ b/src/result-helpers.ts
@@ -5,6 +5,7 @@ import { memoizeWith } from "ramda";
 import { z } from "zod";
 import { NormalizedResponse, ResponseVariant } from "./api-response";
 import { FlatObject, getMessageFromError } from "./common-helpers";
+import { CommonConfig } from "./config-type";
 import { InputValidationError, ResultHandlerError } from "./errors";
 import { ActualLogger } from "./logger-helpers";
 import type { LazyResult, Result } from "./result-handler";
@@ -58,15 +59,16 @@ export const logServerError = (
 /**
  * @example InputValidationError —> BadRequest(400)
  * @example Error —> InternalServerError(500)
- * @todo make it configurable?
  * */
-export const ensureHttpError = (error: Error): HttpError => {
-  if (isHttpError(error)) return error;
-  return createHttpError(
+export const ensureHttpError = (
+  error: Error,
+  getStatusCode: CommonConfig["getStatusCode"] = () =>
     error instanceof InputValidationError ? 400 : 500,
-    getMessageFromError(error),
-    { cause: error.cause || error },
-  );
+): HttpError => {
+  if (isHttpError(error)) return error;
+  return createHttpError(getStatusCode(error), getMessageFromError(error), {
+    cause: error.cause || error,
+  });
 };
 
 const isProduction = memoizeWith(

--- a/src/result-helpers.ts
+++ b/src/result-helpers.ts
@@ -58,6 +58,7 @@ export const logServerError = (
 /**
  * @example InputValidationError —> BadRequest(400)
  * @example Error —> InternalServerError(500)
+ * @todo make it configurable?
  * */
 export const ensureHttpError = (error: Error): HttpError => {
   if (isHttpError(error)) return error;

--- a/src/result-helpers.ts
+++ b/src/result-helpers.ts
@@ -59,6 +59,8 @@ export const logServerError = (
 /**
  * @example InputValidationError —> BadRequest(400)
  * @example Error —> InternalServerError(500)
+ * @todo remove from index
+ * @todo remove from migration
  * */
 export const ensureHttpError = (
   error: Error,

--- a/tests/system/__snapshots__/system.spec.ts.snap
+++ b/tests/system/__snapshots__/system.spec.ts.snap
@@ -19,7 +19,10 @@ exports[`App in production mode > Negative > Should treat custom errors in endpo
     "cause": AssertionError({
       "message": "I am faulty",
     }),
-    "handled": AssertionError({
+    "handled": InternalServerError({
+      "cause": AssertionError({
+        "message": "Custom error in the Endpoint input validation",
+      }),
       "message": "Custom error in the Endpoint input validation",
     }),
     "message": "I am faulty",
@@ -34,7 +37,10 @@ exports[`App in production mode > Negative > Should treat custom errors in middl
     "cause": AssertionError({
       "message": "I am faulty",
     }),
-    "handled": AssertionError({
+    "handled": InternalServerError({
+      "cause": AssertionError({
+        "message": "Custom error in the Middleware input validation",
+      }),
       "message": "Custom error in the Middleware input validation",
     }),
     "message": "I am faulty",

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -1,3 +1,4 @@
+import createHttpError from "http-errors";
 import { z } from "zod";
 import { DocumentationError, RoutingError } from "../../src";
 import {
@@ -96,7 +97,7 @@ describe("Errors", () => {
     });
   });
 
-  describe.each([new Error("test2"), undefined])(
+  describe.each([createHttpError(500, "test2"), undefined])(
     "ResultHandlerError",
     (handled) => {
       const error = new ResultHandlerError(new Error("test"), handled);

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -25,7 +25,7 @@ describe("Last Resort Handler", () => {
         const loggerMock = makeLoggerMock();
         const error = new ResultHandlerError(
           cause,
-          new Error("what went wrong before"),
+          createHttpError(500, "what went wrong before"),
         );
         lastResortHandler({
           error,

--- a/tests/unit/result-handler.spec.ts
+++ b/tests/unit/result-handler.spec.ts
@@ -6,6 +6,7 @@ import {
   arrayResultHandler,
   defaultResultHandler,
   ResultHandler,
+  ensureHttpError,
 } from "../../src";
 import { ResultHandlerError } from "../../src/errors";
 import { metaSymbol } from "../../src/metadata";
@@ -84,7 +85,7 @@ describe("ResultHandler", () => {
     test("Should handle generic error", () => {
       const responseMock = makeResponseMock();
       const loggerMock = makeLoggerMock();
-      const error = new Error("Some error");
+      const error = createHttpError(500, "Some error");
       subject.execute({
         error,
         input: { something: 453 },
@@ -98,7 +99,7 @@ describe("ResultHandler", () => {
         [
           "Server side error",
           {
-            error: createHttpError(500, error),
+            error,
             payload: { something: 453 },
             url: "http://something/v1/anything",
           },
@@ -120,16 +121,18 @@ describe("ResultHandler", () => {
       const responseMock = makeResponseMock();
       const loggerMock = makeLoggerMock();
       subject.execute({
-        error: new InputValidationError(
-          new z.ZodError([
-            {
-              code: "invalid_type",
-              message: "Expected string, got number",
-              path: ["something"],
-              expected: "string",
-              received: "number",
-            },
-          ]),
+        error: ensureHttpError(
+          new InputValidationError(
+            new z.ZodError([
+              {
+                code: "invalid_type",
+                message: "Expected string, got number",
+                path: ["something"],
+                expected: "string",
+                received: "number",
+              },
+            ]),
+          ),
         ),
         input: { something: 453 },
         output: { anything: 118 },


### PR DESCRIPTION
Due to #2144 

- It might be even better to `ensureHttpError()` internally, so that won't be required to call it in every result handler.
- [x] however, some custom handling should still be possible to customize, presumably in config
- [ ] migration in that case should be changed