### PR TITLE
Exp: on `attw`

### DIFF
--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -17,7 +17,7 @@
   "funding": "https://github.com/sponsors/RobinTail",
   "scripts": {
     "build": "tsup",
-    "postbuild": "yarn pack --filename release.tgz && attw release.tgz && rm release.tgz",
+    "postbuild": "attw --pack",
     "pretest": "tsc --noEmit",
     "test": "vitest run --coverage",
     "bench": "vitest bench --run ./bench",


### PR DESCRIPTION
The weird `postbuild` command was introduced in https://github.com/RobinTail/express-zod-api/pull/2374 in response `attw` failure to work together with `npm publish -w` (within workspace), see https://github.com/RobinTail/express-zod-api/pull/2374/commits/1b556540c32781852be0d5a9018835a1463710c0