### PR TITLE
Depicting `propertyNames` for `z.record()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### v23.1.0
 
-- Fixed length array support in generated Documentation (`z.boolean().array().length(2)`).
+- Improved generated Documentation:
+  - Arrays having fixed length: `z.boolean().array().length(2)`;
+  - Records with non-literal keys (added `propertyNames`): `z.record(z.string().regex(/x-\w+/), z.boolean())`.
 
 ### v23.0.0
 

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -492,6 +492,8 @@ paths:
                         type: string
                       otherInputs:
                         type: object
+                        propertyNames:
+                          type: string
                         additionalProperties:
                           format: any
                     required:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -355,7 +355,11 @@ export const depictRecord: Depicter = (
       required,
     };
   }
-  return { type: "object", additionalProperties: next(valueSchema) };
+  return {
+    type: "object",
+    propertyNames: next(keySchema),
+    additionalProperties: next(valueSchema),
+  };
 };
 
 export const depictArray: Depicter = (

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -384,6 +384,9 @@ exports[`Documentation helpers > depictIntersection() > should fall back to allO
         "minimum": -1.7976931348623157e+308,
         "type": "number",
       },
+      "propertyNames": {
+        "type": "string",
+      },
       "type": "object",
     },
     {
@@ -924,6 +927,9 @@ exports[`Documentation helpers > depictRecord() > should set properties+required
   "additionalProperties": {
     "type": "boolean",
   },
+  "propertyNames": {
+    "type": "string",
+  },
   "type": "object",
 }
 `;
@@ -932,6 +938,9 @@ exports[`Documentation helpers > depictRecord() > should set properties+required
 {
   "additionalProperties": {
     "type": "boolean",
+  },
+  "propertyNames": {
+    "type": "string",
   },
   "type": "object",
 }
@@ -991,6 +1000,22 @@ exports[`Documentation helpers > depictRecord() > should set properties+required
 {
   "additionalProperties": {
     "format": "any",
+  },
+  "propertyNames": {
+    "type": "string",
+  },
+  "type": "object",
+}
+`;
+
+exports[`Documentation helpers > depictRecord() > should set properties+required or additionalProperties props 6 1`] = `
+{
+  "additionalProperties": {
+    "type": "boolean",
+  },
+  "propertyNames": {
+    "pattern": "x-\\w+",
+    "type": "string",
   },
   "type": "object",
 }
@@ -1622,6 +1647,9 @@ exports[`Documentation helpers > excludeParamsFromDepiction() > should omit spec
     },
     {
       "additionalProperties": {
+        "type": "string",
+      },
+      "propertyNames": {
         "type": "string",
       },
       "type": "object",

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1808,6 +1808,8 @@ paths:
                     properties:
                       simple:
                         type: object
+                        propertyNames:
+                          type: string
                         additionalProperties:
                           type: integer
                           format: int64
@@ -1815,10 +1817,18 @@ paths:
                           maximum: 9007199254740991
                       stringy:
                         type: object
+                        propertyNames:
+                          type: string
+                          pattern: "[A-Z]+"
                         additionalProperties:
                           type: boolean
                       numeric:
                         type: object
+                        propertyNames:
+                          type: integer
+                          format: int64
+                          minimum: -9007199254740991
+                          maximum: 9007199254740991
                         additionalProperties:
                           type: boolean
                       literal:

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -397,6 +397,7 @@ describe("Documentation helpers", () => {
       z.record(z.literal("testing"), z.boolean()),
       z.record(z.literal("one").or(z.literal("two")), z.boolean()),
       z.record(z.any()), // Issue #900
+      z.record(z.string().regex(/x-\w+/), z.boolean()),
     ])(
       "should set properties+required or additionalProperties props %#",
       (schema) => {


### PR DESCRIPTION
when it's not literal, general case.
discovered while working on #2537 