### PR TITLE
Declaring the package manager for Node `corepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,5 +182,6 @@
     "swagger-documentation",
     "zod",
     "validation"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
Modern Node versions require this entry for corepack