### PR TITLE
Vitest snapshot serializers instead of traversing schema in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,7 +67,7 @@ export default [
   },
   {
     name: "tests/all",
-    files: ["tests/**/*.ts"],
+    files: ["tests/**/*.ts", "vitest.setup.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-object-type": "warn",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,8 +1,5 @@
 import forge from "node-forge";
-import { map, when, equals, nAry } from "ramda";
-import { z } from "zod";
-import { ezFileBrand } from "../src/file-schema";
-import { SchemaHandler, walkSchema } from "../src/schema-walker";
+import { when, equals, nAry } from "ramda";
 
 const disposer = (function* () {
   let port = 8e3 + 1e2 * Number(process.env.VITEST_POOL_ID);
@@ -49,78 +46,4 @@ export const signCert = () => {
     cert: forge.pki.certificateToPem(cert),
     key: forge.pki.privateKeyToPem(keys.privateKey),
   };
-};
-
-export const serializeSchemaForTest = (
-  subject: z.ZodTypeAny,
-): Record<string, any> => {
-  const onSomeUnion: SchemaHandler<object> = (
-    {
-      options,
-    }:
-      | z.ZodUnion<z.ZodUnionOptions>
-      | z.ZodDiscriminatedUnion<
-          string,
-          z.ZodDiscriminatedUnionOption<string>[]
-        >,
-    { next },
-  ) => ({
-    options: Array.from(options.values()).map(next),
-  });
-  const onOptionalOrNullable: SchemaHandler<object> = (
-    schema: z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny>,
-    { next },
-  ) => ({
-    value: next(schema.unwrap()),
-  });
-  const onPrimitive = () => ({});
-  return walkSchema(subject, {
-    rules: {
-      ZodNull: onPrimitive,
-      ZodNumber: onPrimitive,
-      ZodString: onPrimitive,
-      ZodBoolean: onPrimitive,
-      ZodUnion: onSomeUnion,
-      ZodDiscriminatedUnion: onSomeUnion,
-      ZodOptional: onOptionalOrNullable,
-      ZodNullable: onOptionalOrNullable,
-      ZodIntersection: ({ _def }: z.ZodIntersection<any, any>, { next }) => ({
-        left: next(_def.left),
-        right: next(_def.right),
-      }),
-      ZodObject: ({ shape }: z.ZodObject<any>, { next }) => ({
-        shape: map(next, shape),
-      }),
-      ZodEffects: ({ _def }: z.ZodEffects<any>, { next }) => ({
-        value: next(_def.schema),
-      }),
-      ZodRecord: ({ keySchema, valueSchema }: z.ZodRecord, { next }) => ({
-        keys: next(keySchema),
-        values: next(valueSchema),
-      }),
-      ZodArray: ({ element }: z.ZodArray<any>, { next }) => ({
-        items: next(element),
-      }),
-      ZodLiteral: ({ value }: z.ZodLiteral<any>) => ({ value }),
-      ZodDefault: ({ _def }: z.ZodDefault<any>, { next }) => ({
-        value: next(_def.innerType),
-        default: _def.defaultValue(),
-      }),
-      ZodReadonly: (schema: z.ZodReadonly<any>, { next }) =>
-        next(schema.unwrap()),
-      ZodCatch: ({ _def }: z.ZodCatch<any>, { next }) => ({
-        value: next(_def.innerType),
-      }),
-      ZodPipeline: ({ _def }: z.ZodPipeline<any, any>, { next }) => ({
-        from: next(_def.in),
-        to: next(_def.out),
-      }),
-      [ezFileBrand]: () => ({ brand: ezFileBrand }),
-    },
-    onEach: ({ _def }: z.ZodTypeAny) => ({ _type: _def.typeName }),
-    onMissing: ({ _def }: z.ZodTypeAny) => {
-      console.warn(`There is no serializer for ${_def.typeName}`);
-      return {};
-    },
-  });
 };

--- a/tests/unit/documentation-helpers.spec.ts
+++ b/tests/unit/documentation-helpers.spec.ts
@@ -50,7 +50,6 @@ import {
   reformatParamsInPath,
 } from "../../src/documentation-helpers";
 import { walkSchema } from "../../src/schema-walker";
-import { serializeSchemaForTest } from "../helpers";
 
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();
@@ -117,7 +116,7 @@ describe("Documentation helpers", () => {
     test("should pass the object schema through", () => {
       const subject = extractObjectSchema(z.object({ one: z.string() }));
       expect(subject).toBeInstanceOf(z.ZodObject);
-      expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+      expect(subject).toMatchSnapshot();
     });
 
     test("should return object schema for the union of object schemas", () => {
@@ -125,7 +124,7 @@ describe("Documentation helpers", () => {
         z.object({ one: z.string() }).or(z.object({ two: z.number() })),
       );
       expect(subject).toBeInstanceOf(z.ZodObject);
-      expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+      expect(subject).toMatchSnapshot();
     });
 
     test("should return object schema for the intersection of object schemas", () => {
@@ -133,13 +132,13 @@ describe("Documentation helpers", () => {
         z.object({ one: z.string() }).and(z.object({ two: z.number() })),
       );
       expect(subject).toBeInstanceOf(z.ZodObject);
-      expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+      expect(subject).toMatchSnapshot();
     });
 
     test("should support ez.raw()", () => {
       const subject = extractObjectSchema(ez.raw());
       expect(subject).toBeInstanceOf(z.ZodObject);
-      expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+      expect(subject).toMatchSnapshot();
     });
 
     describe("Feature #600: Top level refinements", () => {
@@ -148,7 +147,7 @@ describe("Documentation helpers", () => {
           z.object({ one: z.string() }).refine(() => true),
         );
         expect(subject).toBeInstanceOf(z.ZodObject);
-        expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+        expect(subject).toMatchSnapshot();
       });
     });
 
@@ -158,7 +157,7 @@ describe("Documentation helpers", () => {
           z.object({ one: z.string() }).transform(({ one }) => ({ two: one })),
         );
         expect(subject).toBeInstanceOf(z.ZodObject);
-        expect(serializeSchemaForTest(subject)).toMatchSnapshot();
+        expect(subject).toMatchSnapshot();
       });
     });
   });

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -9,7 +9,6 @@ import {
   ResultHandler,
 } from "../../src";
 import { AbstractEndpoint, Endpoint } from "../../src/endpoint";
-import { serializeSchemaForTest } from "../helpers";
 
 describe("Endpoint", () => {
   describe(".getMethods()", () => {
@@ -305,9 +304,7 @@ describe("Endpoint", () => {
           output: z.object({ something: z.number() }),
           handler: vi.fn(),
         });
-        expect(
-          serializeSchemaForTest(endpoint.getSchema(variant)),
-        ).toMatchSnapshot();
+        expect(endpoint.getSchema(variant)).toMatchSnapshot();
       },
     );
   });

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -9,7 +9,6 @@ import {
 } from "../../src";
 import { EmptyObject, EmptySchema } from "../../src/common-helpers";
 import { Endpoint } from "../../src/endpoint";
-import { serializeSchemaForTest } from "../helpers";
 import { z } from "zod";
 
 describe("EndpointsFactory", () => {
@@ -244,12 +243,8 @@ describe("EndpointsFactory", () => {
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
       expect(endpoint.getMethods()).toStrictEqual(["get"]);
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("input")),
-      ).toMatchSnapshot();
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("output")),
-      ).toMatchSnapshot();
+      expect(endpoint.getSchema("input")).toMatchSnapshot();
+      expect(endpoint.getSchema("output")).toMatchSnapshot();
       expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
         n: number;
         s: string;
@@ -277,12 +272,8 @@ describe("EndpointsFactory", () => {
         output: z.object({ o: z.boolean() }),
         handler: vi.fn(),
       });
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("input")),
-      ).toMatchSnapshot();
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("output")),
-      ).toMatchSnapshot();
+      expect(endpoint.getSchema("input")).toMatchSnapshot();
+      expect(endpoint.getSchema("output")).toMatchSnapshot();
       expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
         a?: number;
         b?: string;
