### PR TITLE
Renaming protected method in `BuiltinLogger`

### DIFF
--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -57,7 +57,7 @@ export class BuiltinLogger implements AbstractLogger {
     this.config = { color, level, depth, ctx };
   }
 
-  protected prettyPrint(subject: unknown) {
+  protected format(subject: unknown) {
     const { depth, color: colors, level } = this.config;
     return inspect(subject, {
       depth,
@@ -80,8 +80,8 @@ export class BuiltinLogger implements AbstractLogger {
       hasColor ? `${styles[method](method)}:` : `${method}:`,
       message,
     );
-    if (meta !== undefined) output.push(this.prettyPrint(meta));
-    if (Object.keys(ctx).length > 0) output.push(this.prettyPrint(ctx));
+    if (meta !== undefined) output.push(this.format(meta));
+    if (Object.keys(ctx).length > 0) output.push(this.format(ctx));
     console.log(output.join(" "));
   }
 


### PR DESCRIPTION
Should be only one `print()`, that is actually printing