### PR TITLE
Fix `Metadata` constraints

### DIFF
--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -83,12 +83,14 @@ export const getMessageFromError = (error: Error): string => {
 /** Takes the original unvalidated examples from the properties of ZodObject schema shape */
 export const pullExampleProps = <T extends z.SomeZodObject>(subject: T) =>
   Object.entries(subject.shape).reduce<Partial<z.input<T>>[]>(
-    (acc, [key, schema]) =>
-      combinations(
+    (acc, [key, schema]) => {
+      const { _def } = schema as z.ZodType;
+      return combinations(
         acc,
-        (schema._def[metaSymbol]?.examples || []).map(objOf(key)),
+        (_def[metaSymbol]?.examples || []).map(objOf(key)),
         ([left, right]) => ({ ...left, ...right }),
-      ),
+      );
+    },
     [],
   );
 

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -95,7 +95,7 @@ export const pullExampleProps = <T extends z.SomeZodObject>(subject: T) =>
   );
 
 export const getExamples = <
-  T extends z.ZodTypeAny,
+  T extends z.ZodType,
   V extends "original" | "parsed" | undefined,
 >({
   schema,

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -52,7 +52,7 @@ const ioChecks: HandlingRules<boolean, EmptyObject, z.ZodFirstPartyTypeKind> = {
 };
 
 interface NestedSchemaLookupProps {
-  condition?: (schema: z.ZodTypeAny) => boolean;
+  condition?: (schema: z.ZodType) => boolean;
   rules?: HandlingRules<
     boolean,
     EmptyObject,

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -64,7 +64,7 @@ interface NestedSchemaLookupProps {
 
 /** @desc The optimized version of the schema walker for boolean checks */
 export const hasNestedSchema = (
-  subject: z.ZodTypeAny,
+  subject: z.ZodType,
   {
     condition,
     rules = ioChecks,
@@ -76,7 +76,9 @@ export const hasNestedSchema = (
   const handler =
     depth < maxDepth
       ? rules[subject._def[metaSymbol]?.brand as keyof typeof rules] ||
-        rules[subject._def.typeName as keyof typeof rules]
+        ("typeName" in subject._def
+          ? rules[subject._def.typeName as keyof typeof rules]
+          : undefined)
       : undefined;
   if (handler) {
     return handler(subject, {

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -19,15 +19,15 @@ export const cloneSchema = <T extends z.ZodType>(schema: T) => {
   return copy;
 };
 
-export const copyMeta = <A extends z.ZodTypeAny, B extends z.ZodTypeAny>(
+export const copyMeta = <A extends z.ZodType, B extends z.ZodType>(
   src: A,
   dest: B,
 ): B => {
-  if (!(metaSymbol in src._def)) return dest;
-  const result = cloneSchema(dest);
-  result._def[metaSymbol].examples = combinations(
-    result._def[metaSymbol].examples,
-    src._def[metaSymbol].examples,
+  if (!(metaSymbol in src._def)) return dest; // ensure metadata in src below
+  const result = cloneSchema(dest); // ensures metadata in result below
+  result._def[metaSymbol]!.examples = combinations(
+    result._def[metaSymbol]!.examples,
+    src._def[metaSymbol]!.examples,
     ([destExample, srcExample]) =>
       typeof destExample === "object" && typeof srcExample === "object"
         ? mergeDeepRight({ ...destExample }, { ...srcExample })

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -35,7 +35,7 @@ export const walkSchema = <
   U extends object,
   Context extends FlatObject = EmptyObject,
 >(
-  schema: z.ZodTypeAny,
+  schema: z.ZodType,
   {
     onEach,
     rules,
@@ -50,7 +50,9 @@ export const walkSchema = <
 ): U => {
   const handler =
     rules[schema._def[metaSymbol]?.brand as keyof typeof rules] ||
-    rules[schema._def.typeName as keyof typeof rules];
+    ("typeName" in schema._def
+      ? rules[schema._def.typeName as keyof typeof rules]
+      : undefined);
   const next = (subject: z.ZodTypeAny) =>
     walkSchema(subject, { ctx, onEach, rules, onMissing });
   const result = handler


### PR DESCRIPTION
- using `ZodTypeAny` makes `_def: any`.
- found it during #2390 
- should rather use `ZodType` where possible
- `ZodRawShape` always refers to `ZodTypeAny` so have to use `as ZodType` statement
- several places using `_def.typeName` from `ZodTypeAny` which works because of `any` 