### PR TITLE
Revert "Fix: `Endpoint::getSecurity()` returns `ReadonlyArray`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Version 22
 
-### v22.9.1
-
-- Return type of public method `Endpoint::getSecurity()` corrected to `ReadonlyArray<LogicalContainer<Security>>`.
-
 ### v22.9.0
 
 - Featuring Deprecations:

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -50,7 +50,8 @@ export abstract class AbstractEndpoint extends Routable {
   public abstract getResponses(
     variant: ResponseVariant,
   ): ReadonlyArray<NormalizedResponse>;
-  public abstract getSecurity(): ReadonlyArray<LogicalContainer<Security>>;
+  // @todo should return ReadonlyArray
+  public abstract getSecurity(): LogicalContainer<Security>[];
   public abstract getScopes(): ReadonlyArray<string>;
   public abstract getTags(): ReadonlyArray<string>;
   public abstract getOperationId(method: Method): string | undefined;
@@ -128,11 +129,9 @@ export class Endpoint<
   }
 
   public override getSecurity() {
-    return Object.freeze(
-      (this.#def.middlewares || [])
-        .map((middleware) => middleware.getSecurity())
-        .filter((entry) => entry !== undefined),
-    );
+    return (this.#def.middlewares || [])
+      .map((middleware) => middleware.getSecurity())
+      .filter((entry) => entry !== undefined);
   }
 
   public override getScopes() {

--- a/express-zod-api/src/logical-container.ts
+++ b/express-zod-api/src/logical-container.ts
@@ -32,7 +32,7 @@ type Combination<T> = T[];
 export type Alternatives<T> = Array<Combination<T>>;
 
 export const processContainers = <T>(
-  containers: ReadonlyArray<LogicalContainer<T>>,
+  containers: LogicalContainer<T>[],
 ): Alternatives<T> => {
   const simples = filter(isSimple, containers);
   const ands = chain(prop("and"), filter(isLogicalAnd, containers));

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -318,27 +318,6 @@ describe("Endpoint", () => {
     );
   });
 
-  describe(".getSecurity()", () => {
-    test("should return a readonly array of security based logical containers", () => {
-      const endpoint = defaultEndpointsFactory
-        .addMiddleware({
-          security: { type: "header", name: "X-Token" },
-          handler: vi.fn(),
-        })
-        .addMiddleware({
-          security: { type: "header", name: "X-API-Key" },
-          handler: vi.fn(),
-        })
-        .build({ output: z.object({}), handler: vi.fn() });
-      const result = endpoint.getSecurity();
-      expect(result).toEqual([
-        { name: "X-Token", type: "header" },
-        { name: "X-API-Key", type: "header" },
-      ]);
-      expect(() => (result as any[]).push()).toThrowError(/read only/);
-    });
-  });
-
   describe("getRequestType()", () => {
     test.each([
       { input: z.object({}), expected: "json" },


### PR DESCRIPTION
Reverts RobinTail/express-zod-api#2396

After checking a little, I realized that it's not really needed, because the returned array has no reference to internal property