### PR TITLE
Aligning catcher with documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Version 22
 
+### v22.13.2
+
+- Fixed inconsistency between the actual catcher behavior and the error handling documentation:
+  - Removed conversion of non-`HttpError`s to `BadRequest` before passing them to `errorHandler`;
+  - A `ResultHandler` configured as `errorHandler` is responsible to handling all errors and responding accordingly.
+  - The default `errorHandler` is `defaultResultHandler`:
+    - Using `ensureHttpError()` it coverts non-`HttpError`s to `InternalServerError` and responds with status code `500`;
+  - The issue has occurred since [v19.0.0](#v1900).
+
 ### v22.13.1
 
 - Fixed: the output type of the `ez.raw()` schema (without an argument) was missing the `raw` property (since v19.0.0).

--- a/README.md
+++ b/README.md
@@ -903,21 +903,21 @@ All runtime errors are handled by a `ResultHandler`. The default is `defaultResu
 it normalizes errors into consistent HTTP responses with sensible status codes. Errors can originate from three layers:
 
 - `Endpoint` execution (including attached `Middleware`):
-  - Handled by `ResultHandler` assigned to `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
-  - `InputValidationError`: violating `input` schema, the default status code is `400`;
-  - `OutputValidationError`: violating `output` schema, the default status code is `500`;
-  - `HttpError`: can be thrown in handlers using `createHttpError()`, its `statusCode` used by default;
+  - Handled by a `ResultHandler` used by `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
+  - `InputValidationError`: request violates `input` schema, the default status code is `400`;
+  - `OutputValidationError`: handler violates `output` schema, the default status code is `500`;
+  - `HttpError`: can be thrown in handlers with helps of `createHttpError()`, its `.statusCode` is used for response;
   - For other errors the default status code is `500`;
 - Routing, parsing and upload issues:
-  - Handled by `ResultHandler` assigned to `errorHandler` config option (`defaultResultHandler` is default);
-  - Parsing errors: handled as they are (usually it's `HttpError` having `4XX` status code used by default);
-  - Routing errors: `404` and `405` (depending on `wrongMethodBehavior` config option);
-  - Upload issues: when `upload.limitError` config option is set (takes its `statusCode` if it's also `HttpError`);
+  - Handled by `ResultHandler` configured as `errorHandler` (the defaults is `defaultResultHandler`);
+  - Parsing errors: passed through as-is (typically `HttpError` with `4XX` code used for response by default);
+  - Routing errors: `404` or `405`, based on `wrongMethodBehavior` configuration;
+  - Upload issues: thrown only if `upload.limitError` is configured (`HttpError::statusCode` can be used for response);
   - For other errors the default status code is `500`;
 - `ResultHandler` failures:
   - Handled by `LastResortHandler` with status code `500` and a plain text response.
 
-You can override these behaviors by using a custom `ResultHandler` with `EndpointsFactory` and as the `errorHandler`.
+You can customize it by passing a custom `ResultHandler` to `EndpointsFactory` and by configuring `errorHandler`.
 
 ## Production mode
 

--- a/README.md
+++ b/README.md
@@ -917,6 +917,8 @@ it normalizes errors into consistent HTTP responses with sensible status codes. 
 - `ResultHandler` failures:
   - Handled by `LastResortHandler` with status code `500` and a plain text response.
 
+You can override these behaviors by using a custom `ResultHandler` with `EndpointsFactory` and as the `errorHandler`.
+
 ## Production mode
 
 Consider enabling production mode by setting `NODE_ENV` environment variable to `production` for your deployment:

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ const resultHandlerWithCleanup = new ResultHandler({
 There are two ways of connecting the native express middlewares depending on their nature and your objective.
 
 In case it's a middleware establishing and serving its own routes, or somehow globally modifying the behaviour, or
-being an additional request parser (like `cookie-parser`), use the `beforeRouting` hook. However, it might be better
+being an additional request parser (like `cookie-parser`), use the `beforeRouting` option. However, it might be better
 to avoid `cors` here — [the framework handles it on its own](#cross-origin-resource-sharing).
 
 ```typescript
@@ -644,7 +644,7 @@ declare module "express-zod-api" {
 ## Child logger
 
 In case you need a dedicated logger for each request (for example, equipped with a request ID), you can specify the
-`childLoggerProvider` hook in your configuration. The function accepts the initially defined logger and the request,
+`childLoggerProvider` option in your configuration. The function accepts the initially defined logger and the request,
 it can also be asynchronous. The child logger returned by that function will replace the `logger` in all handlers.
 You can use the `.child()` method of the built-in logger or [install a custom logger](#customizing-logger) instead.
 
@@ -906,9 +906,9 @@ it normalizes errors into consistent HTTP responses with sensible status codes. 
   - Handled by a `ResultHandler` used by `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
   - `InputValidationError`: request violates `input` schema, the default status code is `400`;
   - `OutputValidationError`: handler violates `output` schema, the default status code is `500`;
-  - `HttpError` thrown in handlers (with help of `createHttpError()`): its `.statusCode` is used for response;
+  - `HttpError`: can be thrown in handlers with help of `createHttpError()`, its `.statusCode` is used for response;
   - For other errors the default status code is `500`;
-- Routing, parsing, hooks, and upload issues:
+- Routing, parsing and upload issues:
   - Handled by `ResultHandler` configured as `errorHandler` (the defaults is `defaultResultHandler`);
   - Parsing errors: passed through as-is (typically `HttpError` with `4XX` code used for response by default);
   - Routing errors: `404` or `405`, based on `wrongMethodBehavior` configuration;
@@ -996,7 +996,7 @@ _Hint: for unlisted extra fields use the following syntax: `ez.form( z.object({}
 Install the following additional packages: `express-fileupload` and `@types/express-fileupload`, and enable or
 configure file uploads. Refer to [documentation](https://www.npmjs.com/package/express-fileupload#available-options) on
 available options. The `limitHandler` option is replaced by the `limitError` one. You can also connect an additional
-middleware for restricting the ability to upload using the `beforeUpload` hook. So the configuration for the limited
+middleware for restricting the ability to upload using the `beforeUpload` option. So the configuration for the limited
 and restricted upload might look this way:
 
 ```typescript
@@ -1080,7 +1080,7 @@ errors yourself. In this regard `attachRouting()` provides you with `notFoundHan
 to your custom express app.
 
 Besides that, if you're looking to include additional request parsers, or a middleware that establishes its own routes,
-then consider using the `beforeRouting` [hook in config instead](#using-native-express-middlewares).
+then consider using the `beforeRouting` [option in config instead](#using-native-express-middlewares).
 
 ## Testing endpoints
 

--- a/README.md
+++ b/README.md
@@ -902,23 +902,20 @@ const resultHandler = new ResultHandler({
 All runtime errors are handled by a `ResultHandler`. The default is `defaultResultHandler`. Using `ensureHttpError()`
 it normalizes errors into consistent HTTP responses with sensible status codes. Errors can originate from three layers:
 
-- Ones related to `Endpoint` execution — handled by a `ResultHandler` assigned to the `EndpointsFactory` produced it:
-  - The following proprietary classes are available to you for customizing error handling in your `ResultHandler`:
-    - `InputValidationError` — when request payload does not match the `input` schema of the endpoint or middleware.
-      The default response status code is `400`, `cause` property contains the original `ZodError`;
-    - `OutputValidationError` — when returns of the endpoint's `handler` does not match its `output` schema (`500`);
-  - Errors thrown within endpoint's `handler`:
-    - `HttpError`, made by `createHttpError()` method of `http-errors` (required peer dependency). The default response
-      status code is taken from `error.statusCode`;
-    - For other errors the default status code is `500`;
-- Ones related to routing, parsing and upload issues — handled by `ResultHandler` assigned to `errorHandler` in config:
-  - Default is `defaultResultHandler`:
-    - Parsing errors as they are (usually `HttpError` having `4XX` codes);
-    - Routing errors: `404` or `405` depending on `wrongMethodBehavior` config option;
-    - Upload issues: only when `upload.limitError` config option is set (takes its `statusCode` if it's `HttpError`);
-    - For other errors `500` for others;
-- In case your custom `ResultHandler` throws an error it's handled by `LastResortHandler`:
-  - Response status code is always `500` and the response itself is a plain text.
+- `Endpoint` execution (including attached `Middleware`):
+  - Handled by `ResultHandler` assigned to `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
+  - `InputValidationError`: violating `input` schema, the default status code is `400`;
+  - `OutputValidationError`: violating `output` schema, the default status code is `500`;
+  - `HttpError`: can be thrown in handlers using `createHttpError()`, its `statusCode` used by default;
+  - For other errors the default status code is `500`;
+- Routing, parsing and upload issues:
+  - Handled by `ResultHandler` assigned to `errorHandler` config option (`defaultResultHandler` is default);
+  - Parsing errors: handled as they are (usually it's `HttpError` having `4XX` status code used by default);
+  - Routing errors: `404` and `405` (depending on `wrongMethodBehavior` config option);
+  - Upload issues: when `upload.limitError` config option is set (takes its `statusCode` if it's also `HttpError`);
+  - For other errors the default status code is `500`;
+- `ResultHandler` failures:
+  - Handled by `LastResortHandler` with status code `500` and a plain text response.
 
 ## Production mode
 

--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ origins of errors that could happen in runtime and be handled the following way:
   - Errors thrown within endpoint's `handler`:
     - `HttpError`, made by `createHttpError()` method of `http-errors` (required peer dependency). The default response
       status code is taken from `error.statusCode`;
-    - Others, inheriting from `Error` class (`500`);
+    - For other errors the default status code is `500`;
 - Ones related to routing, parsing and upload issues — handled by `ResultHandler` assigned to `errorHandler` in config:
   - Default is `defaultResultHandler` — it sets the response status code from the corresponding `HttpError`:
     `400` for parsing, `404` for routing, `config.upload.limitError.statusCode` for upload issues, or `500` for others;

--- a/README.md
+++ b/README.md
@@ -913,11 +913,12 @@ origins of errors that could happen in runtime and be handled the following way:
       status code is taken from `error.statusCode`;
     - For other errors the default status code is `500`;
 - Ones related to routing, parsing and upload issues — handled by `ResultHandler` assigned to `errorHandler` in config:
-  - Default is `defaultResultHandler` — it sets the response status code from the corresponding `HttpError`:
-    `400` for parsing, `404` for routing, `config.upload.limitError.statusCode` for upload issues, or `500` for others;
-  - You can also set `wrongMethodBehavior` config option to `405` (Method not allowed) for requests having wrong method;
-  - `ResultHandler` must handle possible `error` and avoid throwing its own errors, otherwise:
-- Ones related to `ResultHandler` execution — handled by `LastResortHandler`:
+  - Default is `defaultResultHandler`:
+    - Parsing errors as they are (usually `HttpError` having `4XX` codes);
+    - Routing errors: `404` or `405` depending on `wrongMethodBehavior` config option;
+    - Upload issues: only when `upload.limitError` config option is set (takes its `statusCode` if it's `HttpError`);
+    - For other errors `500` for others;
+- In case your custom `ResultHandler` throws an error it's handled by `LastResortHandler`:
   - Response status code is always `500` and the response itself is a plain text.
 
 ## Production mode

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ it normalizes errors into consistent HTTP responses with sensible status codes. 
   - Handled by a `ResultHandler` used by `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
   - `InputValidationError`: request violates `input` schema, the default status code is `400`;
   - `OutputValidationError`: handler violates `output` schema, the default status code is `500`;
-  - `HttpError`: can be thrown in handlers with helps of `createHttpError()`, its `.statusCode` is used for response;
+  - `HttpError`: can be thrown in handlers with help of `createHttpError()`, its `.statusCode` is used for response;
   - For other errors the default status code is `500`;
 - Routing, parsing and upload issues:
   - Handled by `ResultHandler` configured as `errorHandler` (the defaults is `defaultResultHandler`);

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ const resultHandlerWithCleanup = new ResultHandler({
 There are two ways of connecting the native express middlewares depending on their nature and your objective.
 
 In case it's a middleware establishing and serving its own routes, or somehow globally modifying the behaviour, or
-being an additional request parser (like `cookie-parser`), use the `beforeRouting` option. However, it might be better
+being an additional request parser (like `cookie-parser`), use the `beforeRouting` hook. However, it might be better
 to avoid `cors` here — [the framework handles it on its own](#cross-origin-resource-sharing).
 
 ```typescript
@@ -644,7 +644,7 @@ declare module "express-zod-api" {
 ## Child logger
 
 In case you need a dedicated logger for each request (for example, equipped with a request ID), you can specify the
-`childLoggerProvider` option in your configuration. The function accepts the initially defined logger and the request,
+`childLoggerProvider` hook in your configuration. The function accepts the initially defined logger and the request,
 it can also be asynchronous. The child logger returned by that function will replace the `logger` in all handlers.
 You can use the `.child()` method of the built-in logger or [install a custom logger](#customizing-logger) instead.
 
@@ -906,9 +906,9 @@ it normalizes errors into consistent HTTP responses with sensible status codes. 
   - Handled by a `ResultHandler` used by `EndpointsFactory` (`defaultEndpointsFactory` uses `defaultResultHandler`);
   - `InputValidationError`: request violates `input` schema, the default status code is `400`;
   - `OutputValidationError`: handler violates `output` schema, the default status code is `500`;
-  - `HttpError`: can be thrown in handlers with help of `createHttpError()`, its `.statusCode` is used for response;
+  - `HttpError` thrown in handlers (with help of `createHttpError()`): its `.statusCode` is used for response;
   - For other errors the default status code is `500`;
-- Routing, parsing and upload issues:
+- Routing, parsing, hooks, and upload issues:
   - Handled by `ResultHandler` configured as `errorHandler` (the defaults is `defaultResultHandler`);
   - Parsing errors: passed through as-is (typically `HttpError` with `4XX` code used for response by default);
   - Routing errors: `404` or `405`, based on `wrongMethodBehavior` configuration;
@@ -996,7 +996,7 @@ _Hint: for unlisted extra fields use the following syntax: `ez.form( z.object({}
 Install the following additional packages: `express-fileupload` and `@types/express-fileupload`, and enable or
 configure file uploads. Refer to [documentation](https://www.npmjs.com/package/express-fileupload#available-options) on
 available options. The `limitHandler` option is replaced by the `limitError` one. You can also connect an additional
-middleware for restricting the ability to upload using the `beforeUpload` option. So the configuration for the limited
+middleware for restricting the ability to upload using the `beforeUpload` hook. So the configuration for the limited
 and restricted upload might look this way:
 
 ```typescript
@@ -1080,7 +1080,7 @@ errors yourself. In this regard `attachRouting()` provides you with `notFoundHan
 to your custom express app.
 
 Besides that, if you're looking to include additional request parsers, or a middleware that establishes its own routes,
-then consider using the `beforeRouting` [option in config instead](#using-native-express-middlewares).
+then consider using the `beforeRouting` [hook in config instead](#using-native-express-middlewares).
 
 ## Testing endpoints
 

--- a/README.md
+++ b/README.md
@@ -899,9 +899,8 @@ const resultHandler = new ResultHandler({
 
 ## Error handling
 
-`ResultHandler` is designed to be the entity responsible for centralized error handling. By default, that center is
-the `defaultResultHandler`, however, since much can be customized, you should be aware that there are three possible
-origins of errors that could happen in runtime and be handled the following way:
+All runtime errors are handled by a `ResultHandler`. The default is `defaultResultHandler`. Using `ensureHttpError()`
+it normalizes errors into consistent HTTP responses with sensible status codes. Errors can originate from three layers:
 
 - Ones related to `Endpoint` execution — handled by a `ResultHandler` assigned to the `EndpointsFactory` produced it:
   - The following proprietary classes are available to you for customizing error handling in your `ResultHandler`:

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -60,12 +60,12 @@ export interface CommonConfig {
    * */
   logger?: Partial<BuiltinLoggerConfig> | AbstractLogger;
   /**
-   * @desc A child logger returned by this hook overrides the logger in all handlers for each request
+   * @desc A child logger returned by this function can override the logger in all handlers for each request
    * @example ({ parent }) => parent.child({ requestId: uuid() })
    * */
   childLoggerProvider?: ChildLoggerProvider;
   /**
-   * @desc The hook for producing access logs
+   * @desc The function for producing access logs
    * @default ({ method, path }, logger) => logger.debug(`${method}: ${path}`)
    * @example null — disables the feature
    * */
@@ -109,7 +109,7 @@ type UploadOptions = Pick<
    * */
   limitError?: Error;
   /**
-   * @desc A hook to execute before uploading — it can be used for restrictions by throwing an error.
+   * @desc A handler to execute before uploading — it can be used for restrictions by throwing an error.
    * @example ({ request }) => { throw createHttpError(403, "Not authorized"); }
    * */
   beforeUpload?: BeforeUpload;
@@ -184,7 +184,7 @@ export interface ServerConfig extends CommonConfig {
    * */
   formParser?: RequestHandler;
   /**
-   * @desc A hook to execute before processing the Routing of your API (and before parsing).
+   * @desc A code to execute before processing the Routing of your API (and before parsing).
    * @desc This can be a good place for express middlewares establishing their own routes.
    * @desc It can help to avoid making a DIY solution based on the attachRouting() approach.
    * @example ({ app }) => { app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument)); }

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -60,12 +60,12 @@ export interface CommonConfig {
    * */
   logger?: Partial<BuiltinLoggerConfig> | AbstractLogger;
   /**
-   * @desc A child logger returned by this function can override the logger in all handlers for each request
+   * @desc A child logger returned by this hook overrides the logger in all handlers for each request
    * @example ({ parent }) => parent.child({ requestId: uuid() })
    * */
   childLoggerProvider?: ChildLoggerProvider;
   /**
-   * @desc The function for producing access logs
+   * @desc The hook for producing access logs
    * @default ({ method, path }, logger) => logger.debug(`${method}: ${path}`)
    * @example null — disables the feature
    * */
@@ -109,7 +109,7 @@ type UploadOptions = Pick<
    * */
   limitError?: Error;
   /**
-   * @desc A handler to execute before uploading — it can be used for restrictions by throwing an error.
+   * @desc A hook to execute before uploading — it can be used for restrictions by throwing an error.
    * @example ({ request }) => { throw createHttpError(403, "Not authorized"); }
    * */
   beforeUpload?: BeforeUpload;
@@ -184,7 +184,7 @@ export interface ServerConfig extends CommonConfig {
    * */
   formParser?: RequestHandler;
   /**
-   * @desc A code to execute before processing the Routing of your API (and before parsing).
+   * @desc A hook to execute before processing the Routing of your API (and before parsing).
    * @desc This can be a good place for express middlewares establishing their own routes.
    * @desc It can help to avoid making a DIY solution based on the attachRouting() approach.
    * @example ({ app }) => { app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument)); }

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -5,11 +5,12 @@ import { AbstractResultHandler } from "./result-handler";
 import { ActualLogger } from "./logger-helpers";
 import { CommonConfig, ServerConfig } from "./config-type";
 import { ErrorRequestHandler, RequestHandler, Request } from "express";
-import createHttpError, { isHttpError } from "http-errors";
+import createHttpError from "http-errors";
 import { lastResortHandler } from "./last-resort";
 import { ResultHandlerError } from "./errors";
 import { ensureError } from "./common-helpers";
 import { monitor } from "./graceful-shutdown";
+import { ensureHttpError } from "./result-helpers";
 
 type EquippedRequest = Request<
   unknown,
@@ -32,9 +33,7 @@ export const createCatcher =
   async (error, request, response, next) => {
     if (!error) return next();
     return errorHandler.execute({
-      error: isHttpError(error)
-        ? error
-        : createHttpError(400, ensureError(error).message),
+      error: ensureHttpError(ensureError(error)),
       request,
       response,
       input: null,

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -10,7 +10,6 @@ import { lastResortHandler } from "./last-resort";
 import { ResultHandlerError } from "./errors";
 import { ensureError } from "./common-helpers";
 import { monitor } from "./graceful-shutdown";
-import { ensureHttpError } from "./result-helpers";
 
 type EquippedRequest = Request<
   unknown,
@@ -33,7 +32,7 @@ export const createCatcher =
   async (error, request, response, next) => {
     if (!error) return next();
     return errorHandler.execute({
-      error: ensureHttpError(ensureError(error)),
+      error: ensureError(error),
       request,
       response,
       input: null,

--- a/express-zod-api/tests/__snapshots__/system.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/system.spec.ts.snap
@@ -90,19 +90,19 @@ exports[`App in production mode > Protocol > Should fail on invalid path 1`] = `
 }
 `;
 
-exports[`App in production mode > Protocol > Should fail on malformed body 1`] = `
+exports[`App in production mode > Protocol > Should fail when missing content type header 1`] = `
 {
   "error": {
-    "message": StringMatching /Unterminated string in JSON at position 25/,
+    "message": "key: Required",
   },
   "status": "error",
 }
 `;
 
-exports[`App in production mode > Protocol > Should fail when missing content type header 1`] = `
+exports[`App in production mode > Protocol > Should handle JSON parser failures 1`] = `
 {
   "error": {
-    "message": "key: Required",
+    "message": StringMatching /Unterminated string in JSON at position 25/,
   },
   "status": "error",
 }

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -20,7 +20,7 @@ import {
   makeRequestMock,
   makeResponseMock,
 } from "../src/testing";
-import createHttpError from "http-errors";
+import createHttpError, { HttpError } from "http-errors";
 
 describe("Server helpers", () => {
   describe("createCatcher()", () => {
@@ -35,11 +35,11 @@ describe("Server helpers", () => {
     });
 
     test.each([
-      new SyntaxError("Unexpected end of JSON input"),
-      createHttpError(400, "Unexpected end of JSON input"),
+      [new SyntaxError("Unexpected end of JSON input"), 500],
+      [createHttpError(400, "Unexpected end of JSON input"), 400],
     ])(
       "the handler should call error handler with correct error code %#",
-      async (error) => {
+      async (error, expected) => {
         const errorHandler = new ResultHandler({
           positive: vi.fn(),
           negative: vi.fn(),
@@ -57,9 +57,11 @@ describe("Server helpers", () => {
           vi.fn<any>(),
         );
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy.mock.calls[0][0].error).toEqual(
-          createHttpError(400, "Unexpected end of JSON input"),
+        expect(spy.mock.calls[0][0].error).toBeInstanceOf(HttpError);
+        expect(spy.mock.calls[0][0].error!.message).toBe(
+          "Unexpected end of JSON input",
         );
+        expect(spy.mock.calls[0][0].error).toHaveProperty("status", expected);
       },
     );
   });

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -113,7 +113,7 @@ describe("App in production mode", async () => {
   });
   const rawEndpoint = new EndpointsFactory(defaultResultHandler).build({
     method: "post",
-    input: ez.raw({}), // @todo rm argument
+    input: ez.raw(),
     output: z.object({ crc: z.number() }),
     handler: async ({ input: { raw } }) => ({ crc: raw.length }),
   });

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -118,6 +118,11 @@ describe("App in production mode", async () => {
       app.use((req, {}, next) => {
         const childLogger = getLogger(req);
         assert("isChild" in childLogger && childLogger.isChild);
+        assert.notEqual(
+          req.path,
+          "/trigger/before-routing",
+          "Failure of beforeRouting triggered",
+        );
         next();
       });
     },
@@ -297,6 +302,19 @@ describe("App in production mode", async () => {
       const text = await response.text();
       expect(text).toBe("Internal Server Error");
       expect(errorMethod.mock.lastCall).toMatchSnapshot();
+    });
+
+    test("Should treat beforeRouting error as internal", async () => {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/trigger/before-routing`,
+      );
+      expect(await response.json()).toEqual({
+        status: "error",
+        error: {
+          message: expect.stringMatching(/Failure of beforeRouting triggered/),
+        },
+      });
+      expect(response.status).toBe(500);
     });
   });
 


### PR DESCRIPTION
Removing the status code coercion to `400` in the catcher, so that errors other than `HttpError` lead to `500` response by default.
Found the discrepancy from the documented behaviour on error handling.
Most likely introduced in v19.0.0 by #1741 

Pick from the documentation

> - Ones related to routing, parsing and upload issues — handled by `ResultHandler` assigned to `errorHandler` in config:
>   - Default is `defaultResultHandler` — it sets the response status code from the corresponding `HttpError`:
>     `400` for parsing ⚠️ 👀   **(this should be corrected to what specific parser throws)**, `404` for routing ✅ ,  `config.upload.limitError.statusCode` for upload issues ✅ , or `500` for others ⚠️  **(this one was 400 in catcher, fixed below)**;
