### PR TITLE
Feat: `buildVoid` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,22 @@
 
 ## Version 21
 
-### v21.3.1
+### v21.4.0
 
-- Return type of public methods `getTags()` and `getScopes()` of `Endpoint` corrected to `ReadyonlyArray<string>`.
+- Return type of public methods `getTags()` and `getScopes()` of `Endpoint` corrected to `ReadyonlyArray<string>`;
+- Featuring `EndpointsFactory::buildVoid()` method:
+  - It's a shorthand for returning `{}` while having `output` schema `z.object({})`;
+  - When using this method, `handler` may return `void` while retaining the object-based operation internally.
+
+```diff
+- factory.build({
++ factory.buildVoid({
+-   output: z.object({}),
+    handler: async () => {
+-     return {};
+    },
+  });
+```
 
 ### v21.3.0
 

--- a/example/endpoints/delete-user.ts
+++ b/example/endpoints/delete-user.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { noContentFactory } from "../factories";
 
 /** @desc The endpoint demonstrates no content response established by its factory */
-export const deleteUserEndpoint = noContentFactory.build({
+export const deleteUserEndpoint = noContentFactory.buildEmpty({
   method: "delete",
   tag: "users",
   input: z.object({
@@ -14,9 +14,7 @@ export const deleteUserEndpoint = noContentFactory.build({
       .transform((id) => parseInt(id, 10))
       .describe("numeric string"),
   }),
-  output: z.object({}),
   handler: async ({ input: { id } }) => {
     assert(id <= 100, createHttpError(404, "User not found"));
-    return {};
   },
 });

--- a/example/endpoints/delete-user.ts
+++ b/example/endpoints/delete-user.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { noContentFactory } from "../factories";
 
 /** @desc The endpoint demonstrates no content response established by its factory */
-export const deleteUserEndpoint = noContentFactory.buildEmpty({
+export const deleteUserEndpoint = noContentFactory.buildVoid({
   method: "delete",
   tag: "users",
   input: z.object({

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -18,7 +18,7 @@ import {
 
 interface BuildProps<
   IN extends IOSchema,
-  OUT extends IOSchema,
+  OUT extends IOSchema | z.ZodVoid,
   MIN extends IOSchema<"strip">,
   OPT extends FlatObject,
   SCO extends string,
@@ -145,6 +145,20 @@ export class EndpointsFactory<
       description,
       shortDescription,
       inputSchema: getFinalEndpointInputSchema<IN, BIN>(middlewares, input),
+    });
+  }
+
+  public buildEmpty<BIN extends IOSchema = EmptySchema>({
+    handler,
+    ...rest
+  }: Omit<BuildProps<BIN, z.ZodVoid, IN, OUT, SCO, TAG>, "output">) {
+    return this.build({
+      ...rest,
+      output: z.object({}),
+      handler: async (props) => {
+        await handler(props);
+        return {};
+      },
     });
   }
 }

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -148,6 +148,7 @@ export class EndpointsFactory<
     });
   }
 
+  /** @desc shorthand for returning {} while having output schema z.object({}) */
   public buildVoid<BIN extends IOSchema = EmptySchema>({
     handler,
     ...rest

--- a/src/endpoints-factory.ts
+++ b/src/endpoints-factory.ts
@@ -148,7 +148,7 @@ export class EndpointsFactory<
     });
   }
 
-  public buildEmpty<BIN extends IOSchema = EmptySchema>({
+  public buildVoid<BIN extends IOSchema = EmptySchema>({
     handler,
     ...rest
   }: Omit<BuildProps<BIN, z.ZodVoid, IN, OUT, SCO, TAG>, "output">) {

--- a/tests/unit/__snapshots__/endpoints-factory.spec.ts.snap
+++ b/tests/unit/__snapshots__/endpoints-factory.spec.ts.snap
@@ -174,6 +174,13 @@ exports[`EndpointsFactory > .build() > Should create an endpoint with union midd
 }
 `;
 
+exports[`EndpointsFactory > .buildVoid() > Should be a shorthand for empty object output 1`] = `
+{
+  "_type": "ZodObject",
+  "shape": {},
+}
+`;
+
 exports[`EndpointsFactory > .use() > Should transform errors 1`] = `
 UnauthorizedError({
   "message": "This one has failed",

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -618,7 +618,7 @@ describe("Endpoint", () => {
 
       const endpoint = defaultEndpointsFactory
         .addMiddleware(dateInputMiddleware)
-        .buildEmpty({
+        .buildVoid({
           handler: async ({ input: { middleware_date_input }, logger }) =>
             logger.debug(
               "date in endpoint handler",

--- a/tests/unit/endpoint.spec.ts
+++ b/tests/unit/endpoint.spec.ts
@@ -618,15 +618,12 @@ describe("Endpoint", () => {
 
       const endpoint = defaultEndpointsFactory
         .addMiddleware(dateInputMiddleware)
-        .build({
-          output: z.object({}),
-          handler: async ({ input: { middleware_date_input }, logger }) => {
+        .buildEmpty({
+          handler: async ({ input: { middleware_date_input }, logger }) =>
             logger.debug(
               "date in endpoint handler",
               typeof middleware_date_input,
-            );
-            return {};
-          },
+            ),
         });
 
       const { loggerMock, responseMock } = await testEndpoint({

--- a/tests/unit/endpoints-factory.spec.ts
+++ b/tests/unit/endpoints-factory.spec.ts
@@ -342,4 +342,15 @@ describe("EndpointsFactory", () => {
       ).toEqualTypeOf<EmptyObject>();
     });
   });
+
+  describe(".buildVoid()", () => {
+    test("Should be a shorthand for empty object output", () => {
+      const factory = new EndpointsFactory(resultHandlerMock);
+      const endpoint = factory.buildVoid({
+        handler: async () => {},
+      });
+      expect(endpoint.getSchema("output")).toMatchSnapshot();
+      expectTypeOf(endpoint.getSchema("output")).toMatchTypeOf<EmptySchema>();
+    });
+  });
 });


### PR DESCRIPTION
Alternative to #2241 

This one should be better because it helps to avoid the situation when you just forget to place `output` schema while using `.build()`. The dedicated method. Not sure yet how to call it.
But it should be helpful for #2238 