### PR TITLE
fix: port conditional call of `response.flush` for SSE from v21

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
   schedule:
     - cron: '26 8 * * 1'
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
   pull_request:
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
 
 jobs:
   build:

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -2,9 +2,9 @@ name: OpenAPI Validation
 
 on:
   push:
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
   pull_request:
-    branches: [ master, v18, v19, v20 ]
+    branches: [ master, v18, v19, v20, v21 ]
 
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Version 21
 
+### v21.11.2
+
+- Fixed issue on emitting server-sent events (SSE), introduced in v21.5.0:
+  - Emitting SSE failed due to internal error `flush is not a function` having `compression` disabled in config;
+  - The `.flush()` method of `response` is a feature of `compression` (optional peer dependency);
+  - It is required to call the method when `compression` is enabled;
+  - This version fixes the issue by calling the method conditionally;
+  - This bug was reported by [@bobgubko](https://github.com/bobgubko).
+
 ### v21.11.1
 
 - Common styling methods (coloring) are extracted from the built-in logger instance:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Therefore, many basic tasks can be accomplished faster and easier, in particular
 
 These people contributed to the improvement of the framework by reporting bugs, making changes and suggesting ideas:
 
+[<img src="https://github.com/bobgubko.png" alt="@bobgubko" width="50px" />](https://github.com/bobgubko)
 [<img src="https://github.com/HenriJ.png" alt="@HenriJ" width="50px" />](https://github.com/HenriJ)
 [<img src="https://github.com/JonParton.png" alt="@JonParton" width="50px" />](https://github.com/JonParton)
 [<img src="https://github.com/williamgcampbell.png" alt="@williamgcampbell" width="50px" />](https://github.com/williamgcampbell)
@@ -102,7 +103,6 @@ These people contributed to the improvement of the framework by reporting bugs, 
 [<img src="https://github.com/danclaytondev.png" alt="@danclaytondev" width="50px" />](https://github.com/danclaytondev)
 [<img src="https://github.com/huyhoang160593.png" alt="@huyhoang160593" width="50px" />](https://github.com/huyhoang160593)
 [<img src="https://github.com/sarahssharkey.png" alt="@sarahssharkey" width="50px" />](https://github.com/sarahssharkey)
-[<img src="https://github.com/bobgubko.png" alt="@bobgubko" width="50px" />](https://github.com/bobgubko)
 [<img src="https://github.com/master-chu.png" alt="@master-chu" width="50px" />](https://github.com/master-chu)
 [<img src="https://github.com/alindsay55661.png" alt="@alindsay55661" width="50px" />](https://github.com/alindsay55661)
 [<img src="https://github.com/john-schmitz.png" alt="@john-schmitz" width="50px" />](https://github.com/john-schmitz)

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Example API
-  version: 21.11.1
+  version: 21.11.2
 paths:
   /v1/user/retrieve:
     get:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-zod-api",
-  "version": "21.11.1",
+  "version": "21.11.2",
   "description": "A Typescript framework to help you get an API server up and running with I/O schema validation and custom middlewares in minutes.",
   "license": "MIT",
   "repository": {

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -62,7 +62,11 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
         emit: (event, data) => {
           ensureStream(response);
           response.write(formatEvent(events, event, data), "utf-8");
-          response.flush();
+          /**
+           * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
+           * @link https://github.com/RobinTail/express-zod-api/issues/2347
+           * */
+          response.flush?.();
         },
       },
   });


### PR DESCRIPTION
#2348 merging into v22
Fixes #2347 