### PR TITLE
Fix for `ez.raw()` without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 22
 
+### v22.13.1
+
+- Fixed: the output type of the `ez.raw()` schema (without an argument) was missing the `raw` property (since v19.0.0).
+
 ### v22.13.0
 
 - Ability to configure and disable access logging:

--- a/express-zod-api/src/raw-schema.ts
+++ b/express-zod-api/src/raw-schema.ts
@@ -3,11 +3,15 @@ import { file } from "./file-schema";
 
 export const ezRawBrand = Symbol("Raw");
 
+const base = z.object({ raw: file("buffer") });
+
 /** Shorthand for z.object({ raw: ez.file("buffer") }) */
-export const raw = <S extends z.ZodRawShape>(extra: S = {} as S) =>
-  z
-    .object({ raw: file("buffer") })
-    .extend(extra)
-    .brand(ezRawBrand as symbol);
+export function raw(): z.ZodBranded<typeof base, symbol>;
+export function raw<S extends z.ZodRawShape>(
+  extra: S,
+): z.ZodBranded<ReturnType<typeof base.extend<S>>, symbol>;
+export function raw(extra?: z.ZodRawShape) {
+  return (extra ? base.extend(extra) : base).brand(ezRawBrand);
+}
 
 export type RawSchema = ReturnType<typeof raw>;

--- a/express-zod-api/tests/raw-schema.spec.ts
+++ b/express-zod-api/tests/raw-schema.spec.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { ez } from "../src";
+import { metaSymbol } from "../src/metadata";
+import { ezRawBrand } from "../src/raw-schema";
+
+describe("ez.raw()", () => {
+  describe("creation", () => {
+    test("should be an instance of branded object", () => {
+      const schema = ez.raw();
+      expect(schema).toBeInstanceOf(z.ZodBranded);
+      expect(schema._def[metaSymbol]?.brand).toBe(ezRawBrand);
+    });
+  });
+
+  describe("types", () => {
+    test("without extension", () => {
+      const schema = ez.raw();
+      expectTypeOf(schema._output).toExtend<{ raw: Buffer }>();
+    });
+
+    test("with empty extension", () => {
+      const schema = ez.raw({});
+      expectTypeOf(schema._output).toExtend<{ raw: Buffer }>();
+    });
+
+    test("with populated extension", () => {
+      const schema = ez.raw({ extra: z.number() });
+      expectTypeOf(schema._output).toExtend<{ raw: Buffer; extra: number }>();
+    });
+  });
+
+  describe("parsing", () => {
+    test("should accept buffer as the raw prop", () => {
+      const schema = ez.raw();
+      expect(schema.parse({ raw: Buffer.from("test"), extra: 123 })).toEqual({
+        raw: expect.any(Buffer),
+      });
+    });
+
+    test("should allow extension", () => {
+      const schema = ez.raw({ extra: z.number() });
+      expect(schema.parse({ raw: Buffer.from("test"), extra: 123 })).toEqual({
+        raw: expect.any(Buffer),
+        extra: 123,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Noticed that its output type does not work properly when no extension argument given.
The issue seems to be introduced in v19.0.0
Discovered and needed for #2525 