### PR TITLE
Exp: lazy env access

### DIFF
--- a/tests/bench/experiment.bench.ts
+++ b/tests/bench/experiment.bench.ts
@@ -1,39 +1,63 @@
-import { chain, prop } from "ramda";
-import ts from "typescript";
 import { bench } from "vitest";
-import { f } from "../../src/integration-helpers";
 
-export const current = (nodes: ts.TypeLiteralNode[]) =>
-  f.createTypeLiteralNode(nodes.flatMap(({ members }) => members));
+function lazyWithInternalProp<T>(getter: () => T) {
+  return {
+    __value: undefined as T,
+    get value() {
+      if (this.__value) return this.__value;
+      const value = getter();
+      this.__value = value;
+      return value;
+    },
+  };
+}
 
-export const feat = (nodes: ts.TypeLiteralNode[]) =>
-  f.createTypeLiteralNode(chain(prop("members"), nodes));
+function lazyWithScopeProp<T>(getter: () => T): {
+  value: T;
+  __value?: T;
+} {
+  let __value: T;
+  return {
+    get value() {
+      if (__value) return __value;
+      const value = getter();
+      __value = value;
+      return value;
+    },
+  };
+}
 
-describe("Experiment on flatMap", () => {
-  const subj = [
-    f.createTypeLiteralNode([
-      f.createPropertySignature(
-        undefined,
-        "test1",
-        undefined,
-        f.createTypeReferenceNode("test1"),
-      ),
-    ]),
-    f.createTypeLiteralNode([
-      f.createPropertySignature(
-        undefined,
-        "test2",
-        undefined,
-        f.createTypeReferenceNode("test2"),
-      ),
-    ]),
-  ];
+function lazyWithGetterOverride<T>(getter: () => T): {
+  value: T;
+} {
+  return {
+    get value() {
+      const value = getter();
+      Object.defineProperty(this, "value", { value });
+      return value;
+    },
+  };
+}
 
-  bench("flatMap", () => {
-    current(subj);
+const a = lazyWithInternalProp(() => "test");
+const b = lazyWithScopeProp(() => "test");
+const c = lazyWithGetterOverride(() => "test");
+
+/**
+ * @see https://x.com/colinhacks/status/1865002498332795032
+ * @see https://x.com/colinhacks/status/1865143412812664985
+ * @see https://gist.github.com/colinhacks/a8d5772c1078b9285efb2455ab95fadf
+ */
+describe("AB test: uuid", () => {
+  bench("internal_prop", () => {
+    a.value;
   });
 
-  bench("chain+prop", () => {
-    feat(subj);
+  bench("scope_prop", () => {
+    b.value;
+  });
+
+  bench("getter_override", () => {
+    c.value;
   });
 });


### PR DESCRIPTION
```
 ✓ tests/bench/experiment.bench.ts (2) 5456ms
   ✓ Experiment: memo vs. getter override (2) 5454ms
     name                 hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · current    2,703,600.95  0.0003  0.0813  0.0004  0.0004  0.0004  0.0004  0.0005  ±0.21%  1351801
   · featured  12,468,626.90  0.0001  0.0703  0.0001  0.0001  0.0001  0.0001  0.0001  ±0.21%  6234314   fastest
```

- https://x.com/colinhacks/status/1865002498332795032
- https://x.com/colinhacks/status/1865143412812664985
- https://gist.github.com/colinhacks/a8d5772c1078b9285efb2455ab95fadf
- 