### PR TITLE
Feat: Nested routes helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ```ts
 import { Routing } from "express-zod-api";
 
-// Describing both /v1/path and /v1/path/subpath both having endpoints assigned:
+// Describing routes /v1/path and /v1/path/subpath both having endpoints assigned:
 const before: Routing = {
   v1: {
     path: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Version 20
 
+### v20.22.0
+
+- Featuring a helper to describe nested Routing for already assigned routes:
+  - Suppose you want to describe `Routing` for both `/v1/path` and `/v1/path/subpath` routes having Endpoints attached;
+  - Previously, an empty path segment was proposed for that purpose, but there is more elegant and readable way now;
+  - The `.nest()` method is available both on `Endpoint` and `DependsOnMethod` instances:
+
+```ts
+import { Routing } from "express-zod-api";
+
+// Describing both /v1/path and /v1/path/subpath both having endpoints assigned:
+const before: Routing = {
+  v1: {
+    path: {
+      "": endpointA,
+      subpath: endpointB,
+    },
+  },
+};
+
+const after: Routing = {
+  v1: {
+    path: endpointA.nest({
+      subpath: endpointB,
+    }),
+  },
+};
+```
+
 ### v20.21.2
 
 - Fixed the example implementation in the generated client for endpoints using path params:

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ createConfig({
 
 ## Nested routes
 
-Suppose you want to assign both `/v1/path` and `/v1/path/subpath` routes to Endpoints:
+Suppose you want to assign both `/v1/path` and `/v1/path/subpath` routes with Endpoints:
 
 ```typescript
 import { Routing } from "express-zod-api";

