### PR TITLE
Requiring `express@^5.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v23.0.0
 
-- Minimum version of `express` (required peer dependency) is `5.0.1`;
+- Minimum version of `express` (required peer dependency) is `5.1.0` (first release of v5 marked as `latest`);
 - Minimum version of `compression` (optional peer dependency) is `1.8.0` (it supports Brotli);
 - The default value for `wrongMethodBehavior` config option is changed to `405`;
 - Publicly exposed interfaces: `CustomHeaderSecurity` renamed to `HeaderSecurity`, `NormalizedResponse` removed.

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -72,7 +72,7 @@
     "@types/express-fileupload": "^1.5.0",
     "@types/http-errors": "^2.0.2",
     "compression": "^1.8.0",
-    "express": "^5.0.1",
+    "express": "^5.1.0",
     "express-fileupload": "^1.5.0",
     "http-errors": "^2.0.0",
     "typescript": "^5.1.3",


### PR DESCRIPTION
That version was the first on v5 marked as `latest`.
So I believe it would be better to focus on it instead of `5.0.1`