### PR TITLE
Exp: Async logging

### DIFF
--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -2,8 +2,8 @@ import { Console } from "node:console";
 import { Writable } from "node:stream";
 import { bench } from "vitest";
 
-describe("Experiment for key lookup", () => {
-  const console = new Console({ stdout: new Writable() });
+describe("Experiment for logging", () => {
+  const console = new Console(new Writable());
 
   bench("sync", () => {
     console.log("test", [1, 2, 3]);

--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -1,6 +1,10 @@
+import { Console } from "node:console";
+import { Writable } from "node:stream";
 import { bench } from "vitest";
 
 describe("Experiment for key lookup", () => {
+  const console = new Console({ stdout: new Writable() });
+
   bench("sync", () => {
     console.log("test", [1, 2, 3]);
   });

--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -1,31 +1,11 @@
-import * as R from "ramda";
 import { bench } from "vitest";
 
 describe("Experiment for key lookup", () => {
-  const subject = {
-    a: 1,
-    b: 2,
-    c: 3,
-  };
-
-  bench("in", () => {
-    return void ("a" in subject && "b" in subject && "c" in subject);
+  bench("sync", () => {
+    console.log("test", [1, 2, 3]);
   });
 
-  bench("R.has", () => {
-    return void (
-      R.has("a", subject) &&
-      R.has("b", subject) &&
-      R.has("c", subject)
-    );
-  });
-
-  bench("Object.keys + includes", () => {
-    const keys = Object.keys(subject);
-    return void (
-      keys.includes("a") &&
-      keys.includes("b") &&
-      keys.includes("c")
-    );
+  bench("async", () => {
+    setImmediate(console.log, "test", [1, 2, 3]);
   });
 });

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -95,7 +95,7 @@ export class BuiltinLogger implements AbstractLogger {
 
   protected postpone(line: string) {
     this.stack.push(line);
-    setImmediate(this.purge.bind(this));
+    setImmediate(this.purge.bind(this)).unref(); // process.exit has higher priority
   }
 
   /** @internal */

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -98,7 +98,8 @@ export class BuiltinLogger implements AbstractLogger {
     setImmediate(this.purge.bind(this));
   }
 
-  protected purge() {
+  /** @internal */
+  public purge() {
     while (this.stack.length) console.log(this.stack.shift());
   }
 

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -100,15 +100,18 @@ export class BuiltinLogger implements AbstractLogger {
     this.postponed = setImmediate(this.purge.bind(this)).unref(); // do not block process.exit()
   }
 
-  /** @internal */
-  public purge() {
+  protected purge() {
     while (this.stack.length) console.log(this.stack.shift());
   }
 
-  /** @internal */
-  public dispose(cb: () => void) {
+  /**
+   * @internal
+   * @desc Prepares the instance for deleting. Callback is for postponed deletion.
+   * */
+  public dispose(cb?: () => void) {
     this.config.level = "silent"; // no more logs
     clearImmediate(this.postponed);
+    if (!cb) return this.purge();
     this.postponed = setImmediate(() => {
       this.purge();
       cb();

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -52,6 +52,7 @@ interface ProfilerOptions {
 export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
   protected readonly stack: string[] = [];
+  protected postponed?: NodeJS.Immediate;
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
   public constructor({
@@ -95,7 +96,8 @@ export class BuiltinLogger implements AbstractLogger {
 
   protected postpone(line: string) {
     this.stack.push(line);
-    setImmediate(this.purge.bind(this)).unref(); // process.exit has higher priority
+    clearImmediate(this.postponed);
+    this.postponed = setImmediate(this.purge.bind(this)).unref(); // do not block process.exit()
   }
 
   /** @internal */

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -90,8 +90,10 @@ export class BuiltinLogger implements AbstractLogger {
     );
     if (meta !== undefined) output.push(this.prettyPrint(meta));
     if (Object.keys(ctx).length > 0) output.push(this.prettyPrint(ctx));
-    const line = output.join(" ");
-    if (!isAsync) return console.log(line);
+    (isAsync ? this.postpone.bind(this) : console.log)(output.join(" "));
+  }
+
+  protected postpone(line: string) {
     this.stack.push(line);
     setImmediate(this.purge.bind(this));
   }

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -110,6 +110,7 @@ export class BuiltinLogger implements AbstractLogger {
    * */
   public dispose(cb?: () => void) {
     this.config.level = "silent"; // no more logs
+    if (!this.config.async) return;
     clearImmediate(this.postponed);
     if (!cb) return this.purge();
     this.postponed = setImmediate(() => {

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -51,6 +51,7 @@ interface ProfilerOptions {
 /** @desc Built-in console logger with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
+  protected readonly stack: string[] = [];
 
   /** @example new BuiltinLogger({ level: "debug", color: true, depth: 4 }) */
   public constructor({
@@ -91,7 +92,12 @@ export class BuiltinLogger implements AbstractLogger {
     if (Object.keys(ctx).length > 0) output.push(this.prettyPrint(ctx));
     const line = output.join(" ");
     if (!isAsync) return console.log(line);
-    setImmediate(console.log, line);
+    this.stack.push(line);
+    setImmediate(this.purge.bind(this));
+  }
+
+  protected purge() {
+    while (this.stack.length) console.log(this.stack.shift());
   }
 
   public debug(message: string, meta?: unknown) {

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -105,6 +105,16 @@ export class BuiltinLogger implements AbstractLogger {
     while (this.stack.length) console.log(this.stack.shift());
   }
 
+  /** @internal */
+  public dispose(cb: () => void) {
+    this.config.level = "silent"; // no more logs
+    clearImmediate(this.postponed);
+    this.postponed = setImmediate(() => {
+      this.purge();
+      cb();
+    });
+  }
+
   public debug(message: string, meta?: unknown) {
     this.print("debug", message, meta);
   }

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -11,8 +11,10 @@ import {
   weAreClosed,
 } from "./graceful-helpers";
 
+export type SomeServers = Array<http.Server | https.Server>;
+
 export const monitor = (
-  servers: Array<http.Server | https.Server>,
+  servers: SomeServers,
   { timeout = 1e3, logger }: { timeout?: number; logger?: ActualLogger } = {},
 ) => {
   let pending: Promise<PromiseSettledResult<void>[]> | undefined;

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -1,6 +1,4 @@
 import type fileUpload from "express-fileupload";
-import http from "node:http";
-import https from "node:https";
 import { BuiltinLogger } from "./builtin-logger";
 import { metaSymbol } from "./metadata";
 import { loadPeer } from "./peer-helpers";
@@ -12,7 +10,7 @@ import createHttpError, { isHttpError } from "http-errors";
 import { lastResortHandler } from "./last-resort";
 import { ResultHandlerError } from "./errors";
 import { ensureError } from "./common-helpers";
-import { monitor } from "./graceful-shutdown";
+import { monitor, SomeServers } from "./graceful-shutdown";
 
 type EquippedRequest = Request<
   unknown,
@@ -161,7 +159,7 @@ export const installDeprecationListener = (logger: ActualLogger) =>
   );
 
 export const installTerminationListener = (
-  servers: Array<http.Server | https.Server>, // @todo extract
+  servers: SomeServers,
   {
     logger,
     childLoggers,

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -178,8 +178,8 @@ export const installTerminationListener = (
   const graceful = grace ? monitor(servers, { logger, timeout }) : undefined;
   const onTerm = async () => {
     await graceful?.shutdown();
-    if (childLoggers) for (const child of childLoggers) child.purge();
-    if (logger instanceof BuiltinLogger) logger.purge();
+    if (childLoggers) for (const child of childLoggers) child.dispose();
+    if (logger instanceof BuiltinLogger) logger.dispose();
     process.exit();
   };
   for (const trigger of events) process.on(trigger, onTerm);

--- a/express-zod-api/src/server.ts
+++ b/express-zod-api/src/server.ts
@@ -102,7 +102,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
   initRouting({ app, routing, getLogger, config, parsers });
   app.use(catcher, notFoundHandler);
 
-  const created: Array<http.Server | https.Server> = [];
+  const created: Parameters<typeof installTerminationListener>[0] = [];
   const makeStarter =
     (server: (typeof created)[number], subject: HttpConfig["listen"]) => () =>
       server.listen(subject, () => logger.info("Listening", subject));

--- a/express-zod-api/src/server.ts
+++ b/express-zod-api/src/server.ts
@@ -104,13 +104,7 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
     starters.push(makeStarter(httpsServer, config.https.listen));
   }
 
-  if (config.gracefulShutdown) {
-    installTerminationListener({
-      logger,
-      servers: created,
-      options: config.gracefulShutdown === true ? {} : config.gracefulShutdown,
-    });
-  }
+  installTerminationListener(created, { logger, config });
 
   return { app, logger, servers: starters.map((starter) => starter()) };
 };

--- a/express-zod-api/tests/builtin-logger.spec.ts
+++ b/express-zod-api/tests/builtin-logger.spec.ts
@@ -41,7 +41,7 @@ describe("BuiltinLogger", () => {
     });
 
     test.each(["development", "production"])(
-      "Level can be omitted and depends on env",
+      "Several settings depend on %s environment",
       (mode) => {
         vi.stubEnv("TSUP_STATIC", mode);
         vi.stubEnv("NODE_ENV", mode);
@@ -49,6 +49,7 @@ describe("BuiltinLogger", () => {
         expect(logger["config"]["level"]).toBe(
           mode === "production" ? "warn" : "debug",
         );
+        expect(logger["config"]["async"]).toBe(mode === "production");
       },
     );
 

--- a/express-zod-api/tests/builtin-logger.spec.ts
+++ b/express-zod-api/tests/builtin-logger.spec.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { performance } from "node:perf_hooks";
 import { BuiltinLogger, BuiltinLoggerConfig } from "../src/builtin-logger";
 
@@ -182,7 +181,7 @@ describe("BuiltinLogger", () => {
 
   // it has to be last, because it affects timer in beforeEach
   describe("async logging", () => {
-    test("on demand", async () => {
+    test("on demand", () => {
       const { logger, logSpy } = makeLogger({
         level: "debug",
         color: false,
@@ -190,11 +189,11 @@ describe("BuiltinLogger", () => {
       });
       logger.debug("testing debug message");
       expect(logSpy).not.toHaveBeenCalled();
-      await vi.waitFor(() => assert(logSpy.mock.calls.length > 0));
+      logger.dispose();
       expect(logSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("maintains the queue", async () => {
+    test("maintains the queue", () => {
       const { logger, logSpy } = makeLogger({
         level: "debug",
         color: false,
@@ -204,11 +203,9 @@ describe("BuiltinLogger", () => {
       logger.debug("two");
       logger.debug("three");
       expect(logSpy).not.toHaveBeenCalled();
-      await vi.waitFor(() => assert(logSpy.mock.calls.length > 2));
+      logger.dispose();
       expect(logSpy.mock.calls).toEqual([
-        [expect.stringContaining("one")],
-        [expect.stringContaining("two")],
-        [expect.stringContaining("three")],
+        [expect.stringMatching(/.+one\n.+two\n.+three/)],
       ]);
     });
   });

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -12,7 +12,12 @@ import {
   installDeprecationListener,
   installTerminationListener,
 } from "../src/server-helpers";
-import { CommonConfig, defaultResultHandler, ResultHandler } from "../src";
+import {
+  CommonConfig,
+  defaultResultHandler,
+  ResultHandler,
+  ServerConfig,
+} from "../src";
 import { Request } from "express";
 import {
   makeLoggerMock,
@@ -303,10 +308,11 @@ describe("Server helpers", () => {
     test("should install termination signal listener on process", () => {
       const spy = vi.spyOn(process, "on").mockImplementation(vi.fn());
       const logger = makeLoggerMock();
-      installTerminationListener({
-        servers: [],
+      installTerminationListener([], {
         logger,
-        options: { events: ["NOT_HAPPEN"] },
+        config: {
+          gracefulShutdown: { events: ["NOT_HAPPEN"] },
+        } as ServerConfig,
       });
       expect(spy).toHaveBeenCalledWith("NOT_HAPPEN", expect.any(Function));
     });


### PR DESCRIPTION
This should be a major performance boost for the `BuiltinLogger`
https://expressjs.com/en/advanced/best-practice-performance.html#do-logging-correctly

```
     name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · sync     248,537.46  0.0034  1.1198  0.0040  0.0037  0.0062  0.0078  0.0301  ±1.66%   124269
   · async  6,109,895.93  0.0001  1.0178  0.0002  0.0001  0.0020  0.0021  0.0026  ±0.83%  3055099   fastest
```

Problems:
- maintaining queue ✅ 
  - `setImmediate()` seems to be doing it good enough, but:
- purging the queue on termination ✅ 
    - using a proprietary stack and use `setImmediate()` only for printing from it
- collaboration with a graceful shutdown ✅ 
  - modified `installTerminationListener()`
- child loggers ✅  
   - introducing a registry and the public `dispose()` method