### PR TITLE
Fixing the nested route traverse order — FIFO

### DIFF
--- a/src/routing-walker.ts
+++ b/src/routing-walker.ts
@@ -52,7 +52,7 @@ export const walkRouting = ({
         onEndpoint(endpoint, path, method, siblingMethods);
       }
     } else {
-      stack.push(...makePairs(element, path));
+      stack.unshift(...makePairs(element, path));
     }
   }
 };


### PR DESCRIPTION
Related to #2188 
Affects #2191 — should reduce shifting 