### PR TITLE
Change default response to `405` for wrong method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### v23.0.0
 
-- Publicly exposed interface `CustomHeaderSecurity` is renamed to `HeaderSecurity`.
+- Publicly exposed interface `CustomHeaderSecurity` is renamed to `HeaderSecurity`;
+- The default value for `wrongMethodBehavior` config option is changed to `405`.
 
 ## Version 22
 

--- a/src/config-type.ts
+++ b/src/config-type.ts
@@ -41,8 +41,7 @@ export interface CommonConfig {
    * @desc How to respond to a request that uses a wrong method to an existing endpoint
    * @example 404 — Not found
    * @example 405 — Method not allowed, incl. the "Allowed" header with a list of methods
-   * @default 404
-   * @todo consider changing default to 405 in v23
+   * @default 405
    * */
   wrongMethodBehavior?: 404 | 405;
   /**

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -80,7 +80,7 @@ export const initRouting = ({
     app[method](path, ...matchingParsers, handler);
   };
   walkRouting({ routing, onEndpoint, onStatic: app.use.bind(app) });
-  if (config.wrongMethodBehavior !== 405) return;
+  if (config.wrongMethodBehavior === 404) return;
   for (const [path, allowedMethods] of familiar.entries())
     app.all(path, createWrongMethodHandler(allowedMethods));
 };

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -112,7 +112,6 @@ describe("App in production mode", async () => {
   const config = createConfig({
     http: { listen: port },
     compression: { threshold: 1 },
-    wrongMethodBehavior: 405,
     beforeRouting: ({ app, getLogger }) => {
       depd("express")("Sample deprecation message");
       app.use((req, {}, next) => {

--- a/tests/unit/__snapshots__/migration.spec.ts.snap
+++ b/tests/unit/__snapshots__/migration.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`Migration > should consist of one rule being the major version of the p
       "meta": {
         "fixable": "code",
         "messages": {
+          "add": "add {{ subject }} to {{ to }}",
           "change": "change {{ subject }} from {{ from }} to {{ to }}",
         },
         "schema": [],

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -18,7 +18,10 @@ describe("Migration", () => {
   });
 
   tester.run("v23", migration.rules.v23, {
-    valid: [`import { HeaderSecurity } from "express-zod-api";`],
+    valid: [
+      `import { HeaderSecurity } from "express-zod-api";`,
+      `createConfig({ wrongMethodBehavior: 405 });`,
+    ],
     invalid: [
       {
         code: `const security: CustomHeaderSecurity = {};`,
@@ -30,6 +33,19 @@ describe("Migration", () => {
               subject: "interface",
               from: "CustomHeaderSecurity",
               to: "HeaderSecurity",
+            },
+          },
+        ],
+      },
+      {
+        code: `createConfig({});`,
+        output: `createConfig({wrongMethodBehavior: 404,});`,
+        errors: [
+          {
+            messageId: "add",
+            data: {
+              subject: "wrongMethodBehavior property",
+              to: "configuration",
             },
           },
         ],


### PR DESCRIPTION
Feature was introduced in #2366 .
Making it default behavior in next major.