### PR TITLE
Making `logger` and its `level` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 - Configuring built-in logger made optional:
   - Built-in logger configuration option `level` made optional as well as the `logger` option for `createConfig()`;
-  - Using `debug` level by default, or `warn` when `NODE_ENV=production`;
+  - Using `debug` level by default, or `warn` when `NODE_ENV=production`.
+- Fixed performance issue on `BuiltinLogger` when its `color` option is not set in config:
+  - `.child()` method is 50x times faster now by only detecting the color support once;
+  - Color autodetection was introduced in v18.3.0.
 
 ### v20.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Version 20
 
+### v20.19.0
+
+- Configuring built-in logger made optional:
+  - Built-in logger configuration option `level` made optional;
+  - Using `debug` level by default, or `warn` when `NODE_ENV=production`;
+
+```diff
+  createConfig({
+-   logger: { level: "debug" }
+  });
+```
+
 ### v20.18.0
 
 - Introducing `ensureHttpError()` method that converts any `Error` into `HttpError`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v20.19.0
 
 - Configuring built-in logger made optional:
-  - Built-in logger configuration option `level` made optional;
+  - Built-in logger configuration option `level` made optional as well as the `logger` option for `createConfig()`;
   - Using `debug` level by default, or `warn` when `NODE_ENV=production`;
 
 ### v20.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@
   - Built-in logger configuration option `level` made optional;
   - Using `debug` level by default, or `warn` when `NODE_ENV=production`;
 
