### PR TITLE
Moving styles from `BuiltinLogger` instance

### DIFF
--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -48,13 +48,12 @@ export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
-  public constructor(config: Partial<BuiltinLoggerConfig> = {}) {
-    const {
-      color = ansis.isSupported(),
-      level = isProduction() ? "warn" : "debug",
-      depth = 2,
-      ctx = {},
-    } = config;
+  public constructor({
+    color = ansis.isSupported(),
+    level = isProduction() ? "warn" : "debug",
+    depth = 2,
+    ctx = {},
+  }: Partial<BuiltinLoggerConfig> = {}) {
     this.config = { color, level, depth, ctx };
   }
 

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -1,4 +1,4 @@
-import { Ansis, blue, cyanBright, green, hex, red } from "ansis";
+import ansis from "ansis";
 import { inspect } from "node:util";
 import { performance } from "node:perf_hooks";
 import { FlatObject, isProduction } from "./common-helpers";
@@ -7,6 +7,7 @@ import {
   formatDuration,
   isHidden,
   Severity,
+  styles,
 } from "./logger-helpers";
 
 interface Context extends FlatObject {
@@ -42,13 +43,6 @@ interface ProfilerOptions {
   formatter?: (ms: number) => string | number;
 }
 
-const styles: Record<Severity, Ansis> = {
-  debug: blue,
-  info: green,
-  warn: hex("#FFA500"),
-  error: red,
-};
-
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
@@ -56,7 +50,7 @@ export class BuiltinLogger implements AbstractLogger {
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
   public constructor(config: Partial<BuiltinLoggerConfig> = {}) {
     const {
-      color = new Ansis().isSupported(),
+      color = ansis.isSupported(),
       level = isProduction() ? "warn" : "debug",
       depth = 2,
       ctx = {},
@@ -82,7 +76,7 @@ export class BuiltinLogger implements AbstractLogger {
     } = this.config;
     if (level === "silent" || isHidden(method, level)) return;
     const output: string[] = [new Date().toISOString()];
-    if (requestId) output.push(hasColor ? cyanBright(requestId) : requestId);
+    if (requestId) output.push(hasColor ? styles.ctx(requestId) : requestId);
     output.push(
       hasColor ? `${styles[method](method)}:` : `${method}:`,
       message,

--- a/src/builtin-logger.ts
+++ b/src/builtin-logger.ts
@@ -42,15 +42,16 @@ interface ProfilerOptions {
   formatter?: (ms: number) => string | number;
 }
 
+const styles: Record<Severity, Ansis> = {
+  debug: blue,
+  info: green,
+  warn: hex("#FFA500"),
+  error: red,
+};
+
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
-  protected readonly styles: Record<Severity, Ansis> = {
-    debug: blue,
-    info: green,
-    warn: hex("#FFA500"),
-    error: red,
-  };
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
   public constructor(config: Partial<BuiltinLoggerConfig> = {}) {
@@ -83,7 +84,7 @@ export class BuiltinLogger implements AbstractLogger {
     const output: string[] = [new Date().toISOString()];
     if (requestId) output.push(hasColor ? cyanBright(requestId) : requestId);
     output.push(
-      hasColor ? `${this.styles[method](method)}:` : `${method}:`,
+      hasColor ? `${styles[method](method)}:` : `${method}:`,
       message,
     );
     if (meta !== undefined) output.push(this.prettyPrint(meta));

--- a/src/logger-helpers.ts
+++ b/src/logger-helpers.ts
@@ -1,4 +1,13 @@
+import { Ansis, blue, green, hex, red, cyanBright } from "ansis";
 import { isObject } from "./common-helpers";
+
+export const styles = {
+  debug: blue,
+  info: green,
+  warn: hex("#FFA500"),
+  error: red,
+  ctx: cyanBright,
+} satisfies Record<string, Ansis>;
 
 const severity = {
   debug: 10,


### PR DESCRIPTION
There is no need to recreate these props for every instance of the logger, which may be important when using child loggers. The measure aims to reduce the logger instance weight.