### PR TITLE
`Endpoint::getSecurity()` to return an array of containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - The overload of `EndpointsFactory::constructor()` accepting `config` property is removed;
   - The argument of `EventStreamFactory::constructor()` is now the events map (formerly assigned to `events` property);
   - Tags should be declared as the keys of the augmented interface `TagOverrides` instead;
+- The public method `Endpoint::getSecurity()` now returns an array;
 - Consider the automated migration using the built-in ESLint rule.
 
 ```js

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -13,7 +13,7 @@ import { contentTypes } from "./content-type";
 import { DocumentationError } from "./errors";
 import { defaultInputSources, makeCleanId } from "./common-helpers";
 import { CommonConfig } from "./config-type";
-import { mapLogicalContainer } from "./logical-container";
+import { combineContainers, mapLogicalContainer } from "./logical-container";
 import { Method } from "./method";
 import {
   OpenAPIContext,
@@ -226,7 +226,14 @@ export class Documentation extends OpenApiBuilder {
 
       const securityRefs = depictSecurityRefs(
         mapLogicalContainer(
-          depictSecurity(endpoint.getSecurity(), inputSources),
+          depictSecurity(
+            endpoint
+              .getSecurity()
+              .reduce((acc, entry) => combineContainers(acc, entry), {
+                and: [],
+              }),
+            inputSources,
+          ),
           (securitySchema) => {
             const name = this.ensureUniqSecuritySchemaName(securitySchema);
             const scopes = ["oauth2", "openIdConnect"].includes(

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -227,11 +227,7 @@ export class Documentation extends OpenApiBuilder {
       const securityRefs = depictSecurityRefs(
         mapLogicalContainer(
           depictSecurity(
-            endpoint
-              .getSecurity()
-              .reduce((acc, entry) => combineContainers(acc, entry), {
-                and: [],
-              }),
+            endpoint.getSecurity().reduce(combineContainers, { and: [] }),
             inputSources,
           ),
           (securitySchema) => {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -17,7 +17,7 @@ import {
 import { IOSchema } from "./io-schema";
 import { lastResortHandler } from "./last-resort";
 import { ActualLogger } from "./logger-helpers";
-import { LogicalContainer, combineContainers } from "./logical-container";
+import { LogicalContainer } from "./logical-container";
 import { AuxMethod, Method } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import { ContentType } from "./content-type";
@@ -49,7 +49,7 @@ export abstract class AbstractEndpoint extends Nesting {
   public abstract getResponses(
     variant: ResponseVariant,
   ): ReadonlyArray<NormalizedResponse>;
-  public abstract getSecurity(): LogicalContainer<Security>;
+  public abstract getSecurity(): LogicalContainer<Security>[];
   public abstract getScopes(): ReadonlyArray<string>;
   public abstract getTags(): ReadonlyArray<string>;
   public abstract getOperationId(method: Method): string | undefined;
@@ -145,13 +145,9 @@ export class Endpoint<
   }
 
   public override getSecurity() {
-    return this.#middlewares.reduce<LogicalContainer<Security>>(
-      (acc, middleware) => {
-        const security = middleware.getSecurity();
-        return security ? combineContainers(acc, security) : acc;
-      },
-      { and: [] },
-    );
+    return this.#middlewares
+      .map((middleware) => middleware.getSecurity())
+      .filter((entry) => entry !== undefined);
   }
 
   public override getScopes() {


### PR DESCRIPTION
Cherry-picked from #2332 

This should ease that PR as later fix without any breaking changes