-```diff
-  createConfig({
--   logger: { level: "debug" }
-  });
-```
-
 ### v20.18.0
 
 - Introducing `ensureHttpError()` method that converts any `Error` into `HttpError`:

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ your API at [Let's Encrypt](https://letsencrypt.org/).
 
 ## Customizing logger
 
-By default, library uses a simple built-in console logger, that you can configure this way (these are defaults):
+A simple built-in console logger is used by default with the following options that you can configure:
 
 ```typescript
 import { createConfig } from "express-zod-api";

--- a/README.md
+++ b/README.md
@@ -619,9 +619,9 @@ By default, library uses a simple built-in console logger, that you can configur
 import { createConfig } from "express-zod-api";
 const config = createConfig({
   logger: {
-    level: "debug", // or "warn" in production mode,
-    color: true,
-    depth: 2,
+    level: "debug", // or "warn" in production mode
+    color: undefined, // detects automatically, boolean
+    depth: 2, // controls how deeply entities should be inspected
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ const config = createConfig({
     listen: 8090, // port, UNIX socket or options
   },
   cors: true,
-  logger: { level: "debug", color: true },
 });
 ```
 
@@ -614,8 +613,20 @@ your API at [Let's Encrypt](https://letsencrypt.org/).
 
 ## Customizing logger
 
-If the simple console output of the built-in logger is not enough for you, you can connect any other compatible one.
-It must support at least the following methods: `info()`, `debug()`, `error()` and `warn()`.
+By default, library uses a simple built-in console logger, that you can configure this way (these are defaults):
+
+```typescript
+import { createConfig } from "express-zod-api";
+const config = createConfig({
+  logger: {
+    level: "debug", // or "warn" in production mode,
+    color: true,
+    depth: 2,
+  },
+});
+```
+
+You can also replace it with a one having at least the following methods: `info()`, `debug()`, `error()` and `warn()`.
 Winston and Pino support is well known. Here is an example configuring `pino` logger with `pino-pretty` extension:
 
 ```typescript
@@ -653,7 +664,6 @@ declare module "express-zod-api" {
 }
 
 const config = createConfig({
-  logger: { level: "debug", color: true },
   childLoggerProvider: ({ parent, request }) =>
     parent.child({ requestId: randomUUID() }),
 });
@@ -668,11 +678,10 @@ invoke the returned callback. The default severity of those measurements is `deb
 ```typescript
 import { createConfig, BuiltinLogger } from "express-zod-api";
 
-// This enables the .profile() method on "logger":
+// This enables the .profile() method on built-in logger:
 declare module "express-zod-api" {
   interface LoggerOverrides extends BuiltinLogger {}
 }
-const config = createConfig({ logger: { level: "debug", color: true } });
 
 // Inside a handler of Endpoint, Middleware or ResultHandler:
 const done = logger.profile("expensive operation");

--- a/example/config.ts
+++ b/example/config.ts
@@ -21,10 +21,6 @@ export const config = createConfig({
     },
   },
   cors: true,
-  logger: {
-    level: "debug",
-    color: true,
-  },
   tags: {
     users: "Everything about the users",
     files: "Everything about the files processing",

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -17,17 +17,12 @@ export interface BuiltinLoggerConfig {
   /**
    * @desc The minimal severity to log or "silent" to disable logging
    * @example "debug" also enables pretty output for inspected entities
-   * @default "debug", or "warn" when NODE_ENV=production
    * */
   level: "silent" | "warn" | "info" | "debug";
-  /**
-   * @desc Enables colors on printed severity and inspected entities
-   * @default Ansis::isSupported()
-   * */
+  /** @desc Enables colors on printed severity and inspected entities */
   color: boolean;
   /**
    * @desc Control how deeply entities should be inspected
-   * @default 2
    * @example null
    * @example Infinity
    * */

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -49,8 +49,8 @@ interface ProfilerOptions {
 
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
-  protected hasColor: boolean;
-  protected level: NonNullable<BuiltinLoggerConfig["level"]>;
+  protected readonly hasColor: boolean;
+  protected readonly level: NonNullable<BuiltinLoggerConfig["level"]>;
   protected readonly styles: Record<Severity, Ansis> = {
     debug: blue,
     info: green,

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -17,7 +17,7 @@ export interface BuiltinLoggerConfig {
   /**
    * @desc The minimal severity to log or "silent" to disable logging
    * @example "debug" also enables pretty output for inspected entities
-   * @default "warn" when NODE_ENV=production and "debug" otherwise
+   * @default "debug", or "warn" when NODE_ENV=production
    * */
   level?: "silent" | "warn" | "info" | "debug";
   /**

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -59,7 +59,7 @@ export class BuiltinLogger implements AbstractLogger {
   };
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
-  public constructor(protected config: BuiltinLoggerConfig) {
+  public constructor(protected config: BuiltinLoggerConfig = {}) {
     const {
       color: hasColor = new Ansis().isSupported(),
       level = isProduction() ? "warn" : "debug",

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -79,23 +79,15 @@ export class BuiltinLogger implements AbstractLogger {
       ctx: { requestId, ...ctx },
       color: hasColor,
     } = this.config;
-    if (level === "silent" || isHidden(method, level)) {
-      return;
-    }
+    if (level === "silent" || isHidden(method, level)) return;
     const output: string[] = [new Date().toISOString()];
-    if (requestId) {
-      output.push(hasColor ? cyanBright(requestId) : requestId);
-    }
+    if (requestId) output.push(hasColor ? cyanBright(requestId) : requestId);
     output.push(
       hasColor ? `${this.styles[method](method)}:` : `${method}:`,
       message,
     );
-    if (meta !== undefined) {
-      output.push(this.prettyPrint(meta));
-    }
-    if (Object.keys(ctx).length > 0) {
-      output.push(this.prettyPrint(ctx));
-    }
+    if (meta !== undefined) output.push(this.prettyPrint(meta));
+    if (Object.keys(ctx).length > 0) output.push(this.prettyPrint(ctx));
     console.log(output.join(" "));
   }
 

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -19,24 +19,24 @@ export interface BuiltinLoggerConfig {
    * @example "debug" also enables pretty output for inspected entities
    * @default "debug", or "warn" when NODE_ENV=production
    * */
-  level?: "silent" | "warn" | "info" | "debug";
+  level: "silent" | "warn" | "info" | "debug";
   /**
    * @desc Enables colors on printed severity and inspected entities
    * @default Ansis::isSupported()
    * */
-  color?: boolean;
+  color: boolean;
   /**
    * @desc Control how deeply entities should be inspected
    * @default 2
    * @example null
    * @example Infinity
    * */
-  depth?: number | null;
+  depth: number | null;
   /**
    * @desc Context: the metadata applicable for each logged entry, used by .child() method
    * @see childLoggerProvider
    * */
-  ctx?: Context;
+  ctx: Context;
 }
 
 interface ProfilerOptions {
@@ -49,7 +49,7 @@ interface ProfilerOptions {
 
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
-  protected readonly config: Required<BuiltinLoggerConfig>;
+  protected readonly config: BuiltinLoggerConfig;
   protected readonly styles: Record<Severity, Ansis> = {
     debug: blue,
     info: green,
@@ -58,7 +58,7 @@ export class BuiltinLogger implements AbstractLogger {
   };
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
-  public constructor(config: BuiltinLoggerConfig = {}) {
+  public constructor(config: Partial<BuiltinLoggerConfig> = {}) {
     const {
       color = new Ansis().isSupported(),
       level = isProduction() ? "warn" : "debug",

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { pickBy, xprod } from "ramda";
+import { memoizeWith, pickBy, xprod } from "ramda";
 import { z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
@@ -150,3 +150,8 @@ export const tryToTransform = <T>(
 /** @desc can still be an array, use Array.isArray() or rather R.type() to exclude that case */
 export const isObject = (subject: unknown) =>
   typeof subject === "object" && subject !== null;
+
+export const isProduction = memoizeWith(
+  () => process.env.TSUP_STATIC as string, // dynamic in tests, but static in build
+  () => process.env.NODE_ENV === "production",
+);

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -51,8 +51,9 @@ export interface CommonConfig<TAG extends string = string> {
   /**
    * @desc Built-in logger configuration or an instance of any compatible logger.
    * @example { level: "debug", color: true }
+   * @default {}
    * */
-  logger: BuiltinLoggerConfig | AbstractLogger;
+  logger?: BuiltinLoggerConfig | AbstractLogger;
   /**
    * @desc A child logger returned by this function can override the logger in all handlers for each request
    * @example ({ parent }) => parent.child({ requestId: uuid() })

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -51,6 +51,7 @@ export interface CommonConfig<TAG extends string = string> {
   /**
    * @desc Built-in logger configuration or an instance of any compatible logger.
    * @example { level: "debug", color: true }
+   * @default { level: NODE_ENV === "production" ? "warn" : "debug", color: isSupported(), depth: 2 }
    * */
   logger?: Partial<BuiltinLoggerConfig> | AbstractLogger;
   /**

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -51,7 +51,6 @@ export interface CommonConfig<TAG extends string = string> {
   /**
    * @desc Built-in logger configuration or an instance of any compatible logger.
    * @example { level: "debug", color: true }
-   * @default {}
    * */
   logger?: BuiltinLoggerConfig | AbstractLogger;
   /**

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -52,7 +52,7 @@ export interface CommonConfig<TAG extends string = string> {
    * @desc Built-in logger configuration or an instance of any compatible logger.
    * @example { level: "debug", color: true }
    * */
-  logger?: BuiltinLoggerConfig | AbstractLogger;
+  logger?: Partial<BuiltinLoggerConfig> | AbstractLogger;
   /**
    * @desc A child logger returned by this function can override the logger in all handlers for each request
    * @example ({ parent }) => parent.child({ requestId: uuid() })

--- a/src/result-helpers.ts
+++ b/src/result-helpers.ts
@@ -1,10 +1,13 @@
 import { Request } from "express";
 import createHttpError, { HttpError, isHttpError } from "http-errors";
 import assert from "node:assert/strict";
-import { memoizeWith } from "ramda";
 import { z } from "zod";
 import { NormalizedResponse, ResponseVariant } from "./api-response";
-import { FlatObject, getMessageFromError } from "./common-helpers";
+import {
+  FlatObject,
+  getMessageFromError,
+  isProduction,
+} from "./common-helpers";
 import { InputValidationError, ResultHandlerError } from "./errors";
 import { ActualLogger } from "./logger-helpers";
 import type { LazyResult, Result } from "./result-handler";
@@ -74,11 +77,6 @@ export const ensureHttpError = (error: Error): HttpError => {
     { cause: error.cause || error },
   );
 };
-
-const isProduction = memoizeWith(
-  () => process.env.TSUP_STATIC as string, // dynamic in tests, but static in build
-  () => process.env.NODE_ENV === "production",
-);
 
 export const getPublicErrorMessage = (error: HttpError): string =>
   isProduction() && !error.expose

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ const makeCommonEntities = (config: CommonConfig) => {
   const errorHandler = config.errorHandler || defaultResultHandler;
   const rootLogger = isLoggerInstance(config.logger)
     ? config.logger
-    : new BuiltinLogger(config.logger);
+    : new BuiltinLogger(config.logger || {});
   rootLogger.debug("Running", {
     build: process.env.TSUP_BUILD || "from sources",
     env: process.env.NODE_ENV || "development",

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ const makeCommonEntities = (config: CommonConfig) => {
   const errorHandler = config.errorHandler || defaultResultHandler;
   const rootLogger = isLoggerInstance(config.logger)
     ? config.logger
-    : new BuiltinLogger(config.logger || {});
+    : new BuiltinLogger(config.logger);
   rootLogger.debug("Running", {
     build: process.env.TSUP_BUILD || "from sources",
     env: process.env.NODE_ENV || "development",

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -1,13 +1,94 @@
+import { Ansis, blue, cyanBright, green, hex, red } from "ansis";
+import { inspect } from "node:util";
 import { bench } from "vitest";
+import { BuiltinLogger, FlatObject } from "../../src";
+import { BuiltinLoggerConfig } from "../../src/builtin-logger";
+import { AbstractLogger, isHidden, Severity } from "../../src/logger-helpers";
 
-describe("Experiment for isServerSideIssue()", () => {
-  const env = process.env.NODE_ENV;
+describe("Experiment for builtin logger", () => {
+  interface Context extends FlatObject {
+    requestId?: string;
+  }
 
-  bench("access", () => {
-    return void process.env.NODE_ENV;
+  class Master implements AbstractLogger {
+    protected hasColor: boolean;
+    protected readonly styles: Record<Severity, Ansis> = {
+      debug: blue,
+      info: green,
+      warn: hex("#FFA500"),
+      error: red,
+    };
+
+    /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
+    public constructor(protected config: Partial<BuiltinLoggerConfig>) {
+      const { color: hasColor = new Ansis().isSupported() } = config;
+      this.hasColor = hasColor;
+    }
+
+    protected prettyPrint(subject: unknown) {
+      const { depth = 2 } = this.config;
+      return inspect(subject, {
+        depth,
+        colors: this.hasColor,
+        breakLength: this.config.level === "debug" ? 80 : Infinity,
+        compact: this.config.level === "debug" ? 3 : true,
+      });
+    }
+
+    protected print(method: Severity, message: string, meta?: unknown) {
+      if (
+        this.config.level === "silent" ||
+        isHidden(method, this.config.level!)
+      ) {
+        return;
+      }
+      const { requestId, ...ctx } = this.config.ctx || {};
+      const output: string[] = [new Date().toISOString()];
+      if (requestId) {
+        output.push(this.hasColor ? cyanBright(requestId) : requestId);
+      }
+      output.push(
+        this.hasColor ? `${this.styles[method](method)}:` : `${method}:`,
+        message,
+      );
+      if (meta !== undefined) {
+        output.push(this.prettyPrint(meta));
+      }
+      if (Object.keys(ctx).length > 0) {
+        output.push(this.prettyPrint(ctx));
+      }
+      console.log(output.join(" "));
+    }
+
+    public debug(message: string, meta?: unknown) {
+      this.print("debug", message, meta);
+    }
+
+    public info(message: string, meta?: unknown) {
+      this.print("info", message, meta);
+    }
+
+    public warn(message: string, meta?: unknown) {
+      this.print("warn", message, meta);
+    }
+
+    public error(message: string, meta?: unknown) {
+      this.print("error", message, meta);
+    }
+
+    public child(ctx: Context) {
+      return new BuiltinLogger({ ...this.config, ctx });
+    }
+  }
+
+  const master = new Master({ level: "debug" });
+  const featured = new BuiltinLogger();
+
+  bench("master", () => {
+    return void master.child({});
   });
 
-  bench("cached", () => {
-    return void (env === "production");
+  bench("featured", () => {
+    return void featured.child({});
   });
 });

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -16,7 +16,7 @@ describe("BuiltinLogger", () => {
     vi.useRealTimers();
   });
 
-  const makeLogger = (props?: BuiltinLoggerConfig) => {
+  const makeLogger = (props?: Partial<BuiltinLoggerConfig>) => {
     const logger = new BuiltinLogger(props);
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     return { logger, logSpy };

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -51,7 +51,9 @@ describe("BuiltinLogger", () => {
         vi.stubEnv("TSUP_STATIC", mode);
         vi.stubEnv("NODE_ENV", mode);
         const { logger } = makeLogger();
-        expect(logger["level"]).toBe(mode === "production" ? "warn" : "debug");
+        expect(logger["config"]["level"]).toBe(
+          mode === "production" ? "warn" : "debug",
+        );
       },
     );
 

--- a/tests/unit/config-type.spec.ts
+++ b/tests/unit/config-type.spec.ts
@@ -29,7 +29,6 @@ describe("ConfigType", () => {
       const argument = {
         app: vi.fn() as unknown as IRouter,
         cors: true,
-        logger: { level: "silent" as const },
       };
       const config = createConfig(argument);
       expect(config).toEqual(argument);

--- a/tests/unit/logger-helpers.spec.ts
+++ b/tests/unit/logger-helpers.spec.ts
@@ -51,7 +51,7 @@ describe("Logger helpers", () => {
   });
 
   describe("isLoggerInstance()", () => {
-    test.each<BuiltinLoggerConfig>([
+    test.each<Partial<BuiltinLoggerConfig>>([
       { level: "silent" },
       { level: "debug", color: false },
       { level: "info", color: true },


### PR DESCRIPTION
- Due to #2144 it's now possible to make logging `level` optional with a default depending on environment.
- Since it's used to the only required option, the `logger` itself can become optional as well in config
- Also made `.child()` method 50x times faster when `color` is not set

```
   ✓ Experiment for builtin logger (2) 1624ms
     name                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · master       23,912.42  0.0301  3.5688  0.0418  0.0354  0.0830  0.1226  2.8524  ±5.77%    11957
   · featured  1,299,531.08  0.0004  2.9562  0.0008  0.0005  0.0034  0.0046  0.0060  ±1.64%   649766   fastest
```