### PR TITLE
Organizing Typescipt API

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -155,7 +155,7 @@ export default tsPlugin.config(
   },
   {
     name: "source/integration",
-    files: ["src/integration.ts"],
+    files: ["src/integration.ts", "src/zts.ts"],
     rules: {
       "no-restricted-syntax": [
         "warn",

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -29,7 +29,9 @@ import {
   makeNew,
   makeKeyOf,
   makeSomeOfHelper,
-} from "./integration-helpers";
+  makePropertyIdentifier,
+  printNode,
+} from "./typescript-api";
 import { makeCleanId } from "./common-helpers";
 import { Method, methods } from "./method";
 import { contentTypes } from "./content-type";
@@ -38,7 +40,7 @@ import { Routing } from "./routing";
 import { OnEndpoint, walkRouting } from "./routing-walker";
 import { HandlingRules } from "./schema-walker";
 import { zodToTs } from "./zts";
-import { ZTSContext, printNode, makePropertyIdentifier } from "./zts-helpers";
+import { ZTSContext } from "./zts-helpers";
 import type Prettier from "prettier";
 
 type IOKind = "input" | "response" | ResponseVariant | "encoded";

--- a/src/typescript-api.ts
+++ b/src/typescript-api.ts
@@ -330,3 +330,19 @@ export const makeAnd = (left: ts.Expression, right: ts.Expression) =>
 
 export const makeNew = (cls: ts.Identifier, ...args: ts.Expression[]) =>
   f.createNewExpression(cls, undefined, args);
+
+const primitives: ts.KeywordTypeSyntaxKind[] = [
+  ts.SyntaxKind.AnyKeyword,
+  ts.SyntaxKind.BigIntKeyword,
+  ts.SyntaxKind.BooleanKeyword,
+  ts.SyntaxKind.NeverKeyword,
+  ts.SyntaxKind.NumberKeyword,
+  ts.SyntaxKind.ObjectKeyword,
+  ts.SyntaxKind.StringKeyword,
+  ts.SyntaxKind.SymbolKeyword,
+  ts.SyntaxKind.UndefinedKeyword,
+  ts.SyntaxKind.UnknownKeyword,
+  ts.SyntaxKind.VoidKeyword,
+];
+export const isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
+  (primitives as ts.SyntaxKind[]).includes(node.kind);

--- a/src/typescript-api.ts
+++ b/src/typescript-api.ts
@@ -1,5 +1,4 @@
 import ts from "typescript";
-import { addJsDocComment, makePropertyIdentifier } from "./zts-helpers";
 
 export const f = ts.factory;
 
@@ -13,6 +12,37 @@ export const protectedReadonlyModifier = [
   f.createModifier(ts.SyntaxKind.ProtectedKeyword),
   f.createModifier(ts.SyntaxKind.ReadonlyKeyword),
 ];
+
+export const addJsDocComment = <T extends ts.Node>(node: T, text: string) =>
+  ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    `* ${text} `,
+    true,
+  );
+
+export const printNode = (
+  node: ts.Node,
+  printerOptions?: ts.PrinterOptions,
+) => {
+  const sourceFile = ts.createSourceFile(
+    "print.ts",
+    "",
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS,
+  );
+  const printer = ts.createPrinter(printerOptions);
+  return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
+};
+
+const safePropRegex = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+export const makePropertyIdentifier = (name: string | number) =>
+  typeof name === "number"
+    ? f.createNumericLiteral(name)
+    : safePropRegex.test(name)
+      ? f.createIdentifier(name)
+      : f.createStringLiteral(name);
 
 export const makeTemplate = (
   head: string,

--- a/src/typescript-api.ts
+++ b/src/typescript-api.ts
@@ -95,11 +95,15 @@ export const makeEmptyInitializingConstructor = (
   params: ts.ParameterDeclaration[],
 ) => f.createConstructorDeclaration(undefined, params, f.createBlock([]));
 
-export const makeInterfaceProp = (name: string | number, value: ts.TypeNode) =>
+export const makeInterfaceProp = (
+  name: string | number,
+  value: ts.TypeNode,
+  { isOptional }: { isOptional?: boolean } = {},
+) =>
   f.createPropertySignature(
     undefined,
     makePropertyIdentifier(name),
-    undefined,
+    isOptional ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
     value,
   );
 

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -3,8 +3,6 @@ import { z } from "zod";
 import { FlatObject } from "./common-helpers";
 import { SchemaHandler } from "./schema-walker";
 
-const { factory: f } = ts;
-
 export type LiteralType = string | number | boolean;
 
 export interface ZTSContext extends FlatObject {
@@ -17,38 +15,6 @@ export interface ZTSContext extends FlatObject {
 }
 
 export type Producer = SchemaHandler<ts.TypeNode, ZTSContext>;
-
-export const addJsDocComment = <T extends ts.Node>(node: T, text: string) =>
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    `* ${text} `,
-    true,
-  );
-
-export const printNode = (
-  node: ts.Node,
-  printerOptions?: ts.PrinterOptions,
-) => {
-  const sourceFile = ts.createSourceFile(
-    "print.ts",
-    "",
-    ts.ScriptTarget.Latest,
-    false,
-    ts.ScriptKind.TS,
-  );
-  const printer = ts.createPrinter(printerOptions);
-  return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
-};
-
-const safePropRegex = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-
-export const makePropertyIdentifier = (name: string | number) =>
-  typeof name === "number"
-    ? f.createNumericLiteral(name)
-    : safePropRegex.test(name)
-      ? f.createIdentifier(name)
-      : f.createStringLiteral(name);
 
 const primitives: ts.KeywordTypeSyntaxKind[] = [
   ts.SyntaxKind.AnyKeyword,

--- a/src/zts-helpers.ts
+++ b/src/zts-helpers.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import type ts from "typescript";
 import { z } from "zod";
 import { FlatObject } from "./common-helpers";
 import { SchemaHandler } from "./schema-walker";
@@ -15,20 +15,3 @@ export interface ZTSContext extends FlatObject {
 }
 
 export type Producer = SchemaHandler<ts.TypeNode, ZTSContext>;
-
-const primitives: ts.KeywordTypeSyntaxKind[] = [
-  ts.SyntaxKind.AnyKeyword,
-  ts.SyntaxKind.BigIntKeyword,
-  ts.SyntaxKind.BooleanKeyword,
-  ts.SyntaxKind.NeverKeyword,
-  ts.SyntaxKind.NumberKeyword,
-  ts.SyntaxKind.ObjectKeyword,
-  ts.SyntaxKind.StringKeyword,
-  ts.SyntaxKind.SymbolKeyword,
-  ts.SyntaxKind.UndefinedKeyword,
-  ts.SyntaxKind.UnknownKeyword,
-  ts.SyntaxKind.VoidKeyword,
-];
-
-export const isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
-  (primitives as ts.SyntaxKind[]).includes(node.kind);

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -8,14 +8,8 @@ import { ezFileBrand, FileSchema } from "./file-schema";
 import { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand, RawSchema } from "./raw-schema";
 import { HandlingRules, walkSchema } from "./schema-walker";
-import {
-  addJsDocComment,
-  isPrimitive,
-  LiteralType,
-  makePropertyIdentifier,
-  Producer,
-  ZTSContext,
-} from "./zts-helpers";
+import { addJsDocComment, makePropertyIdentifier } from "./typescript-api";
+import { isPrimitive, LiteralType, Producer, ZTSContext } from "./zts-helpers";
 
 const { factory: f } = ts;
 

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -8,8 +8,12 @@ import { ezFileBrand, FileSchema } from "./file-schema";
 import { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand, RawSchema } from "./raw-schema";
 import { HandlingRules, walkSchema } from "./schema-walker";
-import { addJsDocComment, makePropertyIdentifier } from "./typescript-api";
-import { isPrimitive, LiteralType, Producer, ZTSContext } from "./zts-helpers";
+import {
+  addJsDocComment,
+  isPrimitive,
+  makePropertyIdentifier,
+} from "./typescript-api";
+import { LiteralType, Producer, ZTSContext } from "./zts-helpers";
 
 const { factory: f } = ts;
 

--- a/src/zts.ts
+++ b/src/zts.ts
@@ -11,7 +11,7 @@ import { HandlingRules, walkSchema } from "./schema-walker";
 import {
   addJsDocComment,
   isPrimitive,
-  makePropertyIdentifier,
+  makeInterfaceProp,
 } from "./typescript-api";
 import { LiteralType, Producer, ZTSContext } from "./zts-helpers";
 
@@ -51,14 +51,9 @@ const onObject: Producer = (
       isResponse && hasCoercion(value)
         ? value instanceof z.ZodOptional
         : value.isOptional();
-    const propertySignature = f.createPropertySignature(
-      undefined,
-      makePropertyIdentifier(key),
-      isOptional && hasQuestionMark
-        ? f.createToken(ts.SyntaxKind.QuestionToken)
-        : undefined,
-      next(value),
-    );
+    const propertySignature = makeInterfaceProp(key, next(value), {
+      isOptional: isOptional && hasQuestionMark,
+    });
     return value.description
       ? addJsDocComment(propertySignature, value.description)
       : propertySignature;

--- a/tests/unit/zts.spec.ts
+++ b/tests/unit/zts.spec.ts
@@ -1,9 +1,9 @@
 import ts from "typescript";
 import { z } from "zod";
 import { ez } from "../../src";
-import { f } from "../../src/integration-helpers";
+import { f, printNode } from "../../src/typescript-api";
 import { zodToTs } from "../../src/zts";
-import { ZTSContext, printNode } from "../../src/zts-helpers";
+import { ZTSContext } from "../../src/zts-helpers";
 
 describe("zod-to-ts", () => {
   const printNodeTest = (node: ts.Node) =>


### PR DESCRIPTION
First I wanna keep every helper using typescript factory in one place.
This should allow to use "integration helpers" file for bigger and higher order entities of the code production.
That will be helpful for #2280 that makes "integraton" file even bigger and less readable.