### PR TITLE
Provide universal `getLogger()` to `beforeRouting`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The `serializer` property of `Documentation` and `Integration` constructor argument removed;
 - The `originalError` property of `InputValidationError` and `OutputValidationError` removed (use `cause` instead);
 - The `getStatusCodeFromError()` method removed (use the `ensureHttpError().statusCode` instead);
+- Both `logger` and `getChildLogger` properties of `beforeRouting` argument are replaced with all-purpose `getLogger`;
 - Specifying `method` or `methods` for `EndpointsFactory::build()` made optional and when it's omitted:
   - If the endpoint is assigned to a route using `DependsOnMethod` instance, the corresponding method is used;
   - Otherwise `GET` method is implied by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - The `serializer` property of `Documentation` and `Integration` constructor argument removed;
 - The `originalError` property of `InputValidationError` and `OutputValidationError` removed (use `cause` instead);
 - The `getStatusCodeFromError()` method removed (use the `ensureHttpError().statusCode` instead);
-- Both `logger` and `getChildLogger` properties of `beforeRouting` argument are replaced with all-purpose `getLogger`;
+- Both `logger` and `getChildLogger` properties of `beforeRouting` argument are replaced with all-purpose `getLogger`:
+  - It returns the child logger for the given request (if configured) or the configured logger otherwise.
 - Specifying `method` or `methods` for `EndpointsFactory::build()` made optional and when it's omitted:
   - If the endpoint is assigned to a route using `DependsOnMethod` instance, the corresponding method is used;
   - Otherwise `GET` method is implied by default.

