### PR TITLE
Using `errorHandler` from config for `testMiddleware()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minimum version of `compression` (optional peer dependency) is `1.8.0` (it supports Brotli);
 - The default value for `wrongMethodBehavior` config option is changed to `405`;
 - Publicly exposed interfaces: `CustomHeaderSecurity` —> `HeaderSecurity`, `NormalizedResponse` removed.
+- The `errorHandler` property removed from `testMiddleware()` argument in favor of config option having same name;
 - Only the following methods remained public, while other methods and properties were marked internal or removed:
   - `Endpoint`: `.execute()` and `.deprecated()`;
   - `Middleware`: `.execute()`;

--- a/README.md
+++ b/README.md
@@ -1111,8 +1111,8 @@ test("should respond successfully", async () => {
 ## Testing middlewares
 
 Middlewares can also be tested individually using the `testMiddleware()` method. You can also pass `options` collected
-from outputs of previous middlewares, if the one being tested somehow depends on them. There is `errorHandler` option
-for catching a middleware error and transforming into a response to assert in test along with other returned entities.
+from outputs of previous middlewares, if the one being tested somehow depends on them. Possible errors would be handled
+either by `errorHandler` configured within given `configProps` or `defaultResultHandler`.
 
 ```typescript
 import { z } from "zod";
@@ -1130,7 +1130,6 @@ const { output, responseMock, loggerMock } = await testMiddleware({
   middleware,
   requestProps: { method: "POST", body: { test: "something" } },
   options: { prev: "accumulated" }, // responseOptions, configProps, loggerProps
-  // errorHandler: (error, response) => response.end(error.message),
 });
 expect(loggerMock._getLogs().error).toHaveLength(0);
 expect(output).toEqual({ collectedOptions: ["prev"], testLength: 9 });

--- a/express-zod-api/src/testing.ts
+++ b/express-zod-api/src/testing.ts
@@ -2,8 +2,6 @@ import { Request, Response } from "express";
 import { ensureError, FlatObject, getInput } from "./common-helpers";
 import { CommonConfig } from "./config-type";
 import { AbstractEndpoint } from "./endpoint";
-import { ResultHandlerError } from "./errors";
-import { lastResortHandler } from "./last-resort";
 import {
   AbstractLogger,
   ActualLogger,
@@ -148,15 +146,11 @@ export const testMiddleware = async <
     const output = await middleware.execute(commons);
     return { requestMock, responseMock, loggerMock, output };
   } catch (e) {
-    const error = ensureError(e);
-    try {
-      await errorHandler.execute({ ...commons, error, output: null });
-    } catch (handlingError) {
-      lastResortHandler({
-        ...commons,
-        error: new ResultHandlerError(error, ensureError(handlingError)),
-      });
-    }
+    await errorHandler.execute({
+      ...commons,
+      error: ensureError(e),
+      output: null,
+    });
     return { requestMock, responseMock, loggerMock, output: {} };
   }
 };

