### PR TITLE
Exposing the child logger context on `BuiltinLogger`

### DIFF
--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -111,6 +111,14 @@ export class BuiltinLogger implements AbstractLogger {
     return new BuiltinLogger({ ...this.config, ctx });
   }
 
+  /**
+   * @desc The argument used for instance created by .child() method
+   * @see ChildLoggerProvider
+   * */
+  public get ctx() {
+    return this.config.ctx;
+  }
+
   /** @desc Measures the duration until you invoke the returned callback */
   public profile(message: string): () => void;
   public profile(options: ProfilerOptions): () => void;

--- a/tests/unit/builtin-logger.spec.ts
+++ b/tests/unit/builtin-logger.spec.ts
@@ -130,6 +130,7 @@ describe("BuiltinLogger", () => {
         color,
       });
       const child = parent.child(ctx);
+      expect(child.ctx).toEqual(ctx);
       child.info("Here is some message", { more: "information" });
       expect(logSpy.mock.calls).toMatchSnapshot();
     });


### PR DESCRIPTION
https://github.com/RobinTail/express-zod-api/discussions/2294#discussioncomment-11796052