### PR TITLE
Enforce `node:` prefix for built-in modules

### DIFF
--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -1,4 +1,4 @@
-import { has } from "ramda";
+import * as R from "ramda";
 import { bench } from "vitest";
 
 describe("Experiment for key lookup", () => {
@@ -13,7 +13,11 @@ describe("Experiment for key lookup", () => {
   });
 
   bench("R.has", () => {
-    return void (has("a", subject) && has("b", subject) && has("c", subject));
+    return void (
+      R.has("a", subject) &&
+      R.has("b", subject) &&
+      R.has("c", subject)
+    );
   });
 
   bench("Object.keys + includes", () => {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { ReferenceObject } from "openapi3-ts/oas31";
-import { prop } from "ramda";
+import * as R from "ramda";
 import { z } from "zod";
 import { ez } from "../src";
 import {
@@ -899,7 +899,7 @@ describe("Documentation helpers", () => {
         depictSecurityRefs(
           [[{ type: "apiKey" }, { type: "oauth2" }, { type: "openIdConnect" }]],
           [],
-          prop("type"),
+          R.prop("type"),
         ),
       ).toMatchSnapshot();
       expect(
@@ -909,7 +909,7 @@ describe("Documentation helpers", () => {
             [{ type: "apiKey" }, { type: "openIdConnect" }],
           ],
           [],
-          prop("type"),
+          R.prop("type"),
         ),
       ).toMatchSnapshot();
       expect(
@@ -920,7 +920,7 @@ describe("Documentation helpers", () => {
             [{ type: "openIdConnect" }],
           ],
           [],
-          prop("type"),
+          R.prop("type"),
         ),
       ).toMatchSnapshot();
     });
@@ -934,7 +934,7 @@ describe("Documentation helpers", () => {
             [{ type: "openIdConnect" }],
           ],
           ["read", "write"],
-          prop("type"),
+          R.prop("type"),
         ),
       ).toMatchSnapshot();
     });

--- a/tools/headers.ts
+++ b/tools/headers.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
-import { tryCatch } from "ramda";
+import * as R from "ramda";
 import { z } from "zod";
 
 /**
@@ -199,7 +199,7 @@ const responseOnlyHeaders = {
 };
 
 const dest = "express-zod-api/src/well-known-headers.json";
-const mtime = tryCatch(
+const mtime = R.tryCatch(
   (cmd) => new Date(execSync(cmd, { encoding: "utf8" })),
   () => undefined,
 )(`git log -1 --pretty="format:%ci" ${dest}`);

--- a/tools/ports.ts
+++ b/tools/ports.ts
@@ -1,4 +1,4 @@
-import { equals, nAry, when } from "ramda";
+import * as R from "ramda";
 
 const disposer = (function* () {
   let port = 8e3 + 1e2 * Number(process.env.VITEST_POOL_ID);
@@ -6,4 +6,6 @@ const disposer = (function* () {
 })();
 
 export const givePort = (test?: "example", rsvd = 8090): number =>
-  test ? rsvd : when(equals(rsvd), nAry(0, givePort))(disposer.next().value);
+  test
+    ? rsvd
+    : R.when(R.equals(rsvd), R.nAry(0, givePort))(disposer.next().value);


### PR DESCRIPTION
Addition to #2419 