--- a/README.md
+++ b/README.md
@@ -370,9 +370,13 @@ import { createConfig } from "express-zod-api";
 import ui from "swagger-ui-express";
 
 const config = createConfig({
-  beforeRouting: ({ app, logger, getChildLogger }) => {
+  beforeRouting: ({ app, getLogger }) => {
+    const logger = getLogger();
     logger.info("Serving the API documentation at https://example.com/docs");
     app.use("/docs", ui.serve, ui.setup(documentation));
+    app.use("/custom", (req, res, next) => {
+      const childLogger = getLogger(req); // if childLoggerProvider is configured
+    });
   },
 });
 ```

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -8,7 +8,7 @@ import { AbstractLogger, ActualLogger } from "./logger-helpers";
 import { Method } from "./method";
 import { AbstractResultHandler } from "./result-handler";
 import { ListenOptions } from "node:net";
-import { ChildLoggerExtractor } from "./server-helpers";
+import { LoggerProvider } from "./server-helpers";
 
 export type InputSource = keyof Pick<
   Request,
@@ -131,13 +131,8 @@ interface GracefulOptions {
 
 type BeforeRouting = (params: {
   app: IRouter;
-  /**
-   * @desc Root logger, same for all requests
-   * @todo reconsider the naming in v21
-   * */
-  logger: ActualLogger;
-  /** @desc Returns a child logger if childLoggerProvider is configured (otherwise root logger) */
-  getChildLogger: ChildLoggerExtractor;
+  /** @desc Returns a child logger for the given request if childLoggerProvider is configured (otherwise root logger) */
+  getLogger: LoggerProvider;
 }) => void | Promise<void>;
 
 export interface HttpConfig {

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -8,7 +8,7 @@ import { AbstractLogger, ActualLogger } from "./logger-helpers";
 import { Method } from "./method";
 import { AbstractResultHandler } from "./result-handler";
 import { ListenOptions } from "node:net";
-import { LoggerProvider } from "./server-helpers";
+import { GetLogger } from "./server-helpers";
 
 export type InputSource = keyof Pick<
   Request,
@@ -131,8 +131,8 @@ interface GracefulOptions {
 
 type BeforeRouting = (params: {
   app: IRouter;
-  /** @desc Returns a child logger for the given request if childLoggerProvider is configured (otherwise root logger) */
-  getLogger: LoggerProvider;
+  /** @desc Returns child logger for the given request (if configured) or root logger otherwise */
+  getLogger: GetLogger;
 }) => void | Promise<void>;
 
 export interface HttpConfig {

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -131,7 +131,7 @@ interface GracefulOptions {
 
 type BeforeRouting = (params: {
   app: IRouter;
-  /** @desc Returns child logger for the given request (if configured) or root logger otherwise */
+  /** @desc Returns child logger for the given request (if configured) or the configured logger otherwise */
   getLogger: GetLogger;
 }) => void | Promise<void>;
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -7,7 +7,7 @@ import { AbstractEndpoint } from "./endpoint";
 import { AuxMethod, Method } from "./method";
 import { walkRouting } from "./routing-walker";
 import { ServeStatic } from "./serve-static";
-import { LoggerProvider } from "./server-helpers";
+import { GetLogger } from "./server-helpers";
 
 export interface Routing {
   [SEGMENT: string]: Routing | DependsOnMethod | AbstractEndpoint | ServeStatic;
@@ -23,7 +23,7 @@ export const initRouting = ({
   parsers,
 }: {
   app: IRouter;
-  getLogger: LoggerProvider;
+  getLogger: GetLogger;
   config: CommonConfig;
   routing: Routing;
   parsers?: Parsers;

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -140,7 +140,7 @@ export const createLoggingMiddleware =
     next();
   };
 
-export const makeLoggerProvider =
+export const makeGetLogger =
   (fallback: ActualLogger): GetLogger =>
   (request) =>
     (request && (request as EquippedRequest).res?.locals[metaSymbol]?.logger) ||

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -19,7 +19,7 @@ type EquippedRequest = Request<
   { [metaSymbol]?: { logger: ActualLogger } }
 >;
 
-/** @desc Returns child logger for the given request (if configured) or root logger otherwise */
+/** @desc Returns child logger for the given request (if configured) or the configured logger otherwise */
 export type GetLogger = (request?: Request) => ActualLogger;
 
 interface HandlerCreatorParams {

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -131,9 +131,8 @@ export const createLoggingMiddleware =
     config: CommonConfig;
   }): RequestHandler =>
   async (request, response, next) => {
-    const logger = config.childLoggerProvider
-      ? await config.childLoggerProvider({ request, parent })
-      : parent;
+    const logger =
+      (await config.childLoggerProvider?.({ request, parent })) || parent;
     logger.debug(`${request.method}: ${request.path}`);
     if (request.res)
       (request as EquippedRequest).res!.locals[metaSymbol] = { logger };

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -143,7 +143,7 @@ export const createLoggingMiddleware =
 export const makeGetLogger =
   (fallback: ActualLogger): GetLogger =>
   (request) =>
-    (request && (request as EquippedRequest).res?.locals[metaSymbol]?.logger) ||
+    (request as EquippedRequest | undefined)?.res?.locals[metaSymbol]?.logger ||
     fallback;
 
 export const installDeprecationListener = (logger: ActualLogger) =>

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -124,16 +124,16 @@ export const moveRaw: RequestHandler = (req, {}, next) => {
 /** @since v19 prints the actual path of the request, not a configured route, severity decreased to debug level */
 export const createLoggingMiddleware =
   ({
-    rootLogger,
+    logger: parent,
     config,
   }: {
-    rootLogger: ActualLogger;
+    logger: ActualLogger;
     config: CommonConfig;
   }): RequestHandler =>
   async (request, response, next) => {
     const logger = config.childLoggerProvider
-      ? await config.childLoggerProvider({ request, parent: rootLogger })
-      : rootLogger;
+      ? await config.childLoggerProvider({ request, parent })
+      : parent;
     logger.debug(`${request.method}: ${request.path}`);
     if (request.res)
       (request as EquippedRequest).res!.locals[metaSymbol] = { logger };

--- a/src/server-helpers.ts
+++ b/src/server-helpers.ts
@@ -19,11 +19,12 @@ type EquippedRequest = Request<
   { [metaSymbol]?: { logger: ActualLogger } }
 >;
 
-export type LoggerProvider = (request?: Request) => ActualLogger;
+/** @desc Returns child logger for the given request (if configured) or root logger otherwise */
+export type GetLogger = (request?: Request) => ActualLogger;
 
 interface HandlerCreatorParams {
   errorHandler: AbstractResultHandler;
-  getLogger: LoggerProvider;
+  getLogger: GetLogger;
 }
 
 export const createParserFailureHandler =
@@ -88,7 +89,7 @@ export const createUploadParsers = async ({
   getLogger,
   config,
 }: {
-  getLogger: LoggerProvider;
+  getLogger: GetLogger;
   config: ServerConfig;
 }): Promise<RequestHandler[]> => {
   const uploader = await loadPeer<typeof fileUpload>("express-fileupload");
@@ -140,7 +141,7 @@ export const createLoggingMiddleware =
   };
 
 export const makeLoggerProvider =
-  (fallback: ActualLogger): LoggerProvider =>
+  (fallback: ActualLogger): GetLogger =>
   (request) =>
     (request && (request as EquippedRequest).res?.locals[metaSymbol]?.logger) ||
     fallback;

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
       : [],
   };
 
-  if (config.beforeRouting) await config.beforeRouting({ app, getLogger });
+  await config.beforeRouting?.({ app, getLogger });
   initRouting({ app, routing, getLogger, config, parsers });
   app.use(parserFailureHandler, notFoundHandler);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
   createNotFoundHandler,
   createParserFailureHandler,
   createUploadParsers,
-  makeLoggerProvider,
+  makeGetLogger,
   installDeprecationListener,
   moveRaw,
   installTerminationListener,
@@ -37,7 +37,7 @@ const makeCommonEntities = (config: CommonConfig) => {
   });
   installDeprecationListener(rootLogger);
   const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
-  const getLogger = makeLoggerProvider(rootLogger);
+  const getLogger = makeGetLogger(rootLogger);
   const commons = { getLogger, errorHandler };
   const notFoundHandler = createNotFoundHandler(commons);
   const parserFailureHandler = createParserFailureHandler(commons);

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,22 +28,22 @@ import { getStartupLogo } from "./startup-logo";
 const makeCommonEntities = (config: CommonConfig) => {
   if (config.startupLogo !== false) console.log(getStartupLogo());
   const errorHandler = config.errorHandler || defaultResultHandler;
-  const rootLogger = isLoggerInstance(config.logger)
+  const logger = isLoggerInstance(config.logger)
     ? config.logger
     : new BuiltinLogger(config.logger);
-  rootLogger.debug("Running", {
+  logger.debug("Running", {
     build: process.env.TSUP_BUILD || "from sources",
     env: process.env.NODE_ENV || "development",
   });
-  installDeprecationListener(rootLogger);
-  const loggingMiddleware = createLoggingMiddleware({ rootLogger, config });
-  const getLogger = makeGetLogger(rootLogger);
+  installDeprecationListener(logger);
+  const loggingMiddleware = createLoggingMiddleware({ logger, config });
+  const getLogger = makeGetLogger(logger);
   const commons = { getLogger, errorHandler };
   const notFoundHandler = createNotFoundHandler(commons);
   const parserFailureHandler = createParserFailureHandler(commons);
   return {
     ...commons,
-    rootLogger,
+    logger,
     notFoundHandler,
     parserFailureHandler,
     loggingMiddleware,
@@ -51,7 +51,7 @@ const makeCommonEntities = (config: CommonConfig) => {
 };
 
 export const attachRouting = (config: AppConfig, routing: Routing) => {
-  const { rootLogger, getLogger, notFoundHandler, loggingMiddleware } =
+  const { logger, getLogger, notFoundHandler, loggingMiddleware } =
     makeCommonEntities(config);
   initRouting({
     app: config.app.use(loggingMiddleware),
@@ -59,12 +59,12 @@ export const attachRouting = (config: AppConfig, routing: Routing) => {
     getLogger,
     config,
   });
-  return { notFoundHandler, logger: rootLogger };
+  return { notFoundHandler, logger };
 };
 
 export const createServer = async (config: ServerConfig, routing: Routing) => {
   const {
-    rootLogger,
+    logger,
     getLogger,
     notFoundHandler,
     parserFailureHandler,
@@ -95,7 +95,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
 
   const makeStarter =
     (server: http.Server | https.Server, subject: HttpConfig["listen"]) => () =>
-      server.listen(subject, () => rootLogger.info("Listening", subject));
+      server.listen(subject, () => logger.info("Listening", subject));
 
   const created: Array<http.Server | https.Server> = [];
   const starters: Array<() => http.Server | https.Server> = [];
@@ -112,15 +112,11 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
 
   if (config.gracefulShutdown) {
     installTerminationListener({
+      logger,
       servers: created,
-      logger: rootLogger,
       options: config.gracefulShutdown === true ? {} : config.gracefulShutdown,
     });
   }
 
-  return {
-    app,
-    logger: rootLogger,
-    servers: starters.map((starter) => starter()),
-  };
+  return { app, logger, servers: starters.map((starter) => starter()) };
 };

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -112,10 +112,10 @@ describe("App in production mode", async () => {
   const config = createConfig({
     http: { listen: port },
     compression: { threshold: 1 },
-    beforeRouting: ({ app, getChildLogger }) => {
+    beforeRouting: ({ app, getLogger }) => {
       depd("express")("Sample deprecation message");
       app.use((req, {}, next) => {
-        const childLogger = getChildLogger(req);
+        const childLogger = getLogger(req);
         assert("isChild" in childLogger && childLogger.isChild);
         next();
       });

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -22,6 +22,7 @@ describe("Migration", () => {
       `(() => {})()`,
       `createConfig({ http: {} });`,
       `createConfig({ http: { listen: 8090 }, upload: true });`,
+      `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
       `const { app, servers, logger } = await createServer();`,
       `console.error(error.cause?.message);`,
       `import { ensureHttpError } from "express-zod-api";`,
@@ -48,6 +49,34 @@ describe("Migration", () => {
               subject: "upload",
               from: "http",
               to: "the top level of createConfig argument",
+            },
+          },
+        ],
+      },
+      {
+        code: `createConfig({ beforeRouting: ({ logger }) => {} });`,
+        output: `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "property",
+              from: "logger",
+              to: "getLogger",
+            },
+          },
+        ],
+      },
+      {
+        code: `createConfig({ beforeRouting: ({ getChildLogger }) => {} });`,
+        output: `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "property",
+              from: "getChildLogger",
+              to: "getLogger",
             },
           },
         ],

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -22,7 +22,7 @@ describe("Migration", () => {
       `(() => {})()`,
       `createConfig({ http: {} });`,
       `createConfig({ http: { listen: 8090 }, upload: true });`,
-      `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
+      `createConfig({ beforeRouting: ({ getLogger }) => { getLogger().warn() } });`,
       `const { app, servers, logger } = await createServer();`,
       `console.error(error.cause?.message);`,
       `import { ensureHttpError } from "express-zod-api";`,
@@ -75,6 +75,34 @@ describe("Migration", () => {
             messageId: "change",
             data: {
               subject: "property",
+              from: "getChildLogger",
+              to: "getLogger",
+            },
+          },
+        ],
+      },
+      {
+        code: `createConfig({ beforeRouting: () => { logger.warn() } });`,
+        output: `createConfig({ beforeRouting: () => { getLogger().warn() } });`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "const",
+              from: "logger",
+              to: "getLogger()",
+            },
+          },
+        ],
+      },
+      {
+        code: `createConfig({ beforeRouting: () => { getChildLogger(request).warn() } });`,
+        output: `createConfig({ beforeRouting: () => { getLogger(request).warn() } });`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "method",
               from: "getChildLogger",
               to: "getLogger",
             },

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -54,8 +54,8 @@ describe("Migration", () => {
         ],
       },
       {
-        code: `createConfig({ beforeRouting: ({ logger }) => {} });`,
-        output: `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
+        code: `createConfig({ beforeRouting: ({ logger }) => { logger.warn() } });`,
+        output: `createConfig({ beforeRouting: ({ getLogger }) => { getLogger().warn() } });`,
         errors: [
           {
             messageId: "change",
@@ -65,26 +65,6 @@ describe("Migration", () => {
               to: "getLogger",
             },
           },
-        ],
-      },
-      {
-        code: `createConfig({ beforeRouting: ({ getChildLogger }) => {} });`,
-        output: `createConfig({ beforeRouting: ({ getLogger }) => {} });`,
-        errors: [
-          {
-            messageId: "change",
-            data: {
-              subject: "property",
-              from: "getChildLogger",
-              to: "getLogger",
-            },
-          },
-        ],
-      },
-      {
-        code: `createConfig({ beforeRouting: () => { logger.warn() } });`,
-        output: `createConfig({ beforeRouting: () => { getLogger().warn() } });`,
-        errors: [
           {
             messageId: "change",
             data: {
@@ -96,9 +76,17 @@ describe("Migration", () => {
         ],
       },
       {
-        code: `createConfig({ beforeRouting: () => { getChildLogger(request).warn() } });`,
-        output: `createConfig({ beforeRouting: () => { getLogger(request).warn() } });`,
+        code: `createConfig({ beforeRouting: ({ getChildLogger }) => { getChildLogger(request).warn() } });`,
+        output: `createConfig({ beforeRouting: ({ getLogger }) => { getLogger(request).warn() } });`,
         errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "property",
+              from: "getChildLogger",
+              to: "getLogger",
+            },
+          },
           {
             messageId: "change",
             data: {

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -67,10 +67,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(appMock.get).toHaveBeenCalledTimes(2);
       expect(appMock.post).toHaveBeenCalledTimes(2);
@@ -98,10 +97,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(staticMock).toHaveBeenCalledWith(__dirname, { dotfiles: "deny" });
       expect(appMock.use).toHaveBeenCalledTimes(1);
@@ -140,10 +138,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.post).toHaveBeenCalledTimes(1);
@@ -179,10 +176,9 @@ describe("Routing", () => {
       expect(() =>
         initRouting({
           app: appMock as unknown as IRouter,
-          getChildLogger: () => rootLogger,
+          getLogger: () => rootLogger,
           config: configMock as CommonConfig,
           routing,
-          rootLogger,
         }),
       ).toThrowErrorMatchingSnapshot();
     });
@@ -225,10 +221,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0][0]).toBe("/hello");
@@ -265,10 +260,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(appMock.get).toHaveBeenCalledTimes(1);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/:id");
@@ -295,10 +289,9 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       initRouting({
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing,
-        rootLogger,
       });
       expect(appMock.get).toHaveBeenCalledTimes(2);
       expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/:id");
@@ -316,9 +309,8 @@ describe("Routing", () => {
       const rootLogger = new BuiltinLogger({ level: "silent" });
       expect(() =>
         initRouting({
-          rootLogger,
           app: appMock as unknown as IRouter,
-          getChildLogger: () => rootLogger,
+          getLogger: () => rootLogger,
           config: configMock as CommonConfig,
           routing: {
             v1: {
@@ -329,9 +321,8 @@ describe("Routing", () => {
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
         initRouting({
-          rootLogger,
           app: appMock as unknown as IRouter,
-          getChildLogger: () => rootLogger,
+          getLogger: () => rootLogger,
           config: configMock as CommonConfig,
           routing: {
             "v1/user/retrieve": endpointMock,
@@ -362,12 +353,10 @@ describe("Routing", () => {
           },
         },
       };
-      const rootLogger = makeLoggerMock();
-      const childLogger = makeLoggerMock();
+      const getLoggerMock = vi.fn(() => makeLoggerMock());
       initRouting({
-        rootLogger,
         app: appMock as unknown as IRouter,
-        getChildLogger: () => childLogger,
+        getLogger: getLoggerMock,
         config: configMock as CommonConfig,
         routing,
       });
@@ -380,15 +369,16 @@ describe("Routing", () => {
       const responseMock = makeResponseMock();
       const nextMock = vi.fn();
       await routeHandler(requestMock, responseMock, nextMock);
+      expect(getLoggerMock).toHaveBeenCalledWith(requestMock);
       expect(nextMock).toHaveBeenCalledTimes(0);
       expect(handlerMock).toHaveBeenCalledTimes(1);
-      expect(childLogger._getLogs().error).toHaveLength(0);
+      expect(
+        getLoggerMock.mock.results.pop()!.value._getLogs().error,
+      ).toHaveLength(0);
       expect(handlerMock).toHaveBeenCalledWith({
-        input: {
-          test: 123,
-        },
+        input: { test: 123 },
         options: {},
-        logger: childLogger,
+        logger: getLoggerMock.mock.results.pop()!.value,
       });
       expect(responseMock._getStatusCode()).toBe(200);
       expect(responseMock._getJSONData()).toEqual({
@@ -415,9 +405,8 @@ describe("Routing", () => {
       const configMock = { cors: false, startupLogo: false };
       const rootLogger = makeLoggerMock();
       initRouting({
-        rootLogger,
         app: appMock as unknown as IRouter,
-        getChildLogger: () => rootLogger,
+        getLogger: () => rootLogger,
         config: configMock as CommonConfig,
         routing: { path: endpoint },
       });

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -6,7 +6,6 @@ import {
 } from "../express-mock";
 import { z } from "zod";
 import {
-  BuiltinLogger,
   DependsOnMethod,
   CommonConfig,
   EndpointsFactory,
@@ -64,10 +63,10 @@ describe("Routing", () => {
           },
         },
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -94,10 +93,10 @@ describe("Routing", () => {
         cors: true,
         startupLogo: false,
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -135,10 +134,10 @@ describe("Routing", () => {
           }),
         },
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -172,11 +171,11 @@ describe("Routing", () => {
           }),
         },
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       expect(() =>
         initRouting({
           app: appMock as unknown as IRouter,
-          getLogger: () => rootLogger,
+          getLogger: () => logger,
           config: configMock as CommonConfig,
           routing,
         }),
@@ -218,10 +217,10 @@ describe("Routing", () => {
           patch: putAndPatchEndpoint,
         }),
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -257,10 +256,10 @@ describe("Routing", () => {
           },
         },
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -286,10 +285,10 @@ describe("Routing", () => {
           },
         },
       };
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing,
       });
@@ -306,11 +305,11 @@ describe("Routing", () => {
         output: z.object({}),
         handler: handlerMock,
       });
-      const rootLogger = new BuiltinLogger({ level: "silent" });
+      const logger = makeLoggerMock();
       expect(() =>
         initRouting({
           app: appMock as unknown as IRouter,
-          getLogger: () => rootLogger,
+          getLogger: () => logger,
           config: configMock as CommonConfig,
           routing: {
             v1: {
@@ -322,7 +321,7 @@ describe("Routing", () => {
       expect(() =>
         initRouting({
           app: appMock as unknown as IRouter,
-          getLogger: () => rootLogger,
+          getLogger: () => logger,
           config: configMock as CommonConfig,
           routing: {
             "v1/user/retrieve": endpointMock,
@@ -403,14 +402,14 @@ describe("Routing", () => {
         handler: vi.fn(),
       });
       const configMock = { cors: false, startupLogo: false };
-      const rootLogger = makeLoggerMock();
+      const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
-        getLogger: () => rootLogger,
+        getLogger: () => logger,
         config: configMock as CommonConfig,
         routing: { path: endpoint },
       });
-      expect(rootLogger._getLogs().warn).toEqual([
+      expect(logger._getLogs().warn).toEqual([
         [
           "The final input schema of the endpoint contains an unsupported JSON payload type.",
           { method: "get", path: "/path", reason: expect.any(Error) },

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -7,7 +7,7 @@ import {
   createUploadFailureHandler,
   createUploadLogger,
   createUploadParsers,
-  makeChildLoggerExtractor,
+  makeLoggerProvider,
   moveRaw,
   installDeprecationListener,
   installTerminationListener,
@@ -26,7 +26,7 @@ describe("Server helpers", () => {
     test("the handler should call next if there is no error", () => {
       const handler = createParserFailureHandler({
         errorHandler: defaultResultHandler,
-        getChildLogger: () => makeLoggerMock(),
+        getLogger: () => makeLoggerMock(),
       });
       const next = vi.fn();
       handler(undefined, makeRequestMock(), makeResponseMock(), next);
@@ -47,7 +47,7 @@ describe("Server helpers", () => {
         const spy = vi.spyOn(errorHandler, "execute");
         const handler = createParserFailureHandler({
           errorHandler,
-          getChildLogger: () => makeLoggerMock(),
+          getLogger: () => makeLoggerMock(),
         });
         await handler(
           error,
@@ -73,7 +73,7 @@ describe("Server helpers", () => {
       const spy = vi.spyOn(errorHandler, "execute");
       const handler = createNotFoundHandler({
         errorHandler,
-        getChildLogger: () => makeLoggerMock(),
+        getLogger: () => makeLoggerMock(),
       });
       const next = vi.fn();
       const requestMock = makeRequestMock({
@@ -104,7 +104,7 @@ describe("Server helpers", () => {
       const spy = vi.spyOn(errorHandler, "execute");
       const handler = createNotFoundHandler({
         errorHandler,
-        getChildLogger: () => makeLoggerMock(),
+        getLogger: () => makeLoggerMock(),
       });
       const next = vi.fn();
       const requestMock = makeRequestMock({
@@ -176,7 +176,7 @@ describe("Server helpers", () => {
         cors: false,
         logger: { level: "silent" },
       },
-      getChildLogger: () => loggerMock,
+      getLogger: () => loggerMock,
     });
     const requestMock = makeRequestMock();
     const responseMock = makeResponseMock();
@@ -263,7 +263,7 @@ describe("Server helpers", () => {
 
   describe("makeChildLoggerExtractor()", () => {
     const rootLogger = makeLoggerMock();
-    const getChildLogger = makeChildLoggerExtractor(rootLogger);
+    const getChildLogger = makeLoggerProvider(rootLogger);
 
     test("should extract child logger from request", () => {
       const request = makeRequestMock({

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -7,7 +7,7 @@ import {
   createUploadFailureHandler,
   createUploadLogger,
   createUploadParsers,
-  makeLoggerProvider,
+  makeGetLogger,
   moveRaw,
   installDeprecationListener,
   installTerminationListener,
@@ -261,9 +261,9 @@ describe("Server helpers", () => {
     );
   });
 
-  describe("makeChildLoggerExtractor()", () => {
+  describe("makeGetLogger()", () => {
     const rootLogger = makeLoggerMock();
-    const getChildLogger = makeLoggerProvider(rootLogger);
+    const getLogger = makeGetLogger(rootLogger);
 
     test("should extract child logger from request", () => {
       const request = makeRequestMock({
@@ -273,13 +273,15 @@ describe("Server helpers", () => {
           },
         },
       });
-      expect(getChildLogger(request)).toHaveProperty("isChild", true);
+      expect(getLogger(request)).toHaveProperty("isChild", true);
     });
 
-    test("should fall back to root", () => {
-      const request = makeRequestMock();
-      expect(getChildLogger(request)).toEqual(rootLogger);
-    });
+    test.each([makeRequestMock(), undefined])(
+      "should fall back to root %#",
+      (request) => {
+        expect(getLogger(request)).toEqual(rootLogger);
+      },
+    );
   });
 
   describe("installDeprecationListener()", () => {

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -151,12 +151,12 @@ describe("Server helpers", () => {
   });
 
   describe("createUploadLogger()", () => {
-    const rootLogger = makeLoggerMock();
-    const uploadLogger = createUploadLogger(rootLogger);
+    const logger = makeLoggerMock();
+    const uploadLogger = createUploadLogger(logger);
 
     test("should debug the messages", () => {
       uploadLogger.log("Express-file-upload: Busboy finished parsing request.");
-      expect(rootLogger._getLogs().debug).toEqual([
+      expect(logger._getLogs().debug).toEqual([
         ["Express-file-upload: Busboy finished parsing request."],
       ]);
     });
@@ -262,8 +262,8 @@ describe("Server helpers", () => {
   });
 
   describe("makeGetLogger()", () => {
-    const rootLogger = makeLoggerMock();
-    const getLogger = makeGetLogger(rootLogger);
+    const logger = makeLoggerMock();
+    const getLogger = makeGetLogger(logger);
 
     test("should extract child logger from request", () => {
       const request = makeRequestMock({
@@ -279,7 +279,7 @@ describe("Server helpers", () => {
     test.each([makeRequestMock(), undefined])(
       "should fall back to root %#",
       (request) => {
-        expect(getLogger(request)).toEqual(rootLogger);
+        expect(getLogger(request)).toEqual(logger);
       },
     );
   });

--- a/tests/unit/server-helpers.spec.ts
+++ b/tests/unit/server-helpers.spec.ts
@@ -237,13 +237,13 @@ describe("Server helpers", () => {
   });
 
   describe("createLoggingMiddleware", () => {
-    const rootLogger = makeLoggerMock();
+    const logger = makeLoggerMock();
     const child = makeLoggerMock({ isChild: true });
     test.each([undefined, () => child, async () => child])(
       "should make RequestHandler writing logger to res.locals %#",
       async (childLoggerProvider) => {
         const config = { childLoggerProvider } as CommonConfig;
-        const handler = createLoggingMiddleware({ rootLogger, config });
+        const handler = createLoggingMiddleware({ logger, config });
         expect(typeof handler).toBe("function");
         const nextMock = vi.fn();
         const response = makeResponseMock();
@@ -252,10 +252,10 @@ describe("Server helpers", () => {
         await handler(request, response, nextMock);
         expect(nextMock).toHaveBeenCalled();
         expect(
-          (childLoggerProvider ? child : rootLogger)._getLogs().debug.pop(),
+          (childLoggerProvider ? child : logger)._getLogs().debug.pop(),
         ).toEqual(["GET: /test"]);
         expect(request.res).toHaveProperty("locals", {
-          [metaSymbol]: { logger: childLoggerProvider ? child : rootLogger },
+          [metaSymbol]: { logger: childLoggerProvider ? child : logger },
         });
       },
     );

--- a/tests/unit/server.spec.ts
+++ b/tests/unit/server.spec.ts
@@ -141,8 +141,7 @@ describe("Server", () => {
       expect(configMock.errorHandler.handler).toHaveBeenCalledTimes(0);
       expect(configMock.beforeRouting).toHaveBeenCalledWith({
         app: appMock,
-        logger: customLogger,
-        getChildLogger: expect.any(Function),
+        getLogger: expect.any(Function),
       });
       expect(infoMethod).toHaveBeenCalledTimes(1);
       expect(infoMethod).toHaveBeenCalledWith(`Listening`, { port });


### PR DESCRIPTION
Instead of `logger` and `getChildLogger`