### PR TITLE
Revert `HeaderSecurity` constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### v23.0.0
 
-- Publicly exposed interface `CustomHeaderSecurity` is renamed to `HeaderSecurity`;
-- Restrictions have been placed between header names in the middleware `security` declaration and in `input` properties.
+- Publicly exposed interface `CustomHeaderSecurity` is renamed to `HeaderSecurity`.
 
 ## Version 22
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -12,9 +12,9 @@ export interface InputSecurity<K extends string> {
   name: K;
 }
 
-export interface HeaderSecurity<K extends string> {
+export interface HeaderSecurity {
   type: "header";
-  name: K;
+  name: string;
 }
 
 export interface CookieSecurity {
@@ -89,7 +89,7 @@ export type Security<K extends string = string, S extends string = string> =
   | BasicSecurity
   | BearerSecurity
   | InputSecurity<K>
-  | HeaderSecurity<K>
+  | HeaderSecurity
   | CookieSecurity
   | OpenIdSecurity
   | OAuth2Security<S>;

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -74,7 +74,7 @@ describe("Index Entrypoint", () => {
       expectTypeOf<{
         type: "header";
         name: "some";
-      }>().toMatchTypeOf<HeaderSecurity<string>>();
+      }>().toMatchTypeOf<HeaderSecurity>();
       expectTypeOf<{ type: "input"; name: "some" }>().toMatchTypeOf<
         InputSecurity<string>
       >();


### PR DESCRIPTION
to allow that kind of `Security` without opt-in for `headers` as input source.