### PR TITLE
Replacing `chain()` with `.map()`

### DIFF
--- a/src/integration-helpers.ts
+++ b/src/integration-helpers.ts
@@ -1,5 +1,4 @@
 import ts from "typescript";
-import { chain } from "ramda";
 import { Method } from "./method";
 
 export const f = ts.factory;
@@ -53,9 +52,8 @@ export const makeParams = (
   params: Record<string, ts.TypeNode | undefined>,
   mod?: ts.Modifier[],
 ) =>
-  chain(
-    ([name, node]) => [makeParam(f.createIdentifier(name), node, mod)],
-    Object.entries(params),
+  Object.entries(params).map(([name, node]) =>
+    makeParam(f.createIdentifier(name), node, mod),
   );
 
 export const makeRecord = (
@@ -155,11 +153,10 @@ export const makePublicExtendedInterface = (
     props,
   );
 
-const aggregateDeclarations = chain(([name, id]: [string, ts.Identifier]) => [
-  f.createTypeParameterDeclaration([], name, f.createTypeReferenceNode(id)),
-]);
 export const makeTypeParams = (params: Record<string, ts.Identifier>) =>
-  aggregateDeclarations(Object.entries(params));
+  Object.entries(params).map(([name, id]) =>
+    f.createTypeParameterDeclaration([], name, f.createTypeReferenceNode(id)),
+  );
 
 export const makeArrowFn = (
   params: ts.Identifier[],

--- a/src/logical-container.ts
+++ b/src/logical-container.ts
@@ -1,4 +1,3 @@
-import { chain } from "ramda";
 import { combinations, isObject } from "./common-helpers";
 
 type LogicalOr<T> = { or: T[] };
@@ -17,7 +16,7 @@ const isLogicalAnd = (subject: unknown): subject is LogicalAnd<unknown> =>
 
 /** @desc combines several LogicalAnds into a one */
 const flattenAnds = <T>(subject: (T | LogicalAnd<T>)[]): LogicalAnd<T> => ({
-  and: chain((item) => (isLogicalAnd(item) ? item.and : [item]), subject),
+  and: subject.flatMap((item) => (isLogicalAnd(item) ? item.and : [item])),
 });
 
 /** @desc creates a LogicalContainer out of another one */

--- a/src/logical-container.ts
+++ b/src/logical-container.ts
@@ -1,3 +1,4 @@
+import { chain } from "ramda";
 import { combinations, isObject } from "./common-helpers";
 
 type LogicalOr<T> = { or: T[] };
@@ -16,7 +17,7 @@ const isLogicalAnd = (subject: unknown): subject is LogicalAnd<unknown> =>
 
 /** @desc combines several LogicalAnds into a one */
 const flattenAnds = <T>(subject: (T | LogicalAnd<T>)[]): LogicalAnd<T> => ({
-  and: subject.flatMap((item) => (isLogicalAnd(item) ? item.and : [item])),
+  and: chain((item) => (isLogicalAnd(item) ? item.and : [item]), subject),
 });
 
 /** @desc creates a LogicalContainer out of another one */


### PR DESCRIPTION
went through #1498 , but it seems that no reduction was ever needed.
I need to check if there is no performance reduction caused by this change