@@ -307,12 +298,8 @@ describe("EndpointsFactory", () => {
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
       expect(endpoint.getMethods()).toStrictEqual(["get"]);
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("input")),
-      ).toMatchSnapshot();
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("output")),
-      ).toMatchSnapshot();
+      expect(endpoint.getSchema("input")).toMatchSnapshot();
+      expect(endpoint.getSchema("output")).toMatchSnapshot();
       expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
         n1: number;
         n2: number;
@@ -340,12 +327,8 @@ describe("EndpointsFactory", () => {
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
       expect(endpoint.getMethods()).toStrictEqual(["get"]);
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("input")),
-      ).toMatchSnapshot();
-      expect(
-        serializeSchemaForTest(endpoint.getSchema("output")),
-      ).toMatchSnapshot();
+      expect(endpoint.getSchema("input")).toMatchSnapshot();
+      expect(endpoint.getSchema("output")).toMatchSnapshot();
       expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<
         { s: string } & ({ n1: number } | { n2: number })
       >();

--- a/tests/unit/io-schema.spec.ts
+++ b/tests/unit/io-schema.spec.ts
@@ -3,7 +3,6 @@ import { IOSchema, Middleware, ez } from "../../src";
 import { getFinalEndpointInputSchema } from "../../src/io-schema";
 import { metaSymbol } from "../../src/metadata";
 import { AbstractMiddleware } from "../../src/middleware";
