### PR TITLE
Replacing memoizer with a thunkifier 

### DIFF
--- a/src/common-helpers.ts
+++ b/src/common-helpers.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { chain, memoizeWith, pickBy, xprod } from "ramda";
+import { chain, pickBy, thunkify, xprod } from "ramda";
 import { z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
@@ -147,7 +147,6 @@ export const tryToTransform = <T>(
 export const isObject = (subject: unknown) =>
   typeof subject === "object" && subject !== null;
 
-export const isProduction = memoizeWith(
-  () => process.env.TSUP_STATIC as string, // eslint-disable-line no-restricted-syntax -- substituted by TSUP
-  () => process.env.NODE_ENV === "production", // eslint-disable-line no-restricted-syntax -- memoized
-);
+export const isProduction = thunkify(
+  () => process.env.NODE_ENV === "production", // eslint-disable-line no-restricted-syntax -- thunkified
+)();

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -7,11 +7,7 @@ describe("Experiment on memo/thunk", () => {
     isProduction();
   });
 
-  bench("control", () => {
-    return void (process.env.NODE_ENV === "production");
-  });
-
-  const feat = thunkify(() => process.env.NODE_ENV === "production");
+  const feat = thunkify(() => process.env.NODE_ENV === "production")();
 
   bench("feat", () => {
     feat();

--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -1,39 +1,19 @@
-import { chain, prop } from "ramda";
-import ts from "typescript";
+import { thunkify } from "ramda";
 import { bench } from "vitest";
-import { f } from "../../src/integration-helpers";
+import { isProduction } from "../../src/common-helpers";
 
-export const current = (nodes: ts.TypeLiteralNode[]) =>
-  f.createTypeLiteralNode(nodes.flatMap(({ members }) => members));
-
-export const feat = (nodes: ts.TypeLiteralNode[]) =>
-  f.createTypeLiteralNode(chain(prop("members"), nodes));
-
-describe("Experiment on flatMap", () => {
-  const subj = [
-    f.createTypeLiteralNode([
-      f.createPropertySignature(
-        undefined,
-        "test1",
-        undefined,
-        f.createTypeReferenceNode("test1"),
-      ),
-    ]),
-    f.createTypeLiteralNode([
-      f.createPropertySignature(
-        undefined,
-        "test2",
-        undefined,
-        f.createTypeReferenceNode("test2"),
-      ),
-    ]),
-  ];
-
-  bench("flatMap", () => {
-    current(subj);
+describe("Experiment on memo/thunk", () => {
+  bench("current", () => {
+    isProduction();
   });
 
-  bench("chain+prop", () => {
-    feat(subj);
+  bench("control", () => {
+    return void (process.env.NODE_ENV === "production");
+  });
+
+  const feat = thunkify(() => process.env.NODE_ENV === "production");
+
+  bench("feat", () => {
+    feat();
   });
 });

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -15,7 +15,6 @@ import { givePort } from "../helpers";
 import { setTimeout } from "node:timers/promises";
 
 describe("App in production mode", async () => {
-  vi.stubEnv("TSUP_STATIC", "production");
   vi.stubEnv("NODE_ENV", "production");
   const port = givePort();
   const logger = new BuiltinLogger({ level: "silent" });

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -48,7 +48,6 @@ describe("BuiltinLogger", () => {
     test.each(["development", "production"])(
       "Level can be omitted and depends on env",
       (mode) => {
-        vi.stubEnv("TSUP_STATIC", mode);
         vi.stubEnv("NODE_ENV", mode);
         const { logger } = makeLogger();
         expect(logger["config"]["level"]).toBe(

--- a/tests/unit/last-resort.spec.ts
+++ b/tests/unit/last-resort.spec.ts
@@ -10,7 +10,6 @@ describe("Last Resort Handler", () => {
 
   describe.each(["development", "production"])("%s mode", (mode) => {
     beforeAll(() => {
-      vi.stubEnv("TSUP_STATIC", mode);
       vi.stubEnv("NODE_ENV", mode);
     });
     afterAll(() => vi.unstubAllEnvs());

--- a/tests/unit/result-helpers.spec.ts
+++ b/tests/unit/result-helpers.spec.ts
@@ -97,7 +97,6 @@ describe("Result helpers", () => {
     "getPublicErrorMessage() in %s mode",
     (mode) => {
       beforeAll(() => {
-        vi.stubEnv("TSUP_STATIC", mode);
         vi.stubEnv("NODE_ENV", mode);
       });
       afterAll(() => vi.unstubAllEnvs());

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -32,7 +32,6 @@ export default defineConfig([
       }
       options.define = {
         "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
-        "process.env.TSUP_STATIC": `"static"`, // used by isProduction()
       };
     },
   },


### PR DESCRIPTION
```
 ✓ tests/bench/experiment.bench.ts (2) 3013ms
   ✓ Experiment on memo/thunk (2) 3011ms
     name               hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · current  2,777,123.28  0.0003  0.0839  0.0004  0.0004  0.0004  0.0004  0.0005  ±0.17%  1388562
   · feat     3,018,982.86  0.0003  0.0861  0.0003  0.0003  0.0004  0.0004  0.0006  ±0.18%  1509492   fastest
 ↓ tests/bench/integration.bench.ts (1) [skipped]
   ↓ Integration (1) [skipped]

 BENCH  Summary

  feat - tests/bench/experiment.bench.ts > Experiment on memo/thunk
    1.09x faster than current
```