### PR TITLE
Ease `DocumentationError` constructor

### DIFF
--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -135,12 +135,8 @@ export const depictCatch: Depicter = (
 export const depictAny: Depicter = () => ({ format: "any" });
 
 export const depictUpload: Depicter = ({}: UploadSchema, ctx) => {
-  if (ctx.isResponse) {
-    throw new DocumentationError({
-      message: "Please use ez.upload() only for input.",
-      ...ctx,
-    });
-  }
+  if (ctx.isResponse)
+    throw new DocumentationError("Please use ez.upload() only for input.", ctx);
   return { type: "string", format: "binary" };
 };
 
@@ -297,12 +293,8 @@ export const depictObject: Depicter = (
 export const depictNull: Depicter = () => ({ type: "null" });
 
 export const depictDateIn: Depicter = ({}: DateInSchema, ctx) => {
-  if (ctx.isResponse) {
-    throw new DocumentationError({
-      message: "Please use ez.dateOut() for output.",
-      ...ctx,
-    });
-  }
+  if (ctx.isResponse)
+    throw new DocumentationError("Please use ez.dateOut() for output.", ctx);
   return {
     description: "YYYY-MM-DDTHH:mm:ss.sssZ",
     type: "string",
@@ -315,12 +307,8 @@ export const depictDateIn: Depicter = ({}: DateInSchema, ctx) => {
 };
 
 export const depictDateOut: Depicter = ({}: DateOutSchema, ctx) => {
-  if (!ctx.isResponse) {
-    throw new DocumentationError({
-      message: "Please use ez.dateIn() for input.",
-      ...ctx,
-    });
-  }
+  if (!ctx.isResponse)
+    throw new DocumentationError("Please use ez.dateIn() for input.", ctx);
   return {
     description: "YYYY-MM-DDTHH:mm:ss.sssZ",
     type: "string",
@@ -333,14 +321,14 @@ export const depictDateOut: Depicter = ({}: DateOutSchema, ctx) => {
 
 /** @throws DocumentationError */
 export const depictDate: Depicter = ({}: z.ZodDate, ctx) => {
-  throw new DocumentationError({
-    message: `Using z.date() within ${
+  throw new DocumentationError(
+    `Using z.date() within ${
       ctx.isResponse ? "output" : "input"
     } schema is forbidden. Please use ez.date${
       ctx.isResponse ? "Out" : "In"
     }() instead. Check out the documentation for details.`,
-    ...ctx,
-  });
+    ctx,
+  );
 };
 
 export const depictBoolean: Depicter = () => ({ type: "boolean" });
@@ -747,10 +735,10 @@ export const onMissing: SchemaHandler<
   OpenAPIContext,
   "last"
 > = (schema: z.ZodTypeAny, ctx) => {
-  throw new DocumentationError({
-    message: `Zod type ${schema.constructor.name} is unsupported.`,
-    ...ctx,
-  });
+  throw new DocumentationError(
+    `Zod type ${schema.constructor.name} is unsupported.`,
+    ctx,
+  );
 };
 
 export const excludeParamsFromDepiction = (

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -102,8 +102,7 @@ export class Documentation extends OpenApiBuilder {
       return operationId;
     }
     if (userDefined) {
-      throw new DocumentationError({
-        message: `Duplicated operationId: "${userDefined}"`,
+      throw new DocumentationError(`Duplicated operationId: "${userDefined}"`, {
         method,
         isResponse: false,
         path,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,15 +14,14 @@ export class DocumentationError extends Error {
   public override name = "DocumentationError";
   public override readonly cause: string;
 
-  constructor({
-    message,
-    method,
-    path,
-    isResponse,
-  }: { message: string } & Pick<
-    OpenAPIContext,
-    "path" | "method" | "isResponse"
-  >) {
+  constructor(
+    message: string,
+    {
+      method,
+      path,
+      isResponse,
+    }: Pick<OpenAPIContext, "path" | "method" | "isResponse">,
+  ) {
     super(message);
     this.cause = `${
       isResponse ? "Response" : "Input"

--- a/tests/unit/documentation.spec.ts
+++ b/tests/unit/documentation.spec.ts
@@ -580,12 +580,14 @@ describe("Documentation", () => {
             serverUrl: "https://example.com",
           }),
       ).toThrow(
-        new DocumentationError({
-          method: "post",
-          path: "/v1/getSomething",
-          isResponse: false,
-          message: `Zod type ${zodType._def.typeName} is unsupported.`,
-        }),
+        new DocumentationError(
+          `Zod type ${zodType._def.typeName} is unsupported.`,
+          {
+            method: "post",
+            path: "/v1/getSomething",
+            isResponse: false,
+          },
+        ),
       );
     });
 
@@ -732,12 +734,14 @@ describe("Documentation", () => {
 
     test("should not be able to specify duplicated operation", () => {
       const operationId = "coolOperationId";
-      const expectedError = new DocumentationError({
-        message: 'Duplicated operationId: "coolOperationId"',
-        isResponse: false,
-        method: "get",
-        path: "/v1/getSomeTwo/thing",
-      });
+      const expectedError = new DocumentationError(
+        'Duplicated operationId: "coolOperationId"',
+        {
+          isResponse: false,
+          method: "get",
+          path: "/v1/getSomeTwo/thing",
+        },
+      );
       expect(
         () =>
           new Documentation({

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -22,8 +22,7 @@ describe("Errors", () => {
   });
 
   describe("DocumentationError", () => {
-    const error = new DocumentationError({
-      message: "test",
+    const error = new DocumentationError("test", {
       path: "/v1/testPath",
       method: "get",
       isResponse: true,


### PR DESCRIPTION
It's publicly exposed, therefore I consider it breaking.
I wanna make the usage of that error easier.