### PR TITLE
Adjusting client constructor

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,7 +73,7 @@ const tsFactoryConcerns = [
   },
   {
     selector: "Identifier[name='createConstructorDeclaration']",
-    message: "use makeEmptyInitializingConstructor() helper",
+    message: "use makePublicConstructor() helper",
   },
   {
     selector: "Identifier[name='createParameterDeclaration']",

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -435,7 +435,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],

--- a/src/integration-base.ts
+++ b/src/integration-base.ts
@@ -9,7 +9,7 @@ import {
   makeArrowFn,
   makeConst,
   makeDeconstruction,
-  makeEmptyInitializingConstructor,
+  makeConstructor,
   makeInterface,
   makeInterfaceProp,
   makeKeyOf,
@@ -284,8 +284,8 @@ export abstract class IntegrationBase {
   protected makeClientClass = () =>
     makePublicClass(
       this.ids.clientClass,
-      // constructor(protected readonly implementation: Implementation) {}
-      makeEmptyInitializingConstructor([
+      // public constructor(protected readonly implementation: Implementation) {}
+      makeConstructor([
         makeParam(this.ids.implementationArgument, {
           type: ensureTypeNode(this.ids.implementationType),
           mod: accessModifiers.protectedReadonly,

--- a/src/integration-base.ts
+++ b/src/integration-base.ts
@@ -9,7 +9,7 @@ import {
   makeArrowFn,
   makeConst,
   makeDeconstruction,
-  makeConstructor,
+  makePublicConstructor,
   makeInterface,
   makeInterfaceProp,
   makeKeyOf,
@@ -285,7 +285,7 @@ export abstract class IntegrationBase {
     makePublicClass(
       this.ids.clientClass,
       // public constructor(protected readonly implementation: Implementation) {}
-      makeConstructor([
+      makePublicConstructor([
         makeParam(this.ids.implementationArgument, {
           type: ensureTypeNode(this.ids.implementationType),
           mod: accessModifiers.protectedReadonly,

--- a/src/typescript-api.ts
+++ b/src/typescript-api.ts
@@ -88,7 +88,7 @@ export const makeParams = (params: Partial<Record<string, ts.TypeNode>>) =>
     makeParam(f.createIdentifier(name), { type }),
   );
 
-export const makeConstructor = (params: ts.ParameterDeclaration[]) =>
+export const makePublicConstructor = (params: ts.ParameterDeclaration[]) =>
   f.createConstructorDeclaration(
     accessModifiers.public,
     params,

--- a/src/typescript-api.ts
+++ b/src/typescript-api.ts
@@ -88,9 +88,12 @@ export const makeParams = (params: Partial<Record<string, ts.TypeNode>>) =>
     makeParam(f.createIdentifier(name), { type }),
   );
 
-export const makeEmptyInitializingConstructor = (
-  params: ts.ParameterDeclaration[],
-) => f.createConstructorDeclaration(undefined, params, f.createBlock([]));
+export const makeConstructor = (params: ts.ParameterDeclaration[]) =>
+  f.createConstructorDeclaration(
+    accessModifiers.public,
+    params,
+    f.createBlock([]),
+  );
 
 export const ensureTypeNode = (
   subject: ts.TypeNode | ts.Identifier | string,

--- a/tests/unit/__snapshots__/integration.spec.ts.snap
+++ b/tests/unit/__snapshots__/integration.spec.ts.snap
@@ -86,7 +86,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],
@@ -210,7 +210,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],
@@ -334,7 +334,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],
@@ -876,7 +876,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],
@@ -1479,7 +1479,7 @@ export type Implementation = (
 ) => Promise<any>;
 
 export class ExpressZodAPIClient {
-  constructor(protected readonly implementation: Implementation) {}
+  public constructor(protected readonly implementation: Implementation) {}
   public provide<K extends Request>(
     request: K,
     params: Input[K],


### PR DESCRIPTION
I wanna follow the principle of consistency and ensure that all constructors have an explicit access modifier specified