### PR TITLE
Exp: Testing `superjson` performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "prettier": "3.3.3",
     "semver": "^7.6.3",
     "snakify-ts": "^2.3.0",
+    "superjson": "^2.2.1",
     "swagger-ui-express": "^5.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.6.2",

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -30,6 +30,12 @@ describe("Experiment on serialization", () => {
     JSON.stringify(routing);
   });
 
+  bench("JSON.stringify() with replacer", () => {
+    JSON.stringify(routing, (_key, value) =>
+      value instanceof Date ? value.toISOString() : value,
+    );
+  });
+
   bench("superjson.serialize()", () => {
     serialize(routing);
   });

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -1,7 +1,5 @@
 import { bench } from "vitest";
-import { retrieveUserEndpoint } from "../../example/endpoints/retrieve-user";
-import { DependsOnMethod } from "../../src";
-import { walkRouting } from "../../src/routing-walker";
+import { serialize } from "superjson";
 
 const routing = {
   a: {
@@ -13,9 +11,7 @@ const routing = {
               g: {
                 h: {
                   i: {
-                    j: new DependsOnMethod({
-                      post: retrieveUserEndpoint,
-                    }),
+                    j: new Date(),
                   },
                 },
               },
@@ -29,8 +25,12 @@ const routing = {
   },
 };
 
-describe("Experiment for routing walker", () => {
-  bench("featured", () => {
-    walkRouting({ routing, onEndpoint: vi.fn() });
+describe("Experiment on serialization", () => {
+  bench("JSON.stringify()", () => {
+    JSON.stringify(routing);
+  });
+
+  bench("superjson.serialize()", () => {
+    serialize(routing);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,13 @@ cookie@0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
 
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
+
 core-js-compat@^3.38.1:
   version "3.39.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.39.0.tgz#b12dccb495f2601dc860bdbe7b4e3ffa8ba63f61"
@@ -2232,6 +2239,11 @@ is-promise@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
+is-what@^4.1.8:
+  version "4.1.16"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.16.tgz#1ad860a19da8b4895ad5495da3182ce2acdd7a6f"
+  integrity sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3257,6 +3269,13 @@ sucrase@^3.35.0:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+superjson@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-2.2.1.tgz#9377a7fa80fedb10c851c9dbffd942d4bcf79733"
+  integrity sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==
+  dependencies:
+    copy-anything "^3.0.2"
 
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
This thing seems to be involved into tRPC protocol according to #2180 

Claimed by `superjson` documentation:
- Negligible runtime footprint

Fact checking:
```
   ✓ Experiment on serialization (2) 1350ms
     name                                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · JSON.stringify()                328,889.59  0.0028  0.1905  0.0030  0.0030  0.0047  0.0049  0.0267  ±0.25%   164445   fastest
   · JSON.stringify() with replacer  236,611.42  0.0039  0.3153  0.0042  0.0041  0.0055  0.0064  0.0308  ±0.32%   118306
   · superjson.serialize()            62,360.65  0.0146  0.3626  0.0160  0.0156  0.0326  0.0451  0.2140  ±0.66%    31181   slowest

 BENCH  Summary

  JSON.stringify() - tests/bench/experiment.bench.ts > Experiment on serialization
    1.39x faster than JSON.stringify() with replacer
    5.27x faster than superjson.serialize()
```

Related issue https://github.com/flightcontrolhq/superjson/issues/68


In general, I admire the idea, but it seems to have a massive performance flaw that makes its usage in IO operation questionable. However, it's more powerful and fixes several issues of JSON methods, like circular references.