### PR TITLE
Integration: JSON namespace constraints

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -615,9 +615,11 @@ export class Integration {
       this.ids.bodyProperty,
       makeTernary(
         this.ids.hasBodyConst,
-        makePropCall(f.createIdentifier("JSON"), propOf<JSON>("stringify"), [
-          this.ids.paramsArgument,
-        ]),
+        makePropCall(
+          f.createIdentifier(JSON[Symbol.toStringTag]),
+          propOf<JSON>("stringify"),
+          [this.ids.paramsArgument],
+        ),
         this.ids.undefinedValue,
       ),
     );


### PR DESCRIPTION
`Symbol.toStringTag` is ES2015 feature

`"JSON"` was the last string literal without any constraints