### PR TITLE
Removing redundant methods array in tests.

### DIFF
--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -73,7 +73,6 @@ describe("Documentation", () => {
         routing: {
           v1: {
             getSomething: defaultEndpointsFactory.build({
-              methods: ["get"],
               input: z.object({
                 array: z.array(z.number().int().positive()).min(1).max(3),
                 unlimited: z.array(z.boolean()),
@@ -103,7 +102,6 @@ describe("Documentation", () => {
         routing: {
           v1: {
             getSomething: defaultEndpointsFactory.build({
-              methods: ["get"],
               input: z.object({
                 optional: z.string().optional(),
                 optDefault: z.string().optional().default("test"),

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -330,7 +330,6 @@ describe("Endpoint", () => {
     test("should return undefined if its not defined upon creation", () => {
       expect(
         new Endpoint({
-          methods: ["get"],
           inputSchema: z.object({}),
           outputSchema: z.object({}),
           handler: async () => ({}),

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -298,13 +298,12 @@ describe("EndpointsFactory", () => {
       );
       const handlerMock = vi.fn();
       const endpoint = factory.build({
-        methods: ["get"],
         input: z.object({ s: z.string() }),
         output: z.object({ b: z.boolean() }),
         handler: handlerMock,
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
-      expect(endpoint.getMethods()).toStrictEqual(["get"]);
+      expect(endpoint.getMethods()).toBeUndefined();
       expect(
         serializeSchemaForTest(endpoint.getSchema("input")),
       ).toMatchSnapshot();
@@ -331,13 +330,12 @@ describe("EndpointsFactory", () => {
         b: true,
       }));
       const endpoint = factory.build({
-        methods: ["get"],
         input: z.object({ s: z.string() }),
         output: z.object({ b: z.boolean() }),
         handler: handlerMock,
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
-      expect(endpoint.getMethods()).toStrictEqual(["get"]);
+      expect(endpoint.getMethods()).toBeUndefined();
       expect(
         serializeSchemaForTest(endpoint.getSchema("input")),
       ).toMatchSnapshot();

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -40,12 +40,11 @@ describe("Routing", () => {
       };
       const factory = new EndpointsFactory(defaultResultHandler);
       const getEndpoint = factory.build({
-        methods: ["get"],
         output: z.object({}),
         handler: handlerMock,
       });
       const postEndpoint = factory.build({
-        methods: ["post"],
+        method: "post",
         output: z.object({}),
         handler: handlerMock,
       });
@@ -245,7 +244,6 @@ describe("Routing", () => {
       const handlerMock = vi.fn();
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        methods: ["get"],
         output: z.object({}),
         handler: handlerMock,
       });
@@ -271,7 +269,6 @@ describe("Routing", () => {
       const handlerMock = vi.fn();
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        methods: ["get"],
         output: z.object({}),
         handler: handlerMock,
       });
@@ -301,7 +298,6 @@ describe("Routing", () => {
       const handlerMock = vi.fn();
       const configMock = { startupLogo: false };
       const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        methods: ["get"],
         output: z.object({}),
         handler: handlerMock,
       });


### PR DESCRIPTION
Due to #2128 , did not found those lines initially, but found during work in #2175 