--- a/express-zod-api/tests/__snapshots__/migration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/migration.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`Migration > should consist of one rule being the major version of the p
         "messages": {
           "add": "add {{ subject }} to {{ to }}",
           "change": "change {{ subject }} from {{ from }} to {{ to }}",
+          "move": "move {{ subject }} to {{ to }}",
         },
         "schema": [],
         "type": "problem",

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -1,4 +1,3 @@
-import "../src/zod-plugin"; // required for this test
 import createHttpError from "http-errors";
 import {
   combinations,

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -155,11 +155,14 @@ describe("EndpointsFactory", () => {
           assert.fail("Rejected"),
         );
         const newFactory = factory[method](middleware);
-        await expect(() =>
-          testMiddleware({
-            middleware: newFactory["middlewares"][0],
-          }),
-        ).rejects.toThrowErrorMatchingSnapshot();
+        const { responseMock } = await testMiddleware({
+          middleware: newFactory["middlewares"][0],
+        });
+        expect(responseMock._getStatusCode()).toBe(500);
+        expect(responseMock._getJSONData()).toEqual({
+          error: { message: "Rejected" },
+          status: "error",
+        });
         expect(middleware).toHaveBeenCalledTimes(1);
       });
 
@@ -195,11 +198,14 @@ describe("EndpointsFactory", () => {
           next(new Error("This one has failed"));
         });
         const newFactory = factory[method](middleware);
-        await expect(() =>
-          testMiddleware({
-            middleware: newFactory["middlewares"][0],
-          }),
-        ).rejects.toThrowError("This one has failed");
+        const { responseMock } = await testMiddleware({
+          middleware: newFactory["middlewares"][0],
+        });
+        expect(responseMock._getStatusCode()).toBe(500);
+        expect(responseMock._getJSONData()).toEqual({
+          error: { message: "This one has failed" },
+          status: "error",
+        });
         expect(middleware).toHaveBeenCalledTimes(1);
       });
 
@@ -211,11 +217,14 @@ describe("EndpointsFactory", () => {
         const newFactory = factory[method](middleware, {
           transformer: (err) => createHttpError(401, err.message),
         });
-        await expect(() =>
-          testMiddleware({
-            middleware: newFactory["middlewares"][0],
-          }),
-        ).rejects.toThrowErrorMatchingSnapshot();
+        const { responseMock } = await testMiddleware({
+          middleware: newFactory["middlewares"][0],
+        });
+        expect(responseMock._getStatusCode()).toBe(401);
+        expect(responseMock._getJSONData()).toEqual({
+          error: { message: "This one has failed" },
+          status: "error",
+        });
         expect(middleware).toHaveBeenCalledTimes(1);
       });
     },

--- a/express-zod-api/tests/metadata.spec.ts
+++ b/express-zod-api/tests/metadata.spec.ts
@@ -1,4 +1,3 @@
-import "../src/zod-plugin"; // required for this test
 import { z } from "zod";
 import { copyMeta, metaSymbol } from "../src/metadata";
 

--- a/express-zod-api/tests/migration.spec.ts
+++ b/express-zod-api/tests/migration.spec.ts
@@ -21,6 +21,7 @@ describe("Migration", () => {
     valid: [
       `import { HeaderSecurity } from "express-zod-api";`,
       `createConfig({ wrongMethodBehavior: 405 });`,
+      `testMiddleware({ middleware })`,
     ],
     invalid: [
       {
@@ -47,6 +48,26 @@ describe("Migration", () => {
               subject: "wrongMethodBehavior property",
               to: "configuration",
             },
+          },
+        ],
+      },
+      {
+        code: `testMiddleware({ errorHandler: (error, response) => response.end(error.message) })`,
+        output: `testMiddleware({configProps: {errorHandler: new ResultHandler({ positive: [], negative: [], handler: ({ error, response }) => {response.end(error.message)} }),},  })`,
+        errors: [
+          {
+            messageId: "move",
+            data: { subject: "errorHandler", to: "configProps" },
+          },
+        ],
+      },
+      {
+        code: `testMiddleware({ errorHandler(error, response) { response.end(error.message) }, configProps: { wrongMethodBehavior: 404 } })`,
+        output: `testMiddleware({  configProps: {errorHandler: new ResultHandler({ positive: [], negative: [], handler: ({ error, response }) => {{ response.end(error.message) }} }), wrongMethodBehavior: 404 } })`,
+        errors: [
+          {
+            messageId: "move",
+            data: { subject: "errorHandler", to: "configProps" },
           },
         ],
       },

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -1,4 +1,3 @@
-import { fail } from "node:assert/strict";
 import { z } from "zod";
 import {
   CommonConfig,
@@ -83,11 +82,6 @@ describe("Testing", () => {
         positive: [],
         negative: [],
         handler: ({ error, response }) => void response.end(error!.message),
-      }),
-      new ResultHandler({
-        positive: [],
-        negative: [],
-        handler: () => fail("Malfunction"),
       }),
     ])(
       "Issue #2153: should catch errors using errorHandler %#",

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -1,7 +1,10 @@
+import { fail } from "node:assert/strict";
 import { z } from "zod";
 import {
+  CommonConfig,
   defaultEndpointsFactory,
   Middleware,
+  ResultHandler,
   testEndpoint,
   testMiddleware,
 } from "../src";
@@ -74,20 +77,43 @@ describe("Testing", () => {
       });
     });
 
-    test("Issue #2153: should optionally catch errors to enable usual returns", async () => {
-      const { output, loggerMock, responseMock } = await testMiddleware({
-        errorHandler: (error, response) => response.end(error.message),
-        middleware: new Middleware({
-          input: z.object({}),
-          handler: async ({ logger }) => {
-            logger.info("logging something");
-            throw new Error("something went wrong");
-          },
-        }),
-      });
-      expect(output).toEqual({});
-      expect(loggerMock._getLogs().info).toEqual([["logging something"]]);
-      expect(responseMock._getData()).toBe("something went wrong");
-    });
+    test.each<CommonConfig["errorHandler"]>([
+      undefined,
+      new ResultHandler({
+        positive: [],
+        negative: [],
+        handler: ({ error, response }) => void response.end(error!.message),
+      }),
+      new ResultHandler({
+        positive: [],
+        negative: [],
+        handler: () => fail("Malfunction"),
+      }),
+    ])(
+      "Issue #2153: should catch errors using errorHandler %#",
+      async (errorHandler) => {
+        const { output, loggerMock, responseMock } = await testMiddleware({
+          configProps: { errorHandler },
+          middleware: new Middleware({
+            input: z.object({}),
+            handler: async ({ logger }) => {
+              logger.info("logging something");
+              throw new Error("something went wrong");
+            },
+          }),
+        });
+        expect(output).toEqual({});
+        expect(loggerMock._getLogs().info).toEqual([["logging something"]]);
+        expect(responseMock._isJSON()).toBe(!errorHandler);
+        if (responseMock._isJSON()) {
+          expect(responseMock._getJSONData()).toEqual({
+            status: "error",
+            error: { message: "something went wrong" },
+          });
+        } else {
+          expect(responseMock._getData()).toMatch(/something went wrong/);
+        }
+      },
+    );
   });
 });

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -1,4 +1,3 @@
-import "../src/zod-plugin"; // required for this test
 import camelize from "camelize-ts";
 import { z } from "zod";
 import { metaSymbol } from "../src/metadata";

--- a/express-zod-api/vitest.setup.ts
+++ b/express-zod-api/vitest.setup.ts
@@ -1,3 +1,4 @@
+import "./src/zod-plugin"; // required for tests importing sources using the plugin methods
 import type { NewPlugin } from "@vitest/pretty-format";
 import { z } from "zod";
 import { ResultHandlerError } from "./src/errors";


### PR DESCRIPTION
To reduce the confusion, using `errorHandler` which is already present in config.
This is breaking.
Also, `testMiddleware` will not throw now.