### PR TITLE
Fixing the type of `Itegration::registry`

### DIFF
--- a/src/integration-helpers.ts
+++ b/src/integration-helpers.ts
@@ -226,7 +226,8 @@ export const makeObjectKeysReducer = (
     ],
   );
 
-export const quoteProp = (...parts: [Method, string]) => `"${parts.join(" ")}"`;
+export const quoteProp = (...parts: [Method, string]) =>
+  `"${parts.join(" ")}"` as `"${Method} ${string}"`;
 export const propOf = <T>(name: keyof NoInfer<T>) => name as string;
 
 export const makeTernary = (

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -109,11 +109,8 @@ export class Integration {
   protected program: ts.Node[] = [];
   protected usage: Array<ts.Node | string> = [];
   protected registry = new Map<
-    { method: Method; path: string },
-    Record<IOKind, string> & {
-      isJson: boolean;
-      tags: ReadonlyArray<string>;
-    }
+    ReturnType<typeof quoteProp>, // method+path
+    Record<IOKind, string> & { isJson: boolean; tags: ReadonlyArray<string> }
   >();
   protected paths: string[] = [];
   protected aliases = new Map<z.ZodTypeAny, ts.TypeAliasDeclaration>();
@@ -215,21 +212,18 @@ export class Integration {
           createTypeAlias(genericResponse, genericResponseId),
         );
         this.paths.push(path);
-        this.registry.set(
-          { method, path },
-          {
-            input: inputId,
-            positive: positiveResponseId,
-            negative: negativeResponseId,
-            response: genericResponseId,
-            isJson: endpoint
-              .getResponses("positive")
-              .some((response) =>
-                response.mimeTypes?.includes(contentTypes.json),
-              ),
-            tags: endpoint.getTags(),
-          },
-        );
+        this.registry.set(quoteProp(method, path), {
+          input: inputId,
+          positive: positiveResponseId,
+          negative: negativeResponseId,
+          response: genericResponseId,
+          isJson: endpoint
+            .getResponses("positive")
+            .some((response) =>
+              response.mimeTypes?.includes(contentTypes.json),
+            ),
+          tags: endpoint.getTags(),
+        });
       },
     });
 
@@ -259,8 +253,7 @@ export class Integration {
     // Single walk through the registry for making properties for the next three objects
     const jsonEndpoints: ts.PropertyAssignment[] = [];
     const endpointTags: ts.PropertyAssignment[] = [];
-    for (const [{ method, path }, { isJson, tags, ...rest }] of this.registry) {
-      const propName = quoteProp(method, path);
+    for (const [propName, { isJson, tags, ...rest }] of this.registry) {
       // "get /v1/user/retrieve": GetV1UserRetrieveInput
       for (const face of this.interfaces)
         face.props.push(makeInterfaceProp(propName, rest[face.kind]));

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -212,17 +212,16 @@ export class Integration {
           createTypeAlias(genericResponse, genericResponseId),
         );
         this.paths.push(path);
+        const isJson = endpoint
+          .getResponses("positive")
+          .some(({ mimeTypes }) => mimeTypes?.includes(contentTypes.json));
         this.registry.set(quoteProp(method, path), {
           input: inputId,
           positive: positiveResponseId,
           negative: negativeResponseId,
           response: genericResponseId,
-          isJson: endpoint
-            .getResponses("positive")
-            .some((response) =>
-              response.mimeTypes?.includes(contentTypes.json),
-            ),
           tags: endpoint.getTags(),
+          isJson,
         });
       },
     });


### PR DESCRIPTION
1. `Map` only ensures unique object keys when they are supplied by reference
2. There is no need it to be an object, because its only purpose is to shape the string
Therefore, string can be used as the `Map` key