-import { serializeSchemaForTest } from "../helpers";
 
 describe("I/O Schema and related helpers", () => {
   describe("IOSchema", () => {
@@ -155,7 +154,7 @@ describe("I/O Schema and related helpers", () => {
       });
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
       expect(result).toBeInstanceOf(z.ZodObject);
-      expect(serializeSchemaForTest(result)).toMatchSnapshot();
+      expect(result).toMatchSnapshot();
     });
 
     test("Should merge input object schemas", () => {
@@ -178,7 +177,7 @@ describe("I/O Schema and related helpers", () => {
       });
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
       expect(result).toBeInstanceOf(z.ZodIntersection);
-      expect(serializeSchemaForTest(result)).toMatchSnapshot();
+      expect(result).toMatchSnapshot();
     });
 
     test("Should merge union object schemas", () => {
@@ -201,7 +200,7 @@ describe("I/O Schema and related helpers", () => {
         .or(z.object({ six: z.number() }));
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
       expect(result).toBeInstanceOf(z.ZodIntersection);
-      expect(serializeSchemaForTest(result)).toMatchSnapshot();
+      expect(result).toMatchSnapshot();
     });
 
     test("Should merge intersection object schemas", () => {
@@ -224,7 +223,7 @@ describe("I/O Schema and related helpers", () => {
         .and(z.object({ six: z.number() }));
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
       expect(result).toBeInstanceOf(z.ZodIntersection);
-      expect(serializeSchemaForTest(result)).toMatchSnapshot();
+      expect(result).toMatchSnapshot();
     });
 
     test("Zod Issue #600: can not intersect object schema with passthrough and transformation", () => {
@@ -262,7 +261,7 @@ describe("I/O Schema and related helpers", () => {
       });
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
       expect(result).toBeInstanceOf(z.ZodIntersection);
-      expect(serializeSchemaForTest(result)).toMatchSnapshot();
+      expect(result).toMatchSnapshot();
     });
 
     test("Should merge examples in case of using withMeta()", () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -40,14 +40,7 @@ const makeSchemaSerializer = <
   const classes = Array.isArray(subject) ? subject : [subject];
   return {
     test: (subject) => classes.some((Cls) => subject instanceof Cls),
-    serialize: (
-      subject: z.ZodTypeAny,
-      config,
-      indentation,
-      depth,
-      refs,
-      printer,
-    ) =>
+    serialize: (subject, config, indentation, depth, refs, printer) =>
       printer(
         Object.assign(fn(subject as C), { _type: subject._def.typeName }),
         config,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -87,9 +87,6 @@ expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodOptional, (schema) => ({ value: schema.unwrap() })),
 );
 expect.addSnapshotSerializer(
-  makeSchemaSerializer(z.ZodNullable, (schema) => ({ value: schema.unwrap() })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodBranded, ({ _def }) => ({
     brand: _def[metaSymbol]?.brand,
   })),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -21,12 +21,12 @@ const errorSerializer: NewPlugin = {
   serialize: (error: Error, config, indentation, depth, refs, printer) => {
     const { name, message, cause } = error;
     const { handled } = error instanceof ResultHandlerError ? error : {};
-    const asObject = {
-      message,
-      ...(cause ? { cause } : {}),
-      ...(handled ? { handled } : {}),
-    };
-    return `${name}(${printer(asObject, config, indentation, depth, refs)})`;
+    const obj = Object.assign(
+      { message },
+      cause && { cause },
+      handled && { handled },
+    );
+    return `${name}(${printer(obj, config, indentation, depth, refs)})`;
   },
 };
 
@@ -40,14 +40,12 @@ const makeSchemaSerializer = <
   const classes = Array.isArray(subject) ? subject : [subject];
   return {
     test: (subject) => classes.some((Cls) => subject instanceof Cls),
-    serialize: (subject, config, indentation, depth, refs, printer) =>
-      printer(
-        Object.assign(fn(subject as C), { _type: subject._def.typeName }),
-        config,
-        indentation,
-        depth,
-        refs,
-      ),
+    serialize: (subject, config, indentation, depth, refs, printer) => {
+      const obj = Object.assign(fn(subject as C), {
+        _type: subject._def.typeName,
+      });
+      return printer(obj, config, indentation, depth, refs);
+    },
   };
 };
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -68,38 +68,25 @@ expect.addEqualityTesters([compareHttpErrors]);
  * @see https://github.com/vitest-dev/vitest/issues/5697
  * @see https://vitest.dev/guide/snapshot.html#custom-serializer
  */
-expect.addSnapshotSerializer(errorSerializer);
-expect.addSnapshotSerializer(
+const serializers = [
+  errorSerializer,
   makeSchemaSerializer(z.ZodObject, ({ shape }) => ({ shape })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodLiteral, ({ value }) => ({ value })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodIntersection, ({ _def: { left, right } }) => ({
     left,
     right,
   })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodUnion, ({ options }) => ({ options })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodEffects, ({ _def: { schema: value } }) => ({
     value,
   })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodOptional, (schema) => ({ value: schema.unwrap() })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(z.ZodBranded, ({ _def }) => ({
     brand: _def[metaSymbol]?.brand,
   })),
-);
-expect.addSnapshotSerializer(
   makeSchemaSerializer(
     [z.ZodNumber, z.ZodString, z.ZodBoolean, z.ZodNull],
     () => ({}),
   ),
-);
+];
+for (const serializer of serializers) expect.addSnapshotSerializer(serializer);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -34,29 +34,29 @@ const makeSchemaSerializer = <
   C extends z.ZodType,
   T extends { new (...args: any[]): C }[],
 >(
-  Classes: T | T[number],
+  subject: T | T[number],
   fn: (subject: C) => object,
-): NewPlugin => ({
-  test: (subject) =>
-    (Array.isArray(Classes) ? Classes : [Classes]).some(
-      (Cls) => subject instanceof Cls,
-    ),
-  serialize: (
-    subject: z.ZodTypeAny,
-    config,
-    indentation,
-    depth,
-    refs,
-    printer,
-  ) =>
-    printer(
-      Object.assign(fn(subject as C), { _type: subject._def.typeName }),
+): NewPlugin => {
+  const classes = Array.isArray(subject) ? subject : [subject];
+  return {
+    test: (subject) => classes.some((Cls) => subject instanceof Cls),
+    serialize: (
+      subject: z.ZodTypeAny,
       config,
       indentation,
       depth,
       refs,
-    ),
-});
+      printer,
+    ) =>
+      printer(
+        Object.assign(fn(subject as C), { _type: subject._def.typeName }),
+        config,
+        indentation,
+        depth,
+        refs,
+      ),
+  };
+};
 
 /**
  * @see https://vitest.dev/api/expect.html#expect-addequalitytesters


### PR DESCRIPTION
I could now use the native vitest object traverse for that

https://vitest.dev/guide/snapshot.html#custom-serializer

No performance degradation detected