### PR TITLE
Removing `try..catch` in `createLoggingMiddleware`

### DIFF
--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -131,16 +131,11 @@ export const createLoggingMiddleware =
     config: CommonConfig;
   }): RequestHandler =>
   async (request, response, next) => {
-    try {
-      const logger =
-        (await childLoggerProvider?.({ request, parent })) || parent;
-      accessLogger?.(request, logger);
-      if (request.res)
-        (request as EquippedRequest).res!.locals[metaSymbol] = { logger };
-      next();
-    } catch (error) {
-      next(error); // @todo remove in v23 that is express 5 only
-    }
+    const logger = (await childLoggerProvider?.({ request, parent })) || parent;
+    accessLogger?.(request, logger);
+    if (request.res)
+      (request as EquippedRequest).res!.locals[metaSymbol] = { logger };
+    next();
   };
 
 export const makeGetLogger =

--- a/express-zod-api/tests/__snapshots__/server-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/server-helpers.spec.ts.snap
@@ -1,21 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Server helpers > createLoggingMiddleware > should handle errors in accessLogger 1`] = `
-[
-  [
-    AssertionError({
-      "message": "Something went wrong",
-    }),
-  ],
-]
+exports[`Server helpers > createLoggingMiddleware > should delegate errors in accessLogger 1`] = `
+AssertionError({
+  "message": "Something went wrong",
+})
 `;
 
-exports[`Server helpers > createLoggingMiddleware > should handle errors in childLoggerProvider 1`] = `
-[
-  [
-    AssertionError({
-      "message": "Something went wrong",
-    }),
-  ],
-]
+exports[`Server helpers > createLoggingMiddleware > should delegate errors in childLoggerProvider 1`] = `
+AssertionError({
+  "message": "Something went wrong",
+})
 `;

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -287,7 +287,7 @@ describe("Server helpers", () => {
     );
 
     test.each(["childLoggerProvider", "accessLogger"] as const)(
-      "should handle errors in %s",
+      "should delegate errors in %s",
       async (prop) => {
         const config = {
           [prop]: () => fail("Something went wrong"),
@@ -297,8 +297,10 @@ describe("Server helpers", () => {
         const request = makeRequestMock({ path: "/test" });
         const response = makeResponseMock();
         const nextMock = vi.fn();
-        await handler(request, response, nextMock);
-        expect(nextMock.mock.calls).toMatchSnapshot();
+        await expect(() =>
+          handler(request, response, nextMock),
+        ).rejects.toThrowErrorMatchingSnapshot();
+        expect(nextMock).not.toHaveBeenCalled();
       },
     );
   });


### PR DESCRIPTION
Due to #2475 
Part of #2521 