### PR TITLE
Addressing performance findings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,12 @@ export default [
           selector: "CallExpression > Identifier[name='toPairs']",
           message: "R.toPairs() is 1.1x slower than Object.entries()",
         },
+        {
+          // https://github.com/RobinTail/express-zod-api/pull/2168
+          selector:
+            "CallExpression[callee.name='keys'], CallExpression[callee.name='keysIn']",
+          message: "R.keys() and keysIn() are 1.2x slower than Object.keys()",
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,13 +42,20 @@ export default [
       "no-restricted-syntax": [
         "warn",
         {
+          // https://github.com/RobinTail/express-zod-api/pull/2169
           selector: "ImportDeclaration[source.value=/assert/]",
           message: "assert is slow, use throw",
         },
         {
+          // https://github.com/RobinTail/express-zod-api/pull/2168
           selector:
             "CallExpression > MemberExpression[object.name='Object'][property.name='entries']",
           message: "Object.entries() is 2x slower than R.toPairs()",
+        },
+        {
+          // https://github.com/RobinTail/express-zod-api/pull/2160
+          selector: "ObjectExpression > SpreadElement ~ SpreadElement",
+          message: "Multiple spreading 1.4x slower than Object.assign()",
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,12 +47,6 @@ export default [
           message: "assert is slow, use throw",
         },
         {
-          // https://github.com/RobinTail/express-zod-api/pull/2168
-          selector:
-            "CallExpression > MemberExpression[object.name='Object'][property.name='entries']",
-          message: "Object.entries() is 2x slower than R.toPairs()",
-        },
-        {
           // https://github.com/RobinTail/express-zod-api/pull/2160
           selector: "ObjectExpression > SpreadElement ~ SpreadElement",
           message: "Multiple spreading 1.4x slower than Object.assign()",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,12 @@ export default [
           selector: "ObjectExpression > SpreadElement ~ SpreadElement",
           message: "Multiple spreading 1.4x slower than Object.assign()",
         },
+        {
+          // https://github.com/RobinTail/express-zod-api/pull/2144
+          selector:
+            "MemberExpression[object.name='process'][property.name='env']",
+          message: "Reading process.env is slow and must be memoized",
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,11 @@ export default [
             "MemberExpression[object.name='process'][property.name='env']",
           message: "Reading process.env is slow and must be memoized",
         },
+        {
+          // https://github.com/RobinTail/express-zod-api/pull/2168
+          selector: "CallExpression > Identifier[name='toPairs']",
+          message: "R.toPairs() is 1.1x slower than Object.entries()",
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,11 +47,6 @@ export default [
           message: "assert is slow, use throw",
         },
         {
-          // https://github.com/RobinTail/express-zod-api/pull/2160
-          selector: "ObjectExpression > SpreadElement ~ SpreadElement",
-          message: "Multiple spreading 1.4x slower than Object.assign()",
-        },
-        {
           // https://github.com/RobinTail/express-zod-api/pull/2144
           selector:
             "MemberExpression[object.name='process'][property.name='env']",

--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -148,6 +148,6 @@ export const isObject = (subject: unknown) =>
   typeof subject === "object" && subject !== null;
 
 export const isProduction = memoizeWith(
-  () => process.env.TSUP_STATIC as string, // dynamic in tests, but static in build
-  () => process.env.NODE_ENV === "production",
+  () => process.env.TSUP_STATIC as string, // eslint-disable-line no-restricted-syntax -- substituted by TSUP
+  () => process.env.NODE_ENV === "production", // eslint-disable-line no-restricted-syntax -- memoized
 );

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -8,7 +8,7 @@ export class DependsOnMethod {
 
   constructor(endpoints: Partial<Record<Method, AbstractEndpoint>>) {
     const entries: Array<(typeof this.entries)[number]> = [];
-    const methods = keys(endpoints);
+    const methods = keys(endpoints); // eslint-disable-line no-restricted-syntax -- liternal type required
     for (const method of methods) {
       const endpoint = endpoints[method];
       if (endpoint)

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -70,7 +70,7 @@ interface DocumentationParams {
 export class Documentation extends OpenApiBuilder {
   protected lastSecuritySchemaIds = new Map<SecuritySchemeType, number>();
   protected lastOperationIdSuffixes = new Map<string, number>();
-  protected responseVariants = keys(defaultStatusCodes);
+  protected responseVariants = keys(defaultStatusCodes); // eslint-disable-line no-restricted-syntax -- literal
   protected references = new Map<z.ZodTypeAny, string>();
 
   protected makeRef(

--- a/src/integration-helpers.ts
+++ b/src/integration-helpers.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { chain, toPairs } from "ramda";
+import { chain } from "ramda";
 import { Method } from "./method";
 
 export const f = ts.factory;
@@ -57,7 +57,7 @@ export const makeParams = (
 ) =>
   chain(
     ([name, node]) => [makeParam(f.createIdentifier(name), node, mod)],
-    toPairs(params),
+    Object.entries(params),
   );
 
 export const makeRecord = (
@@ -161,7 +161,7 @@ const aggregateDeclarations = chain(([name, id]: [string, ts.Identifier]) => [
   f.createTypeParameterDeclaration([], name, f.createTypeReferenceNode(id)),
 ]);
 export const makeTypeParams = (params: Record<string, ts.Identifier>) =>
-  aggregateDeclarations(toPairs(params));
+  aggregateDeclarations(Object.entries(params));
 
 export const makeArrowFn = (
   params: ts.Identifier[],

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,7 @@ const makeCommonEntities = (config: CommonConfig) => {
     : new BuiltinLogger(config.logger);
   logger.debug("Running", {
     build: process.env.TSUP_BUILD || "from sources", // eslint-disable-line no-restricted-syntax -- substituted by TSUP
-    env: process.env.NODE_ENV || "development",
+    env: process.env.NODE_ENV || "development", // eslint-disable-line no-restricted-syntax -- intentionally for debug
   });
   installDeprecationListener(logger);
   const loggingMiddleware = createLoggingMiddleware({ logger, config });

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ const makeCommonEntities = (config: CommonConfig) => {
     ? config.logger
     : new BuiltinLogger(config.logger);
   logger.debug("Running", {
-    build: process.env.TSUP_BUILD || "from sources",
+    build: process.env.TSUP_BUILD || "from sources", // eslint-disable-line no-restricted-syntax -- substituted by TSUP
     env: process.env.NODE_ENV || "development",
   });
   installDeprecationListener(logger);

--- a/src/zod-plugin.ts
+++ b/src/zod-plugin.ts
@@ -82,7 +82,7 @@ const objectMapper = function (
     typeof tool === "function"
       ? tool
       : pipe(
-          toPairs,
+          toPairs, // eslint-disable-line no-restricted-syntax -- strict key type required
           map(([key, value]) => pair(tool[String(key)] || key, value)),
           fromPairs,
         );


### PR DESCRIPTION
I wanna put all my recent performance findings into ESLint rules, so that I could address them globally later

- Object.assign turned out to be significantly improved in Node 22, but it's still faster for extending existing aggregator in a reducer. For other cases spread is ok.