### PR TITLE
Replacing deprecated type assertions

### DIFF
--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -475,7 +475,7 @@ describe("Example", async () => {
         id: "10",
       });
       expect(response).toMatchSnapshot();
-      expectTypeOf(response).toMatchTypeOf<
+      expectTypeOf(response).toExtend<
         | { status: "success"; data: { id: number; name: string } }
         | { status: "error"; error: { message: string } }
       >();
@@ -491,10 +491,14 @@ describe("Example", async () => {
       });
       expect(typeof response).toBe("object");
       expect(response).toMatchSnapshot();
-      expectTypeOf(response).toMatchTypeOf<
-        | { status: "success"; data: { name: string; createdAt: string } }
-        | { status: "error"; error: { message: string } }
-      >();
+      expectTypeOf<{
+        status: "success";
+        data: { name: string; createdAt: string };
+      }>().toExtend<typeof response>();
+      expectTypeOf<{
+        status: "error";
+        error: { message: string };
+      }>().toExtend<typeof response>();
     });
 
     test("Issue #2182: should deny unlisted combination of path and method", async () => {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -817,14 +817,8 @@ describe("Documentation", () => {
       const unionSchema = z.union([subType1, subType2]);
       type TestingType = z.infer<typeof unionSchema>;
 
-      expectTypeOf({
-        id: "string",
-        field1: "string",
-      }).toMatchTypeOf<TestingType>();
-      expectTypeOf({
-        id: "string",
-        field2: "string",
-      }).toMatchTypeOf<TestingType>();
+      expectTypeOf<{ id: string; field1: string }>().toExtend<TestingType>();
+      expectTypeOf<{ id: string; field2: string }>().toExtend<TestingType>();
 
       const spec = new Documentation({
         config: sampleConfig,

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -74,7 +74,7 @@ describe("EndpointsFactory", () => {
       const factory = defaultEndpointsFactory.addMiddleware({
         handler: async () => ({ test: "fist option" }),
       });
-      expectTypeOf(factory).toMatchTypeOf<
+      expectTypeOf(factory).toEqualTypeOf<
         EndpointsFactory<
           z.ZodIntersection<EmptySchema, EmptySchema>,
           EmptyObject & { test: string }
@@ -244,7 +244,7 @@ describe("EndpointsFactory", () => {
       expect(endpoint.getMethods()).toBeUndefined();
       expect(endpoint.getSchema("input")).toMatchSnapshot();
       expect(endpoint.getSchema("output")).toMatchSnapshot();
-      expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
+      expectTypeOf(endpoint.getSchema("input")._output).toExtend<{
         n: number;
         s: string;
       }>();
@@ -272,7 +272,7 @@ describe("EndpointsFactory", () => {
       });
       expect(endpoint.getSchema("input")).toMatchSnapshot();
       expect(endpoint.getSchema("output")).toMatchSnapshot();
-      expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
+      expectTypeOf(endpoint.getSchema("input")._output).toExtend<{
         a?: number;
         b?: string;
         i: string;
@@ -297,7 +297,7 @@ describe("EndpointsFactory", () => {
       expect(endpoint.getMethods()).toBeUndefined();
       expect(endpoint.getSchema("input")).toMatchSnapshot();
       expect(endpoint.getSchema("output")).toMatchSnapshot();
-      expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<{
+      expectTypeOf(endpoint.getSchema("input")._output).toExtend<{
         n1: number;
         n2: number;
         s: string;
@@ -325,7 +325,7 @@ describe("EndpointsFactory", () => {
       expect(endpoint.getMethods()).toBeUndefined();
       expect(endpoint.getSchema("input")).toMatchSnapshot();
       expect(endpoint.getSchema("output")).toMatchSnapshot();
-      expectTypeOf(endpoint.getSchema("input")._output).toMatchTypeOf<
+      expectTypeOf(endpoint.getSchema("input")._output).toExtend<
         { s: string } & ({ n1: number } | { n2: number })
       >();
     });
@@ -352,7 +352,7 @@ describe("EndpointsFactory", () => {
         handler: async () => {},
       });
       expect(endpoint.getSchema("output")).toMatchSnapshot();
-      expectTypeOf(endpoint.getSchema("output")).toMatchTypeOf<EmptySchema>();
+      expectTypeOf(endpoint.getSchema("output")).toExtend<EmptySchema>();
     });
   });
 });

--- a/express-zod-api/tests/file-schema.spec.ts
+++ b/express-zod-api/tests/file-schema.spec.ts
@@ -15,25 +15,25 @@ describe("ez.file()", () => {
     test("should create a string file", () => {
       const schema = ez.file("string");
       expect(schema).toBeInstanceOf(z.ZodBranded);
-      expectTypeOf(schema._output).toMatchTypeOf<string>();
+      expectTypeOf(schema._output).toBeString();
     });
 
     test("should create a buffer file", () => {
       const schema = ez.file("buffer");
       expect(schema).toBeInstanceOf(z.ZodBranded);
-      expectTypeOf(schema._output).toMatchTypeOf<Buffer>();
+      expectTypeOf(schema._output).toExtend<Buffer>();
     });
 
     test("should create a binary file", () => {
       const schema = ez.file("binary");
       expect(schema).toBeInstanceOf(z.ZodBranded);
-      expectTypeOf(schema._output).toMatchTypeOf<Buffer | string>();
+      expectTypeOf(schema._output).toExtend<Buffer | string>();
     });
 
     test("should create a base64 file", () => {
       const schema = ez.file("base64");
       expect(schema).toBeInstanceOf(z.ZodBranded);
-      expectTypeOf(schema._output).toMatchTypeOf<string>();
+      expectTypeOf(schema._output).toBeString();
     });
   });
 

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -39,72 +39,77 @@ describe("Index Entrypoint", () => {
     test("Convenience types should be exposed", () => {
       expectTypeOf(() => ({
         type: "number" as const,
-      })).toMatchTypeOf<Depicter>();
+      })).toExtend<Depicter>();
       expectTypeOf(() =>
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-      ).toMatchTypeOf<Producer>();
+      ).toExtend<Producer>();
     });
 
     test("Issue 952, 1182, 1269: should expose certain types and interfaces", () => {
-      expectTypeOf<"get">().toMatchTypeOf<Method>();
-      expectTypeOf(z.object({})).toMatchTypeOf<IOSchema>();
-      expectTypeOf({}).toMatchTypeOf<FlatObject>();
+      expectTypeOf<"get">().toExtend<Method>();
+      expectTypeOf(z.object({})).toExtend<IOSchema>();
+      expectTypeOf({}).toExtend<FlatObject>();
       expectTypeOf({}).toEqualTypeOf<LoggerOverrides>();
-      expectTypeOf({}).toMatchTypeOf<Routing>();
+      expectTypeOf({}).toExtend<Routing>();
       expectTypeOf<{
         cors: true;
         logger: { level: "silent" };
-      }>().toMatchTypeOf<CommonConfig>();
+      }>().toExtend<CommonConfig>();
       expectTypeOf<{
         app: IRouter;
         cors: true;
         logger: { level: "silent" };
-      }>().toMatchTypeOf<AppConfig>();
+      }>().toExtend<AppConfig>();
       expectTypeOf<{
         http: { listen: 8090 };
         logger: { level: "silent" };
         cors: false;
-      }>().toMatchTypeOf<ServerConfig>();
-      expectTypeOf<{ type: "basic" }>().toMatchTypeOf<BasicSecurity>();
-      expectTypeOf<{ type: "bearer" }>().toMatchTypeOf<BearerSecurity>();
+      }>().toExtend<ServerConfig>();
+      expectTypeOf<{ type: "basic" }>().toEqualTypeOf<BasicSecurity>();
+      expectTypeOf<{
+        type: "bearer";
+        format?: string;
+      }>().toEqualTypeOf<BearerSecurity>();
       expectTypeOf<{
         type: "cookie";
-        name: "some";
-      }>().toMatchTypeOf<CookieSecurity>();
+        name: string;
+      }>().toEqualTypeOf<CookieSecurity>();
       expectTypeOf<{
         type: "header";
-        name: "some";
-      }>().toMatchTypeOf<CustomHeaderSecurity>();
-      expectTypeOf<{ type: "input"; name: "some" }>().toMatchTypeOf<
+        name: string;
+      }>().toEqualTypeOf<CustomHeaderSecurity>();
+      expectTypeOf<{ type: "input"; name: string }>().toEqualTypeOf<
         InputSecurity<string>
       >();
-      expectTypeOf<{ type: "oauth2" }>().toMatchTypeOf<
-        OAuth2Security<string>
-      >();
+      expectTypeOf<{ type: "oauth2" }>().toExtend<OAuth2Security<string>>();
       expectTypeOf<{
         type: "openid";
-        url: "https://";
-      }>().toMatchTypeOf<OpenIdSecurity>();
-      expectTypeOf({ schema: z.string() }).toMatchTypeOf<
+        url: string;
+      }>().toEqualTypeOf<OpenIdSecurity>();
+      expectTypeOf({ schema: z.string() }).toExtend<
         ApiResponse<z.ZodTypeAny>
       >();
     });
 
     test("Extended Zod prototypes", () => {
-      expectTypeOf({
-        example: () => z.any(),
-      }).toMatchTypeOf<Partial<z.ZodAny>>();
-      expectTypeOf({
-        example: () => z.string().default(""),
-        label: () => z.string().default(""),
-      }).toMatchTypeOf<Partial<z.ZodDefault<z.ZodString>>>();
+      expectTypeOf<z.ZodAny>()
+        .toHaveProperty("example")
+        .toEqualTypeOf<(value: any) => z.ZodAny>();
+      expectTypeOf<z.ZodDefault<z.ZodString>>()
+        .toHaveProperty("example")
+        .toEqualTypeOf<
+          (value: string | undefined) => z.ZodDefault<z.ZodString>
+        >();
+      expectTypeOf<z.ZodDefault<z.ZodString>>()
+        .toHaveProperty("label")
+        .toEqualTypeOf<(value: string) => z.ZodDefault<z.ZodString>>();
       expectTypeOf({
         remap: () =>
           z.pipeline(
             z.object({}).transform(() => ({})),
             z.object({}),
           ),
-      }).toMatchTypeOf<Partial<z.ZodObject<z.ZodRawShape, "strip">>>();
+      }).toExtend<Partial<z.ZodObject<z.ZodRawShape>>>();
     });
   });
 });

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -10,51 +10,49 @@ import { AbstractMiddleware } from "../src/middleware";
 describe("I/O Schema and related helpers", () => {
   describe("IOSchema", () => {
     test("accepts object", () => {
-      expectTypeOf(z.object({})).toMatchTypeOf<IOSchema>();
-      expectTypeOf(z.object({})).toMatchTypeOf<IOSchema<"strip">>();
-      expectTypeOf(z.object({}).strict()).toMatchTypeOf<IOSchema<"strict">>();
-      expectTypeOf(z.object({}).passthrough()).toMatchTypeOf<
+      expectTypeOf(z.object({})).toExtend<IOSchema>();
+      expectTypeOf(z.object({})).toExtend<IOSchema<"strip">>();
+      expectTypeOf(z.object({}).strict()).toExtend<IOSchema<"strict">>();
+      expectTypeOf(z.object({}).passthrough()).toExtend<
         IOSchema<"passthrough">
       >();
-      expectTypeOf(z.object({}).strip()).toMatchTypeOf<IOSchema<"strip">>();
+      expectTypeOf(z.object({}).strip()).toExtend<IOSchema<"strip">>();
     });
     test("accepts ez.raw()", () => {
-      expectTypeOf(ez.raw()).toMatchTypeOf<IOSchema>();
-      expectTypeOf(ez.raw({ something: z.any() })).toMatchTypeOf<IOSchema>();
+      expectTypeOf(ez.raw()).toExtend<IOSchema>();
+      expectTypeOf(ez.raw({ something: z.any() })).toExtend<IOSchema>();
     });
     test("accepts ez.form()", () => {
       expectTypeOf(ez.form({})).toExtend<IOSchema>();
     });
     test("respects the UnknownKeys type argument", () => {
-      expectTypeOf(z.object({})).not.toMatchTypeOf<IOSchema<"passthrough">>();
+      expectTypeOf(z.object({})).not.toExtend<IOSchema<"passthrough">>();
     });
     test("accepts union of objects", () => {
-      expectTypeOf(
-        z.union([z.object({}), z.object({})]),
-      ).toMatchTypeOf<IOSchema>();
-      expectTypeOf(z.object({}).or(z.object({}))).toMatchTypeOf<IOSchema>();
+      expectTypeOf(z.union([z.object({}), z.object({})])).toExtend<IOSchema>();
+      expectTypeOf(z.object({}).or(z.object({}))).toExtend<IOSchema>();
       expectTypeOf(
         z.object({}).or(z.object({}).or(z.object({}))),
-      ).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
     });
     test("does not accept union of object and array of objects", () => {
       expectTypeOf(
         z.object({}).or(z.array(z.object({}))),
-      ).not.toMatchTypeOf<IOSchema>();
+      ).not.toExtend<IOSchema>();
     });
     test("accepts intersection of objects", () => {
       expectTypeOf(
         z.intersection(z.object({}), z.object({})),
-      ).toMatchTypeOf<IOSchema>();
-      expectTypeOf(z.object({}).and(z.object({}))).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
+      expectTypeOf(z.object({}).and(z.object({}))).toExtend<IOSchema>();
       expectTypeOf(
         z.object({}).and(z.object({}).and(z.object({}))),
-      ).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
     });
     test("does not accepts intersection of object with array of objects", () => {
       expectTypeOf(
         z.object({}).and(z.array(z.object({}))),
-      ).not.toMatchTypeOf<IOSchema>();
+      ).not.toExtend<IOSchema>();
     });
     test("accepts discriminated union of objects", () => {
       expectTypeOf(
@@ -62,28 +60,26 @@ describe("I/O Schema and related helpers", () => {
           z.object({ type: z.literal("one") }),
           z.object({ type: z.literal("two") }),
         ]),
-      ).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
     });
     test("accepts a mix of types based on object", () => {
       expectTypeOf(
         z.object({}).or(z.object({}).and(z.object({}))),
-      ).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
       expectTypeOf(
         z.object({}).and(z.object({}).or(z.object({}))),
-      ).toMatchTypeOf<IOSchema>();
+      ).toExtend<IOSchema>();
     });
     describe("Feature #600: Top level refinements", () => {
       test("accepts a refinement of object", () => {
-        expectTypeOf(z.object({}).refine(() => true)).toMatchTypeOf<IOSchema>();
-        expectTypeOf(
-          z.object({}).superRefine(() => true),
-        ).toMatchTypeOf<IOSchema>();
+        expectTypeOf(z.object({}).refine(() => true)).toExtend<IOSchema>();
+        expectTypeOf(z.object({}).superRefine(() => true)).toExtend<IOSchema>();
         expectTypeOf(
           z.object({}).refinement(() => true, {
             code: "custom",
             message: "test",
           }),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
       });
       test("Issue 662: accepts nested refinements", () => {
         expectTypeOf(
@@ -92,21 +88,21 @@ describe("I/O Schema and related helpers", () => {
             .refine(() => true)
             .refine(() => true)
             .refine(() => true),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
         expectTypeOf(
           z
             .object({})
             .superRefine(() => true)
             .superRefine(() => true)
             .superRefine(() => true),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
       });
     });
     describe("Feature #1869: Top level transformations", () => {
       test("accepts transformations to another object", () => {
         expectTypeOf(
           z.object({ s: z.string() }).transform(() => ({ n: 123 })),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
       });
       test("accepts nested transformations", () => {
         expectTypeOf(
@@ -115,7 +111,7 @@ describe("I/O Schema and related helpers", () => {
             .transform(() => ({ a: 123 }))
             .transform(() => ({ b: 456 }))
             .transform(() => ({ c: 789 })),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
       });
       test("accepts piping into another object schema", () => {
         expectTypeOf(
@@ -123,23 +119,21 @@ describe("I/O Schema and related helpers", () => {
             .object({ s: z.string() })
             .transform(() => ({ n: 123 }))
             .pipe(z.object({ n: z.number() })),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
         expectTypeOf(
           z.object({ user_id: z.string() }).remap({ user_id: "userId" }),
-        ).toMatchTypeOf<IOSchema>();
+        ).toExtend<IOSchema>();
       });
       test("does not accept transformation to another type", () => {
         expectTypeOf(
           z.object({}).transform(() => true),
-        ).not.toMatchTypeOf<IOSchema>();
-        expectTypeOf(
-          z.object({}).transform(() => []),
-        ).not.toMatchTypeOf<IOSchema>();
+        ).not.toExtend<IOSchema>();
+        expectTypeOf(z.object({}).transform(() => [])).not.toExtend<IOSchema>();
       });
       test("does not accept piping into another kind of schema", () => {
         expectTypeOf(
           z.object({ s: z.string() }).pipe(z.array(z.string())),
-        ).not.toMatchTypeOf<IOSchema>();
+        ).not.toExtend<IOSchema>();
       });
       test("does not accept nested piping", () => {
         expectTypeOf(
@@ -147,7 +141,7 @@ describe("I/O Schema and related helpers", () => {
             .object({ a: z.string() })
             .remap({ a: "b" })
             .pipe(z.object({ b: z.string() })),
-        ).not.toMatchTypeOf<IOSchema>();
+        ).not.toExtend<IOSchema>();
       });
     });
   });

--- a/express-zod-api/tests/result-handler.spec.ts
+++ b/express-zod-api/tests/result-handler.spec.ts
@@ -29,7 +29,7 @@ describe("ResultHandler", () => {
           { statusCode: 500, schema: z.literal("failure") },
         ],
         handler: ({ response }) => {
-          expectTypeOf(response).toMatchTypeOf<
+          expectTypeOf(response).toEqualTypeOf<
             Response<"ok" | "kinda" | "error" | "failure">
           >();
           response.status(200).send("error");

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -154,7 +154,7 @@ describe("SSE", () => {
       const endpoint = new EventStreamFactory({ test: z.string() }).buildVoid({
         input: z.object({ some: z.string().optional() }),
         handler: async ({ input, options }) => {
-          expectTypeOf(input).toMatchTypeOf<{ some?: string }>();
+          expectTypeOf(input).toExtend<{ some?: string }>();
           expectTypeOf(options.emit)
             .parameter(0)
             .toEqualTypeOf("test" as const);


### PR DESCRIPTION
`.toMatchTypeOf()` was deprecated