### PR TITLE
Removing redundant type arguments on `Endpoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 21
 
+### v21.3.1
+
+- Return type of public methods `getTags()` and `getScopes()` of `Endpoint` corrected to `ReadyonlyArray<string>`.
+
 ### v21.3.0
 
 - Fixed `provide()` method usage example in the code of the generated client;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -60,8 +60,6 @@ export class Endpoint<
   IN extends IOSchema,
   OUT extends IOSchema,
   OPT extends FlatObject,
-  SCO extends string,
-  TAG extends string,
 > extends AbstractEndpoint {
   readonly #descriptions: Record<DescriptionVariant, string | undefined>;
   readonly #methods?: ReadonlyArray<Method>;
@@ -73,8 +71,8 @@ export class Endpoint<
   readonly #handler: Handler<z.output<IN>, z.input<OUT>, OPT>;
   readonly #resultHandler: AbstractResultHandler;
   readonly #schemas: { input: IN; output: OUT };
-  readonly #scopes: ReadonlyArray<SCO>;
-  readonly #tags: ReadonlyArray<TAG>;
+  readonly #scopes: ReadonlyArray<string>;
+  readonly #tags: ReadonlyArray<string>;
   readonly #getOperationId: (method: Method) => string | undefined;
   readonly #requestType: ContentType;
 
@@ -100,8 +98,8 @@ export class Endpoint<
     shortDescription?: string;
     getOperationId?: (method: Method) => string | undefined;
     methods?: Method[];
-    scopes?: SCO[];
-    tags?: TAG[];
+    scopes?: string[];
+    tags?: string[];
   }) {
     super();
     this.#handler = handler;

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -125,13 +125,7 @@ export class EndpointsFactory<
     scope,
     tag,
     method,
-  }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>): Endpoint<
-    z.ZodIntersection<IN, BIN>,
-    BOUT,
-    OUT,
-    SCO,
-    TAG
-  > {
+  }: BuildProps<BIN, BOUT, IN, OUT, SCO, TAG>) {
     const { middlewares, resultHandler } = this;
     const methods = typeof method === "string" ? [method] : method;
     const getOperationId =


### PR DESCRIPTION
- scopes and tags are only important for `BuildProps`, but not within `Endpoint` class
- I believe it's a rudimentary redundancy in the current arrangement
- This should ease making `output` schema optional