--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ Start your API server with I/O schema validation and custom middlewares in minut
    13. [Enabling compression](#enabling-compression)
 5. [Advanced features](#advanced-features)
    1. [Customizing input sources](#customizing-input-sources)
-   2. [Route path params](#route-path-params)
-   3. [Multiple schemas for one route](#multiple-schemas-for-one-route)
-   4. [Response customization](#response-customization)
-   5. [Error handling](#error-handling)
-   6. [Production mode](#production-mode)
-   7. [Non-object response](#non-object-response) including file downloads
-   8. [File uploads](#file-uploads)
-   9. [Serving static files](#serving-static-files)
-   10. [Connect to your own express app](#connect-to-your-own-express-app)
-   11. [Testing endpoints](#testing-endpoints)
-   12. [Testing middlewares](#testing-middlewares)
+   2. [Nested routes](#nested-routes)
+   3. [Route path params](#route-path-params)
+   4. [Multiple schemas for one route](#multiple-schemas-for-one-route)
+   5. [Response customization](#response-customization)
+   6. [Error handling](#error-handling)
+   7. [Production mode](#production-mode)
+   8. [Non-object response](#non-object-response) including file downloads
+   9. [File uploads](#file-uploads)
+   10. [Serving static files](#serving-static-files)
+   11. [Connect to your own express app](#connect-to-your-own-express-app)
+   12. [Testing endpoints](#testing-endpoints)
+   13. [Testing middlewares](#testing-middlewares)
 6. [Special needs](#special-needs)
    1. [Different responses for different status codes](#different-responses-for-different-status-codes)
    2. [Array response](#array-response) for migrating legacy APIs
@@ -745,21 +746,32 @@ createConfig({
 });
 ```
 
-## Route path params
+## Nested routes
 
-You can describe the route of the endpoint using parameters:
+Suppose you want to assign both `/v1/path` and `/v1/path/subpath` routes to Endpoints:
 
 ```typescript
 import { Routing } from "express-zod-api";
 
 const routing: Routing = {
   v1: {
-    user: {
-      // route path /v1/user/:id, where :id is the path param
-      ":id": getUserEndpoint,
-      // use the empty string to represent /v1/user if needed:
-      // "": listAllUsersEndpoint,
-    },
+    path: endpointA.nest({
+      subpath: endpointB,
+    }),
+  },
+};
+```
+
+## Route path params
+
+You can assign your Endpoint to a route like `/v1/user/:id` where `:id` is the path parameter:
+
+```typescript
+import { Routing } from "express-zod-api";
+
+const routing: Routing = {
+  v1: {
+    user: { ":id": getUserEndpoint },
   },
 };
 ```

--- a/src/depends-on-method.ts
+++ b/src/depends-on-method.ts
@@ -1,13 +1,15 @@
 import { head, tail, toPairs } from "ramda";
 import { AbstractEndpoint } from "./endpoint";
 import { Method } from "./method";
+import { Nesting } from "./nesting";
 
-export class DependsOnMethod {
+export class DependsOnMethod extends Nesting {
   public readonly pairs: ReadonlyArray<[Method, AbstractEndpoint]>;
   public readonly firstEndpoint: AbstractEndpoint | undefined;
   public readonly siblingMethods: ReadonlyArray<Method>;
 
   constructor(endpoints: Partial<Record<Method, AbstractEndpoint>>) {
+    super();
     this.pairs = Object.freeze(
       toPairs(endpoints).filter(
         (pair): pair is [Method, AbstractEndpoint] =>

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -21,6 +21,7 @@ import { LogicalContainer, combineContainers } from "./logical-container";
 import { AuxMethod, Method } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import { ContentType, contentTypes } from "./content-type";
+import { Nesting } from "./nesting";
 import { AbstractResultHandler } from "./result-handler";
 import { Security } from "./security";
 
@@ -34,7 +35,7 @@ type DescriptionVariant = "short" | "long";
 type IOVariant = "input" | "output";
 type MimeVariant = Extract<IOVariant, "input"> | ResponseVariant;
 
-export abstract class AbstractEndpoint {
+export abstract class AbstractEndpoint extends Nesting {
   public abstract execute(params: {
     request: Request;
     response: Response;

--- a/src/nesting.ts
+++ b/src/nesting.ts
@@ -1,0 +1,8 @@
+import { Routing } from "./routing";
+
+export abstract class Nesting {
+  /** @desc Enables nested Routing within the path the subject is assigned to */
+  public nest(routing: Routing): Routing {
+    return Object.assign(routing, { "": this });
+  }
+}

--- a/src/nesting.ts
+++ b/src/nesting.ts
@@ -1,7 +1,7 @@
 import { Routing } from "./routing";
 
 export abstract class Nesting {
-  /** @desc Enables nested Routing within the path the subject is assigned to */
+  /** @desc Enables nested routes within the path assigned to the subject */
   public nest(routing: Routing): Routing {
     return Object.assign(routing, { "": this });
   }

--- a/tests/unit/nesting.spec.ts
+++ b/tests/unit/nesting.spec.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { defaultEndpointsFactory, DependsOnMethod } from "../../src";
+
+const endpoint = defaultEndpointsFactory.build({
+  method: "get", // @todo remove the line in v21
+  output: z.object({}),
+  handler: vi.fn(),
+});
+
+describe.each([new DependsOnMethod({ get: endpoint }), endpoint])(
+  "Nesting mixin %#",
+  (subject) => {
+    test("should have .nest() method returning Routing arrangement", () => {
+      expect(subject).toHaveProperty("nest", expect.any(Function));
+      expect(subject.nest({ subpath: endpoint })).toEqual({
+        "": subject,
+        subpath: endpoint,
+      });
+    });
+  },
+);

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from "vitest";
 import {
   appMock,
   expressMock,

--- a/tests/unit/routing.spec.ts
+++ b/tests/unit/routing.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "vitest";
 import {
   appMock,
   expressMock,
@@ -285,10 +286,9 @@ describe("Routing", () => {
       const routing: Routing = {
         v1: {
           user: {
-            ":id": {
-              "": endpointMock,
+            ":id": endpointMock.nest({
               " download ": endpointMock,
-            },
+            }),
           },
         },
       };
@@ -301,8 +301,14 @@ describe("Routing", () => {
         rootLogger,
       });
       expect(appMock.get).toHaveBeenCalledTimes(2);
-      expect(appMock.get.mock.calls[0][0]).toBe("/v1/user/:id");
-      expect(appMock.get.mock.calls[1][0]).toBe("/v1/user/:id/download");
+      expect(appMock.get).toHaveBeenCalledWith(
+        "/v1/user/:id",
+        expect.any(Function),
+      );
+      expect(appMock.get).toHaveBeenCalledWith(
+        "/v1/user/:id/download",
+        expect.any(Function),
+      );
     });
 
     test("Should throw an error in case of slashes in route", () => {


### PR DESCRIPTION
You will love it :)

```ts
// Describing paths /v1/path and /v1/path/subpath both having endpoints assigned:
const before: Routing = {
  v1: {
    path: {
      "": endpointA,
      "subpath": endpointB,
    }
  }
};

const after: Routing = {
  v1: {
    path: endpointA.nest({
      "subpath": endpointB,
    })
  }
};
```

Both for `Endpoint` and `DependsOnMethod`