### PR TITLE
Delegating depiction to Zod 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   - `IOSchema` type had to be simplified down to a schema resulting in a `object`, but not an `array`;
   - Despite supporting examples by the new Zod method `.meta()`, users should still use `.example()` to set them;
   - Refer to [Migration guide on Zod 4](https://v4.zod.dev/v4/changelog) for adjusting your schemas;
+- Generating Documentation is partially delegated to Zod 4 `z.toJSONSchema()`:
+  - The basic depiction of each schema is now natively performed by Zod 4;
+  - Express Zod API implements some overrides and improvements to fit it into OpenAPI 3.1 that extends JSON Schema;
+  - The `numericRange` option removed from `Documentation` class constructor argument;
+  - The `brandHandling` should consist of postprocessing functions altering the depiction made by Zod 4;
+  - The `Depicter` type changed to `Overrider` having different signature;
 
 ## Version 23
 

--- a/README.md
+++ b/README.md
@@ -1388,7 +1388,7 @@ const routing: Routing = {
 You can customize handling rules for your schemas in Documentation and Integration. Use the `.brand()` method on your
 schema to make it special and distinguishable for the framework in runtime. Using symbols is recommended for branding.
 After that utilize the `brandHandling` feature of both constructors to declare your custom implementation. In case you
-need to reuse a handling rule for multiple brands, use the exposed types `Depicter` and `Producer`.
+need to reuse a handling rule for multiple brands, use the exposed types `Overrider` and `Producer`.
 
 ```ts
 import ts from "typescript";
@@ -1396,19 +1396,19 @@ import { z } from "zod";
 import {
   Documentation,
   Integration,
-  Depicter,
+  Overrider,
   Producer,
 } from "express-zod-api";
 
 const myBrand = Symbol("MamaToldMeImSpecial"); // I recommend to use symbols for this purpose
 const myBrandedSchema = z.string().brand(myBrand);
 
-const ruleForDocs: Depicter = (
-  schema: typeof myBrandedSchema, // you should assign type yourself
-  { next, path, method, isResponse }, // handle a nested schema using next()
+const ruleForDocs: Overrider = (
+  { zodSchema, jsonSchema }, // adjust jsonSchema for overrides
+  { path, method, isResponse }, // handle a nested schema using next()
 ) => {
-  const defaultDepiction = next(schema.unwrap()); // { type: string }
-  return { summary: "Special type of data" };
+  delete jsonSchema.format;
+  jsonSchema.summary = "Special type of data";
 };
 
 const ruleForClient: Producer = (

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -186,9 +186,9 @@ paths:
                         examples:
                           - John Doe
                       createdAt:
-                        format: date-time
                         description: YYYY-MM-DDTHH:mm:ss.sssZ
                         type: string
+                        format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                         examples:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -42,7 +42,7 @@ paths:
                       features:
                         type: array
                         items:
-                          $ref: "#/components/schemas/__schema0"
+                          $ref: "#/components/schemas/Schema1"
                     required:
                       - id
                       - name
@@ -700,7 +700,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    __schema0:
+    Schema1:
       type: object
       properties:
         title:
@@ -708,7 +708,7 @@ components:
         features:
           type: array
           items:
-            $ref: "#/components/schemas/__schema0"
+            $ref: "#/components/schemas/Schema1"
       required:
         - title
         - features

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -29,30 +29,20 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       id:
                         type: integer
-                        format: int64
-                        minimum: 0
                         maximum: 9007199254740991
                       name:
                         type: string
                       features:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            title:
-                              type: string
-                            features:
-                              $ref: "#/components/schemas/Schema1"
-                          required:
-                            - title
-                            - features
+                          $ref: "#/components/schemas/__schema0"
                     required:
                       - id
                       - name
@@ -68,8 +58,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -186,8 +176,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -196,9 +186,9 @@ paths:
                         examples:
                           - John Doe
                       createdAt:
+                        format: date-time
                         description: YYYY-MM-DDTHH:mm:ss.sssZ
                         type: string
-                        format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                         examples:
@@ -224,8 +214,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -269,16 +259,14 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: created
+                    type: string
                   data:
                     type: object
                     properties:
                       id:
                         type: integer
-                        format: int64
-                        exclusiveMinimum: 0
-                        maximum: 9007199254740991
+                        exclusiveMaximum: 9007199254740991
                     required:
                       - id
                 required:
@@ -292,16 +280,14 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: created
+                    type: string
                   data:
                     type: object
                     properties:
                       id:
                         type: integer
-                        format: int64
-                        exclusiveMinimum: 0
-                        maximum: 9007199254740991
+                        exclusiveMaximum: 9007199254740991
                     required:
                       - id
                 required:
@@ -315,8 +301,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   reason:
                     type: string
                 required:
@@ -330,13 +316,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: exists
+                    type: string
                   id:
                     type: integer
-                    format: int64
-                    minimum: -9007199254740991
-                    maximum: 9007199254740991
+                    exclusiveMinimum: -9007199254740991
+                    exclusiveMaximum: 9007199254740991
                 required:
                   - status
                   - id
@@ -348,8 +333,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   reason:
                     type: string
                 required:
@@ -468,6 +453,7 @@ paths:
                   format: binary
               required:
                 - avatar
+              additionalProperties: {}
         required: true
       responses:
         "200":
@@ -478,8 +464,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -487,8 +473,6 @@ paths:
                         type: string
                       size:
                         type: integer
-                        format: int64
-                        minimum: 0
                         maximum: 9007199254740991
                       mime:
                         type: string
@@ -517,8 +501,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -557,15 +541,13 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       length:
                         type: integer
-                        format: int64
-                        minimum: 0
                         maximum: 9007199254740991
                     required:
                       - length
@@ -580,8 +562,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -623,19 +605,15 @@ paths:
                 properties:
                   data:
                     type: integer
-                    format: int64
-                    exclusiveMinimum: 0
-                    maximum: 9007199254740991
+                    exclusiveMaximum: 9007199254740991
                   event:
-                    type: string
                     const: time
+                    type: string
                   id:
                     type: string
                   retry:
                     type: integer
-                    format: int64
-                    exclusiveMinimum: 0
-                    maximum: 9007199254740991
+                    exclusiveMaximum: 9007199254740991
                 required:
                   - data
                   - event
@@ -681,16 +659,14 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       crc:
                         type: integer
-                        format: int64
-                        exclusiveMinimum: 0
-                        maximum: 9007199254740991
+                        exclusiveMaximum: 9007199254740991
                     required:
                       - crc
                 required:
@@ -704,8 +680,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -724,18 +700,18 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    Schema1:
-      type: array
-      items:
-        type: object
-        properties:
-          title:
-            type: string
-          features:
-            $ref: "#/components/schemas/Schema1"
-        required:
-          - title
-          - features
+    __schema0:
+      type: object
+      properties:
+        title:
+          type: string
+        features:
+          type: array
+          items:
+            $ref: "#/components/schemas/__schema0"
+      required:
+        - title
+        - features
   responses: {}
   parameters: {}
   examples: {}

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -2,7 +2,6 @@ import type {
   $ZodCheckGreaterThan,
   $ZodCheckLessThan,
   $ZodChecks,
-  $ZodDate,
   $ZodEnum,
   $ZodIntersection,
   $ZodLazy,
@@ -189,6 +188,16 @@ export const delegate: Depicter = (schema, ctx) =>
           ),
         );
       }
+      if (zodSchema._zod.def.type === "date") {
+        throw new DocumentationError(
+          `Using z.date() within ${
+            ctx.isResponse ? "output" : "input"
+          } schema is forbidden. Please use ez.date${
+            ctx.isResponse ? "Out" : "In"
+          }() instead. Check out the documentation for details.`,
+          ctx,
+        );
+      }
       // on each
       const examples = getExamples({
         schema: zodSchema as z.ZodType, // @todo remove "as"
@@ -296,18 +305,6 @@ export const depictDateOut: Depicter = ({}: DateOutSchema, ctx) => {
       url: isoDateDocumentationUrl,
     },
   };
-};
-
-/** @throws DocumentationError */
-export const depictDate: Depicter = ({}: $ZodDate, ctx) => {
-  throw new DocumentationError(
-    `Using z.date() within ${
-      ctx.isResponse ? "output" : "input"
-    } schema is forbidden. Please use ez.date${
-      ctx.isResponse ? "Out" : "In"
-    }() instead. Check out the documentation for details.`,
-    ctx,
-  );
 };
 
 const isCheck = <T extends $ZodChecks>(
@@ -561,7 +558,7 @@ export const depicters: HandlingRules<
   enum: delegate,
   optional: delegate,
   nullable: delegate,
-  date: depictDate,
+  date: delegate,
   catch: delegate,
   pipe: depictPipeline,
   lazy: delegate,

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -116,7 +116,7 @@ const onUpload: Overrider = ({ jsonSchema }, ctx) => {
 };
 
 const onFile: Overrider = ({ jsonSchema }) => {
-  delete jsonSchema.oneOf; // undo default
+  delete jsonSchema.anyOf; // undo default
   Object.assign(jsonSchema, {
     type: "string",
     format:
@@ -131,7 +131,7 @@ const onFile: Overrider = ({ jsonSchema }) => {
 const onUnion: Overrider = ({ zodSchema, jsonSchema }) => {
   if (!zodSchema._zod.disc) return;
   const propertyName = Array.from(zodSchema._zod.disc.keys()).pop();
-  jsonSchema.discriminator = { propertyName };
+  jsonSchema.discriminator ??= { propertyName };
 };
 
 const propsMerger = (a: unknown, b: unknown) => {
@@ -189,11 +189,11 @@ const onIntersection: Overrider = ({ jsonSchema }) => {
 
 /** @since OAS 3.1 nullable replaced with type array having null */
 const onNullable: Overrider = ({ jsonSchema }) => {
-  if (!jsonSchema.oneOf) return;
-  const original = jsonSchema.oneOf[0];
+  if (!jsonSchema.anyOf) return;
+  const original = jsonSchema.anyOf[0];
   Object.assign(original, { type: makeNullableType(original) });
   Object.assign(jsonSchema, original);
-  delete jsonSchema.oneOf;
+  delete jsonSchema.anyOf;
 };
 
 const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
@@ -225,7 +225,7 @@ const onLiteral: Overrider = ({ zodSchema, jsonSchema }) =>
 const onDateIn: Overrider = ({ jsonSchema }, ctx) => {
   if (ctx.isResponse)
     throw new DocumentationError("Please use ez.dateOut() for output.", ctx);
-  delete jsonSchema.oneOf; // undo default
+  delete jsonSchema.anyOf; // undo default
   Object.assign(jsonSchema, {
     description: "YYYY-MM-DDTHH:mm:ss.sssZ",
     type: "string",
@@ -549,6 +549,7 @@ export const excludeParamsFromDepiction = (
     required: R.without(names),
     allOf: subTransformer,
     oneOf: subTransformer,
+    anyOf: subTransformer,
   };
   const result: SchemaObject = R.evolve(transformers, subject);
   return [result, hasRequired || Boolean(result.required?.length)];

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -1,12 +1,10 @@
 import type {
-  $ZodChecks,
   $ZodEnum,
   $ZodIntersection,
   $ZodLazy,
   $ZodLiteral,
   $ZodNullable,
   $ZodPipe,
-  $ZodStringFormat,
   $ZodTuple,
   $ZodType,
   JSONSchema,
@@ -339,11 +337,6 @@ const getSupportedType = (value: unknown): SchemaObjectType | undefined => {
       ? detected
       : undefined;
 };
-
-const isCheck = <T extends $ZodChecks>(
-  check: unknown,
-  name: T["_zod"]["def"]["check"],
-): check is T => R.pathEq(name, ["_zod", "def", "check"], check);
 
 const makeSample = (depicted: SchemaObject) => {
   const firstType = (

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -309,10 +309,7 @@ const onPipeline: Overrider = ({ zodSchema, jsonSchema }, ctx) => {
             type: targetType as "number" | "string" | "boolean",
           });
         } else {
-          Object.assign(
-            jsonSchema,
-            delegate(z.any(), { ctx, rules: overrides }), // @todo try to avoid it
-          );
+          onAny({ zodSchema, jsonSchema }, ctx);
         }
       }
     }

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -1,9 +1,7 @@
 import type {
   $ZodEnum,
-  $ZodIntersection,
   $ZodLazy,
   $ZodLiteral,
-  $ZodNullable,
   $ZodPipe,
   $ZodTuple,
   $ZodType,
@@ -145,9 +143,8 @@ export const delegate: Depicter = (schema, ctx) =>
       }
       if (zodSchema._zod.def.type === "bigint")
         Object.assign(jsonSchema, { type: "integer", format: "bigint" });
-      if (zodSchema._zod.def.type === "intersection") {
-        const { left, right } = (zodSchema as $ZodIntersection)._zod.def;
-        const attempt = intersect([left, right].map((e) => delegate(e, ctx)));
+      if (zodSchema._zod.def.type === "intersection" && jsonSchema.allOf) {
+        const attempt = intersect(jsonSchema.allOf as SchemaObject[]); // @todo remove "as"
         delete jsonSchema.allOf; // undo default
         Object.assign(jsonSchema, attempt);
       }
@@ -293,6 +290,7 @@ const approaches = {
     R.union(left, right),
   examples: ({ examples: left = [] }, { examples: right = [] }) =>
     combinations(left, right, ([a, b]) => R.mergeDeepRight(a, b)),
+  description: ({ description: left }, { description: right }) => left || right,
 } satisfies {
   [K in keyof SchemaObject]: (...subj: SchemaObject[]) => SchemaObject[K];
 };

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -476,10 +476,7 @@ const onEach: Overrider = ({ zodSchema, jsonSchema }, { isResponse }) => {
   if (examples.length) jsonSchema.examples = examples.slice();
 };
 
-export const delegate = (
-  schema: $ZodType,
-  ctx: Omit<OpenAPIContext, "jsonSchema">, // @todo cleanup the mess
-) => {
+export const delegate = (schema: $ZodType, ctx: OpenAPIContext) => {
   const result = z.toJSONSchema(schema, {
     unrepresentable: "any",
     metadata: globalRegistry,

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -3,6 +3,7 @@ import type {
   $ZodLiteral,
   $ZodPipe,
   $ZodTuple,
+  $ZodType,
   JSONSchema,
 } from "@zod/core";
 import {
@@ -63,7 +64,7 @@ export interface OpenAPIContext extends FlatObject {
     subject: SchemaObject | ReferenceObject,
     name?: string,
   ) => ReferenceObject;
-  brandHandling: HandlingRules<SchemaObject | ReferenceObject, OpenAPIContext>;
+  brandHandling: Record<string | symbol, (zodSchema: $ZodType) => SchemaObject>;
   path: string;
   method: Method;
 }
@@ -257,7 +258,7 @@ export const delegate: Depicter = (schema, ctx) => {
       // custom brands handling
       if (brand && ctx.brandHandling[brand]) {
         for (const key in jsonSchema) delete jsonSchema[key]; // undo default
-        Object.assign(jsonSchema, ctx.brandHandling[brand](zodSchema, ctx));
+        Object.assign(jsonSchema, ctx.brandHandling[brand](zodSchema));
       }
       // on each
       const shouldAvoidParsing =

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -277,7 +277,7 @@ const makeNullableType = ({
   | SchemaObjectType
   | SchemaObjectType[] => {
   if (type === "null") return type;
-  if (typeof type === "string") return [type as SchemaObjectType, "null"];
+  if (typeof type === "string") return [type as SchemaObjectType, "null"]; // @todo make method instead of "as"
   return type ? [...new Set(type).add("null")] : "null";
 };
 
@@ -503,7 +503,7 @@ const fixReferences = (
           const actualName = entry.$ref.split("/").pop()!;
           const depiction = $defs[actualName];
           if (depiction)
-            entry.$ref = ctx.makeRef(depiction, depiction as SchemaObject).$ref;
+            entry.$ref = ctx.makeRef(depiction, depiction as SchemaObject).$ref; // @todo see below
           continue;
         }
       }
@@ -511,9 +511,10 @@ const fixReferences = (
     }
     if (R.is(Array, entry)) stack.push(...R.values(entry));
   }
-  return rest as SchemaObject;
+  return rest as SchemaObject; // @todo ideally, there should be a method to ensure that
 };
 
+// @todo rename?
 export const delegate = (
   schema: $ZodType,
   {

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -107,7 +107,7 @@ export const delegate: Depicter = (schema, ctx) => {
     metadata: globalRegistry,
     io: ctx.isResponse ? "output" : "input",
     override: ({ zodSchema, jsonSchema }) => {
-      const { description } = globalRegistry.get(zodSchema) ?? {};
+      const { description, deprecated } = globalRegistry.get(zodSchema) ?? {};
       const { brand, defaultLabel } =
         globalRegistry.get(zodSchema)?.[metaSymbol] ?? {};
       if (zodSchema._zod.def.type === "nullable" && jsonSchema.oneOf) {
@@ -255,6 +255,7 @@ export const delegate: Depicter = (schema, ctx) => {
       }
       // on each
       if (description) jsonSchema.description ??= description;
+      if (deprecated) jsonSchema.deprecated = true;
       const shouldAvoidParsing =
         zodSchema._zod.def.type === "lazy" ||
         zodSchema._zod.def.type === "promise";

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -78,10 +78,7 @@ export type IsHeader = (
 ) => boolean | null | undefined;
 
 interface ReqResHandlingProps<S extends z.ZodTypeAny>
-  extends Pick<
-    OpenAPIContext,
-    "makeRef" | "brandHandling" | "path" | "method"
-  > {
+  extends Omit<OpenAPIContext, "isResponse"> {
   schema: S;
   composition: "inline" | "components";
   description?: string;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -46,9 +46,7 @@ import { extractObjectSchema, IOSchema } from "./io-schema";
 import { Alternatives } from "./logical-container";
 import { metaSymbol } from "./metadata";
 import { Method } from "./method";
-import { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand } from "./raw-schema";
-import { FirstPartyKind, HandlingRules, SchemaHandler } from "./schema-walker";
 import { Security } from "./security";
 import { ezUploadBrand } from "./upload-schema";
 import wellKnownHeaders from "./well-known-headers.json";
@@ -485,81 +483,6 @@ export const depictRequestParams = ({
       });
     },
     [],
-  );
-};
-
-export const depicters: HandlingRules<
-  SchemaObject | ReferenceObject,
-  OpenAPIContext,
-  FirstPartyKind | ProprietaryBrand
-> = {
-  string: delegate,
-  number: delegate,
-  bigint: delegate,
-  boolean: delegate,
-  null: delegate,
-  array: delegate,
-  tuple: delegate,
-  record: delegate,
-  object: delegate,
-  literal: delegate,
-  intersection: delegate,
-  union: delegate,
-  any: delegate,
-  default: delegate,
-  enum: delegate,
-  optional: delegate,
-  nullable: delegate,
-  date: delegate,
-  catch: delegate,
-  pipe: delegate,
-  lazy: delegate,
-  readonly: delegate,
-  [ezFileBrand]: delegate,
-  [ezUploadBrand]: delegate,
-  [ezDateOutBrand]: delegate,
-  [ezDateInBrand]: delegate,
-  [ezRawBrand]: delegate,
-};
-
-export const onEach: SchemaHandler<
-  SchemaObject | ReferenceObject,
-  OpenAPIContext,
-  "each"
-> = (schema: z.ZodType, { isResponse, prev }) => {
-  if (isReferenceObject(prev)) return {};
-  const { description } = schema;
-  const shouldAvoidParsing =
-    schema instanceof z.ZodLazy || schema instanceof z.ZodPromise;
-  const hasTypePropertyInDepiction = prev.type !== undefined;
-  const acceptsNull =
-    !isResponse &&
-    !shouldAvoidParsing &&
-    hasTypePropertyInDepiction &&
-    schema.isNullable();
-  const result: SchemaObject = {};
-  if (description) result.description = description;
-  if (schema.meta()?.deprecated) result.deprecated = true;
-  if (acceptsNull) result.type = makeNullableType(prev);
-  if (!shouldAvoidParsing) {
-    const examples = getExamples({
-      schema,
-      variant: isResponse ? "parsed" : "original",
-      validate: true,
-    });
-    if (examples.length) result.examples = examples.slice();
-  }
-  return result;
-};
-
-export const onMissing: SchemaHandler<
-  SchemaObject | ReferenceObject,
-  OpenAPIContext,
-  "last"
-> = (schema: z.ZodTypeAny, ctx) => {
-  throw new DocumentationError(
-    `Zod type ${schema.constructor.name} is unsupported.`,
-    ctx,
   );
 };
 

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -56,6 +56,7 @@ import wellKnownHeaders from "./well-known-headers.json";
 export interface OpenAPIContext {
   isResponse: boolean;
   makeRef: (
+    key: object,
     subject: SchemaObject | ReferenceObject,
     name?: string,
   ) => ReferenceObject;
@@ -423,7 +424,7 @@ export const depictRequestParams = ({
       });
       const result =
         composition === "components"
-          ? makeRef(depicted, makeCleanId(description, name))
+          ? makeRef(paramSchema, depicted, makeCleanId(description, name))
           : depicted;
       return acc.concat({
         name,
@@ -497,7 +498,7 @@ const fixReferences = (
         const actualName = entry.$ref.split("/").pop()!;
         const depiction = $defs?.[actualName];
         if (depiction)
-          entry.$ref = makeRef(depiction as SchemaObject, actualName).$ref;
+          entry.$ref = makeRef(depiction, depiction as SchemaObject).$ref;
         continue;
       }
       stack.push(...R.values(entry));
@@ -590,7 +591,7 @@ export const depictResponse = ({
   const media: MediaTypeObject = {
     schema:
       composition === "components"
-        ? makeRef(depictedSchema, makeCleanId(description))
+        ? makeRef(schema, depictedSchema, makeCleanId(description))
         : depictedSchema,
     examples: depictExamples(schema, true),
   };
@@ -714,7 +715,7 @@ export const depictBody = ({
   const media: MediaTypeObject = {
     schema:
       composition === "components"
-        ? makeRef(bodyDepiction, makeCleanId(description))
+        ? makeRef(schema, bodyDepiction, makeCleanId(description))
         : bodyDepiction,
     examples: depictExamples(extractObjectSchema(schema), false, paramNames),
   };

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -477,7 +477,7 @@ const onEach: Overrider = ({ zodSchema, jsonSchema }, { isResponse }) => {
   if (acceptsNull)
     Object.assign(jsonSchema, { type: makeNullableType(jsonSchema) });
   const examples = getExamples({
-    schema: zodSchema as z.ZodType, // @todo remove "as"
+    schema: zodSchema,
     variant: isResponse ? "parsed" : "original",
     validate: true,
   });

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -497,7 +497,7 @@ const fixReferences = (
         const actualName = entry.$ref.split("/").pop()!;
         const depiction = $defs?.[actualName];
         if (depiction)
-          entry.$ref = makeRef(depiction as SchemaObject, actualName).$ref; // @todo remove as
+          entry.$ref = makeRef(depiction as SchemaObject, actualName).$ref;
         continue;
       }
       stack.push(...R.values(entry));

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -288,7 +288,7 @@ const onPipeline: Overrider = ({ zodSchema, jsonSchema }, ctx) => {
     ctx.isResponse ? "in" : "out"
   ];
   if (target instanceof z.ZodTransform) {
-    const opposingDepiction = delegate(opposite, { ctx, rules: overrides }); // @todo can avoid it?
+    const opposingDepiction = delegate(opposite, { ctx, rules: overrides });
     if (isSchemaObject(opposingDepiction)) {
       if (!ctx.isResponse) {
         const { type: opposingType, ...rest } = opposingDepiction;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -156,13 +156,9 @@ export const delegate: Depicter = (schema, ctx) =>
         Object.assign(jsonSchema, attempt);
       }
       if (zodSchema._zod.def.type === "literal") {
-        {
-          jsonSchema.type = getSupportedType(
-            Object.values((zodSchema as $ZodLiteral)._zod.def.values)[0],
-          );
-          //if (values.length === 1) result.const = values[0];
-          //else result.enum = Object.values(def.values);
-        }
+        jsonSchema.type = getSupportedType(
+          Object.values((zodSchema as $ZodLiteral)._zod.def.values)[0],
+        );
       }
       if (
         zodSchema._zod.def.type === "tuple" &&

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -472,7 +472,8 @@ const onEach: Overrider = ({ zodSchema, jsonSchema }, { isResponse }) => {
     !isResponse &&
     !shouldAvoidParsing &&
     hasTypePropertyInDepiction &&
-    (zodSchema as z.ZodType).isNullable(); // @todo remove "as"
+    zodSchema instanceof z.ZodType &&
+    zodSchema.isNullable();
   if (acceptsNull)
     Object.assign(jsonSchema, { type: makeNullableType(jsonSchema) });
   const examples = getExamples({

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -496,10 +496,8 @@ const fixReferences = (
     if (R.is(Object, entry)) {
       if (isReferenceObject(entry)) {
         if (entry.$ref === "#" && !$defs[entry.$ref]) {
-          return fixReferences(
-            { $defs: { ...$defs, [entry.$ref]: rest }, $ref: entry.$ref }, // false root handling
-            ctx,
-          );
+          $defs[entry.$ref] = rest;
+          return fixReferences({ $defs, $ref: entry.$ref }, ctx); // false root rewriting
         }
         if (!entry.$ref.startsWith("#/components")) {
           const actualName = entry.$ref.split("/").pop()!;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -120,17 +120,13 @@ export const delegate: Depicter = (schema, ctx) =>
     io: ctx.isResponse ? "output" : "input",
     override: ({ zodSchema, jsonSchema }) => {
       const brand = globalRegistry.get(zodSchema)?.[metaSymbol]?.brand;
-      if (zodSchema._zod.def.type === "nullable") {
-        const nested = delegate(
-          (zodSchema as $ZodNullable)._zod.def.innerType,
-          ctx,
-        );
+      if (zodSchema._zod.def.type === "nullable" && jsonSchema.oneOf) {
+        const original = jsonSchema.oneOf[0];
+        Object.assign(original, {
+          type: makeNullableType(original as SchemaObject), // @todo remove "as"
+        });
+        Object.assign(jsonSchema, original);
         delete jsonSchema.oneOf; // undo defaults
-        Object.assign(
-          jsonSchema,
-          nested,
-          isSchemaObject(nested) && { type: makeNullableType(nested) },
-        );
       }
       if (zodSchema._zod.def.type === "default") {
         jsonSchema.default =

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -90,7 +90,7 @@ export type IsHeader = (
 ) => boolean | null | undefined;
 
 interface ReqResHandlingProps<S extends z.ZodTypeAny>
-  extends Pick<OpenAPIContext, "makeRef" | "path" | "method" | "numericRange"> {
+  extends Pick<OpenAPIContext, "makeRef" | "path" | "method"> {
   schema: S;
   composition: "inline" | "components";
   description?: string;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -191,9 +191,7 @@ const onIntersection: Overrider = ({ jsonSchema }) => {
 const onNullable: Overrider = ({ jsonSchema }) => {
   if (!jsonSchema.oneOf) return;
   const original = jsonSchema.oneOf[0];
-  Object.assign(original, {
-    type: makeNullableType(original as SchemaObject), // @todo remove "as"
-  });
+  Object.assign(original, { type: makeNullableType(original) });
   Object.assign(jsonSchema, original);
   delete jsonSchema.oneOf;
 };
@@ -274,9 +272,11 @@ const makeSample = (depicted: SchemaObject) => {
 
 const makeNullableType = ({
   type,
-}: SchemaObject): SchemaObjectType | SchemaObjectType[] => {
+}: JSONSchema.BaseSchema | SchemaObject):
+  | SchemaObjectType
+  | SchemaObjectType[] => {
   if (type === "null") return type;
-  if (typeof type === "string") return [type, "null"];
+  if (typeof type === "string") return [type as SchemaObjectType, "null"];
   return type ? [...new Set(type).add("null")] : "null";
 };
 
@@ -473,11 +473,8 @@ const onEach: Overrider = ({ zodSchema, jsonSchema }, { isResponse }) => {
     !shouldAvoidParsing &&
     hasTypePropertyInDepiction &&
     (zodSchema as z.ZodType).isNullable(); // @todo remove "as"
-  if (acceptsNull) {
-    Object.assign(jsonSchema, {
-      type: makeNullableType(jsonSchema as SchemaObject), // @todo remove "as"
-    });
-  }
+  if (acceptsNull)
+    Object.assign(jsonSchema, { type: makeNullableType(jsonSchema) });
   const examples = getExamples({
     schema: zodSchema as z.ZodType, // @todo remove "as"
     variant: isResponse ? "parsed" : "original",

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -268,6 +268,20 @@ export const delegate: Depicter = (schema, ctx) =>
         delete jsonSchema.required;
       }
       // on each
+      const shouldAvoidParsing =
+        zodSchema._zod.def.type === "lazy" ||
+        zodSchema._zod.def.type === "promise";
+      const hasTypePropertyInDepiction = jsonSchema.type !== undefined;
+      const isActuallyNullable =
+        !ctx.isResponse &&
+        !shouldAvoidParsing &&
+        hasTypePropertyInDepiction &&
+        (zodSchema as z.ZodType).isNullable(); // @todo remove "as"
+      if (isActuallyNullable) {
+        Object.assign(jsonSchema, {
+          type: makeNullableType(jsonSchema as SchemaObject), // @todo remove "as"
+        });
+      }
       const examples = getExamples({
         schema: zodSchema as z.ZodType, // @todo remove "as"
         variant: ctx.isResponse ? "parsed" : "original",

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -367,11 +367,6 @@ export const depictNumber: Depicter = (
   return result;
 };
 
-export const depictObjectProperties = (
-  { _zod: { def } }: $ZodObject,
-  next: Parameters<Depicter>[1]["next"],
-) => R.map(next, def.shape);
-
 const makeSample = (depicted: SchemaObject) => {
   const firstType = (
     Array.isArray(depicted.type) ? depicted.type[0] : depicted.type

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -59,7 +59,7 @@ export interface OpenAPIContext extends FlatObject {
     subject: SchemaObject | ReferenceObject,
     name?: string,
   ) => ReferenceObject;
-  brandHandling: Record<string | symbol, Depicter>;
+  brandHandling?: Record<string | symbol, Depicter>;
   path: string;
   method: Method;
 }
@@ -251,7 +251,7 @@ export const delegate: Depicter = (schema, ctx) => {
         delete jsonSchema.required;
       }
       // custom brands handling
-      if (brand && ctx.brandHandling[brand]) {
+      if (brand && ctx.brandHandling && ctx.brandHandling[brand]) {
         for (const key in jsonSchema) delete jsonSchema[key]; // undo default
         Object.assign(jsonSchema, ctx.brandHandling[brand](zodSchema, ctx));
       }

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -177,6 +177,7 @@ const onIntersection: Depicter = ({}, { jsonSchema }) => {
   Object.assign(jsonSchema, attempt);
 };
 
+/** @since OAS 3.1 nullable replaced with type array having null */
 const onNullable: Depicter = ({}, { jsonSchema }) => {
   if (!jsonSchema.oneOf) return;
   const original = jsonSchema.oneOf[0];
@@ -244,8 +245,13 @@ const onDateOut: Depicter = ({}, ctx) => {
 const onBigInt: Depicter = ({}, { jsonSchema }) =>
   Object.assign(jsonSchema, { type: "integer", format: "bigint" });
 
+/**
+ * @since OAS 3.1 using prefixItems for depicting tuples
+ * @since 17.5.0 added rest handling, fixed tuple type
+ */
 const onTuple: Depicter = (zodSchema, { jsonSchema }) => {
   if ((zodSchema as $ZodTuple)._zod.def.rest !== null) return;
+  // does not appear to support items:false, so not:{} is a recommended alias
   jsonSchema.items = { not: {} };
 };
 

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -117,7 +117,7 @@ export const delegate: Depicter = (schema, ctx) =>
   z.toJSONSchema(schema, {
     unrepresentable: "any",
     metadata: globalRegistry,
-    pipes: ctx.isResponse ? "output" : "input",
+    io: ctx.isResponse ? "output" : "input",
     override: ({ zodSchema, jsonSchema }) => {
       const brand = globalRegistry.get(zodSchema)?.[metaSymbol]?.brand;
       if (zodSchema._zod.def.type === "nullable") {

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -64,7 +64,7 @@ interface DocumentationParams {
    * @desc Handling rules for your own branded schemas.
    * @desc Keys: brands (recommended to use unique symbols).
    * @desc Values: functions having schema as first argument that you should assign type to, second one is a context.
-   * @example { MyBrand: ( schema: typeof myBrandSchema, { next } ) => ({ type: "object" })
+   * @example { MyBrand: ( schema: typeof myBrandSchema, ctx ) => ({ type: "object" })
    */
   brandHandling?: OpenAPIContext["brandHandling"];
   /**

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -64,7 +64,7 @@ interface DocumentationParams {
    * @desc Handling rules for your own branded schemas.
    * @desc Keys: brands (recommended to use unique symbols).
    * @desc Values: functions having schema as first argument that you should assign type to, second one is a context.
-   * @example { MyBrand: ( schema: typeof myBrandSchema, ctx ) => ({ type: "object" })
+   * @example { MyBrand: ( schema: typeof myBrandSchema, { jsonSchema } ) => ({ type: "object" })
    */
   brandHandling?: OpenAPIContext["brandHandling"];
   /**
@@ -136,7 +136,7 @@ export class Documentation extends OpenApiBuilder {
     descriptions,
     tags,
     isHeader,
-    brandHandling = {},
+    brandHandling,
     hasSummaryFromDescription = true,
     composition = "inline",
   }: DocumentationParams) {

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -85,11 +85,17 @@ interface DocumentationParams {
 export class Documentation extends OpenApiBuilder {
   readonly #lastSecuritySchemaIds = new Map<SecuritySchemeType, number>();
   readonly #lastOperationIdSuffixes = new Map<string, number>();
+  readonly #references = new Map<object, string>();
 
   #makeRef(
+    key: object,
     subject: SchemaObject | ReferenceObject,
-    name = `Schema${Object.keys(this.rootDoc.components?.schemas || {}).length + 1}`,
+    name = this.#references.get(key),
   ): ReferenceObject {
+    if (!name) {
+      name = `Schema${Object.keys(this.rootDoc.components?.schemas || {}).length + 1}`;
+      this.#references.set(key, name);
+    }
     this.addSchema(name, subject);
     return { $ref: `#/components/schemas/${name}` };
   }

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -135,9 +135,9 @@ export class Documentation extends OpenApiBuilder {
     version,
     serverUrl,
     descriptions,
-    brandHandling,
     tags,
     isHeader,
+    brandHandling = {},
     hasSummaryFromDescription = true,
     composition = "inline",
   }: DocumentationParams) {

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -28,7 +28,6 @@ import {
   reformatParamsInPath,
   IsHeader,
   nonEmpty,
-  NumericRange,
 } from "./documentation-helpers";
 import { Routing } from "./routing";
 import { OnEndpoint, walkRouting } from "./routing-walker";
@@ -61,12 +60,6 @@ interface DocumentationParams {
   descriptions?: Partial<Record<Component, Descriptor>>;
   /** @default true */
   hasSummaryFromDescription?: boolean;
-  /**
-   * @desc Acceptable limits of z.number() that API can handle (default: the limits of JavaScript engine)
-   * @default {integer:[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER], float:[-Number.MAX_VALUE, Number.MAX_VALUE]}
-   * @example null — to disable the feature
-   * @see depictNumber */
-  numericRange?: NumericRange | null;
   /** @default inline */
   composition?: "inline" | "components";
   /**
@@ -156,7 +149,6 @@ export class Documentation extends OpenApiBuilder {
     brandHandling,
     tags,
     isHeader,
-    numericRange,
     hasSummaryFromDescription = true,
     composition = "inline",
   }: DocumentationParams) {
@@ -171,7 +163,6 @@ export class Documentation extends OpenApiBuilder {
         endpoint,
         composition,
         brandHandling,
-        numericRange,
         makeRef: this.#makeRef.bind(this),
       };
       const { description, shortDescription, scopes, inputSchema } = endpoint;

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -16,7 +16,6 @@ import { CommonConfig } from "./config-type";
 import { processContainers } from "./logical-container";
 import { Method } from "./method";
 import {
-  OpenAPIContext,
   depictBody,
   depictRequestParams,
   depictResponse,
@@ -27,6 +26,7 @@ import {
   reformatParamsInPath,
   IsHeader,
   nonEmpty,
+  BrandHandling,
 } from "./documentation-helpers";
 import { Routing } from "./routing";
 import { OnEndpoint, walkRouting } from "./routing-walker";
@@ -66,7 +66,7 @@ interface DocumentationParams {
    * @desc Values: functions having schema as first argument that you should assign type to, second one is a context.
    * @example { MyBrand: ( schema: typeof myBrandSchema, { jsonSchema } ) => ({ type: "object" })
    */
-  brandHandling?: OpenAPIContext["brandHandling"];
+  brandHandling?: BrandHandling;
   /**
    * @desc Ability to configure recognition of headers among other input data
    * @desc Only applicable when "headers" is present within inputSources config option

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -1,4 +1,3 @@
-import type { $ZodType } from "@zod/core";
 import {
   OpenApiBuilder,
   OperationObject,
@@ -87,22 +86,12 @@ interface DocumentationParams {
 export class Documentation extends OpenApiBuilder {
   readonly #lastSecuritySchemaIds = new Map<SecuritySchemeType, number>();
   readonly #lastOperationIdSuffixes = new Map<string, number>();
-  readonly #references = new Map<$ZodType | (() => $ZodType), string>();
 
   #makeRef(
-    schema: $ZodType | (() => $ZodType),
-    subject:
-      | SchemaObject
-      | ReferenceObject
-      | (() => SchemaObject | ReferenceObject),
-    name = this.#references.get(schema),
+    subject: SchemaObject | ReferenceObject,
+    name = `Schema${Object.keys(this.rootDoc.components?.schemas || {}).length + 1}`,
   ): ReferenceObject {
-    if (!name) {
-      name = `Schema${this.#references.size + 1}`;
-      this.#references.set(schema, name);
-      if (typeof subject === "function") subject = subject();
-    }
-    if (typeof subject === "object") this.addSchema(name, subject);
+    this.addSchema(name, subject);
     return { $ref: `#/components/schemas/${name}` };
   }
 

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -30,7 +30,6 @@ import {
 } from "./documentation-helpers";
 import { Routing } from "./routing";
 import { OnEndpoint, walkRouting } from "./routing-walker";
-import { HandlingRules } from "./schema-walker";
 
 type Component =
   | "positiveResponse"
@@ -67,7 +66,7 @@ interface DocumentationParams {
    * @desc Values: functions having schema as first argument that you should assign type to, second one is a context.
    * @example { MyBrand: ( schema: typeof myBrandSchema, { next } ) => ({ type: "object" })
    */
-  brandHandling?: HandlingRules<SchemaObject | ReferenceObject, OpenAPIContext>;
+  brandHandling?: OpenAPIContext["brandHandling"];
   /**
    * @desc Ability to configure recognition of headers among other input data
    * @desc Only applicable when "headers" is present within inputSources config option

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -33,7 +33,7 @@ export { EventStreamFactory } from "./sse";
 export { ez } from "./proprietary-schemas";
 
 // Convenience types
-export type { Depicter } from "./documentation-helpers";
+export type { Overrider } from "./documentation-helpers";
 export type { Producer } from "./zts-helpers";
 
 // Interfaces exposed for augmentation

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -463,17 +463,12 @@ exports[`Documentation helpers > depictLiteral() > should set type and involve c
 
 exports[`Documentation helpers > depictLiteral() > should set type and involve const property 2 1`] = `
 {
-  "const": 123n,
+  "const": 123,
   "type": "integer",
 }
 `;
 
-exports[`Documentation helpers > depictLiteral() > should set type and involve const property 3 1`] = `
-{
-  "const": undefined,
-  "type": undefined,
-}
-`;
+exports[`Documentation helpers > depictLiteral() > should set type and involve const property 3 1`] = `{}`;
 
 exports[`Documentation helpers > depictNull() > should give type:null 1`] = `
 {

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -684,13 +684,13 @@ exports[`Documentation helpers > depictPipeline > should depict as 'string (prep
 }
 `;
 
-exports[`Documentation helpers > depictPipeline > should handle edge cases 1`] = `
+exports[`Documentation helpers > depictPipeline > should handle edge cases 0 1`] = `
 {
   "format": "any",
 }
 `;
 
-exports[`Documentation helpers > depictPipeline > should handle edge cases 2`] = `
+exports[`Documentation helpers > depictPipeline > should handle edge cases 1 1`] = `
 {
   "format": "any",
 }

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -764,7 +764,7 @@ exports[`Documentation helpers > depictRecord() > should set properties+required
     "type": "boolean",
   },
   "propertyNames": {
-    "oneOf": [
+    "anyOf": [
       {
         "const": "one",
         "type": "string",
@@ -1336,10 +1336,7 @@ exports[`Documentation helpers > depictTuple() > should utilize prefixItems and 
 
 exports[`Documentation helpers > depictUnion() > should wrap next depicters in oneOf prop and set discriminator prop 1`] = `
 {
-  "discriminator": {
-    "propertyName": "status",
-  },
-  "oneOf": [
+  "anyOf": [
     {
       "properties": {
         "data": {
@@ -1381,12 +1378,15 @@ exports[`Documentation helpers > depictUnion() > should wrap next depicters in o
       "type": "object",
     },
   ],
+  "discriminator": {
+    "propertyName": "status",
+  },
 }
 `;
 
 exports[`Documentation helpers > depictUnion() > should wrap next depicters into oneOf property 1`] = `
 {
-  "oneOf": [
+  "anyOf": [
     {
       "type": "string",
     },
@@ -1471,7 +1471,7 @@ exports[`Documentation helpers > excludeParamsFromDepiction() > should omit spec
 
 exports[`Documentation helpers > excludeParamsFromDepiction() > should omit specified params 1 1`] = `
 {
-  "oneOf": [
+  "anyOf": [
     {
       "properties": {},
       "required": [],

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -707,7 +707,10 @@ exports[`Documentation helpers > depictObject() > should type:object, properties
       "type": "number",
     },
     "b": {
-      "type": "string",
+      "type": [
+        "string",
+        "null",
+      ],
     },
   },
   "required": [
@@ -1506,7 +1509,10 @@ exports[`Documentation helpers > depictWrapped() > handle readonly 1`] = `
 exports[`Documentation helpers > depictWrapped() > should handle catch 1`] = `
 {
   "default": true,
-  "type": "boolean",
+  "type": [
+    "boolean",
+    "null",
+  ],
 }
 `;
 

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -217,7 +217,9 @@ exports[`Documentation helpers > depictFile() > should set type:string and forma
 
 exports[`Documentation helpers > depictFile() > should set type:string and format accordingly 2 1`] = `
 {
+  "contentEncoding": "base64",
   "format": "byte",
+  "pattern": "^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$",
   "type": "string",
 }
 `;

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -80,20 +80,6 @@ exports[`Documentation helpers > depictBoolean() > should set type:boolean 1`] =
 }
 `;
 
-exports[`Documentation helpers > depictDate > should throw clear error 0 1`] = `
-DocumentationError({
-  "cause": "Response schema of an Endpoint assigned to GET method of /v1/user/:id path.",
-  "message": "Using z.date() within output schema is forbidden. Please use ez.dateOut() instead. Check out the documentation for details.",
-})
-`;
-
-exports[`Documentation helpers > depictDate > should throw clear error 1 1`] = `
-DocumentationError({
-  "cause": "Input schema of an Endpoint assigned to GET method of /v1/user/:id path.",
-  "message": "Using z.date() within input schema is forbidden. Please use ez.dateIn() instead. Check out the documentation for details.",
-})
-`;
-
 exports[`Documentation helpers > depictDateIn > should set type:string, pattern and format 1`] = `
 {
   "description": "YYYY-MM-DDTHH:mm:ss.sssZ",
@@ -418,24 +404,6 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
 }
 `;
 
-exports[`Documentation helpers > depictLazy > should handle circular references 0 1`] = `
-{
-  "$ref": "#/components/schemas/SomeSchema",
-}
-`;
-
-exports[`Documentation helpers > depictLazy > should handle circular references 1 1`] = `
-{
-  "$ref": "#/components/schemas/SomeSchema",
-}
-`;
-
-exports[`Documentation helpers > depictLazy > should handle circular references 2 1`] = `
-{
-  "$ref": "#/components/schemas/SomeSchema",
-}
-`;
-
 exports[`Documentation helpers > depictLiteral() > should handle multiple values 1`] = `
 {
   "enum": [
@@ -509,24 +477,6 @@ exports[`Documentation helpers > depictNullable() > should not add null type whe
 }
 `;
 
-exports[`Documentation helpers > depictNumber() > should not use numericRange when it is null 0 1`] = `
-{
-  "format": "double",
-  "maximum": undefined,
-  "minimum": undefined,
-  "type": "number",
-}
-`;
-
-exports[`Documentation helpers > depictNumber() > should not use numericRange when it is null 1 1`] = `
-{
-  "format": "int64",
-  "maximum": undefined,
-  "minimum": undefined,
-  "type": "integer",
-}
-`;
-
 exports[`Documentation helpers > depictNumber() > should set min/max values according to JS capabilities 0 1`] = `
 {
   "type": "number",
@@ -546,33 +496,6 @@ exports[`Documentation helpers > depictNumber() > should set min/max values acco
   "exclusiveMaximum": 1.7976931348623157e+308,
   "exclusiveMinimum": -1.7976931348623157e+308,
   "type": "number",
-}
-`;
-
-exports[`Documentation helpers > depictNumber() > should set min/max values according to JS capabilities 3 1`] = `
-{
-  "format": "hacked",
-  "maximum": 1.7976931348623157e+308,
-  "minimum": -1.7976931348623157e+308,
-  "type": "number",
-}
-`;
-
-exports[`Documentation helpers > depictNumber() > should use numericRange when set 0 1`] = `
-{
-  "format": "double",
-  "maximum": 333.3333333333333,
-  "minimum": -333.3333333333333,
-  "type": "number",
-}
-`;
-
-exports[`Documentation helpers > depictNumber() > should use numericRange when set 1 1`] = `
-{
-  "format": "int64",
-  "maximum": 100,
-  "minimum": -100,
-  "type": "integer",
 }
 `;
 
@@ -717,17 +640,6 @@ exports[`Documentation helpers > depictObject() > should type:object, properties
     "b",
   ],
   "type": "object",
-}
-`;
-
-exports[`Documentation helpers > depictObjectProperties() > should wrap next depicters in a shape of object 1`] = `
-{
-  "one": {
-    "type": "string",
-  },
-  "two": {
-    "type": "boolean",
-  },
 }
 `;
 

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -532,27 +532,22 @@ exports[`Documentation helpers > depictNumber() > should not use numericRange wh
 
 exports[`Documentation helpers > depictNumber() > should set min/max values according to JS capabilities 0 1`] = `
 {
-  "format": "double",
-  "maximum": 1.7976931348623157e+308,
-  "minimum": -1.7976931348623157e+308,
   "type": "number",
 }
 `;
 
 exports[`Documentation helpers > depictNumber() > should set min/max values according to JS capabilities 1 1`] = `
 {
-  "format": "int64",
-  "maximum": 9007199254740991,
-  "minimum": -9007199254740991,
+  "exclusiveMaximum": 9007199254740991,
+  "exclusiveMinimum": -9007199254740991,
   "type": "integer",
 }
 `;
 
 exports[`Documentation helpers > depictNumber() > should set min/max values according to JS capabilities 2 1`] = `
 {
-  "format": "double",
-  "maximum": 1.7976931348623157e+308,
-  "minimum": -1.7976931348623157e+308,
+  "exclusiveMaximum": 1.7976931348623157e+308,
+  "exclusiveMinimum": -1.7976931348623157e+308,
   "type": "number",
 }
 `;
@@ -586,7 +581,6 @@ exports[`Documentation helpers > depictNumber() > should use numericRange when s
 
 exports[`Documentation helpers > depictNumber() > should use schema checks for min/max and exclusiveness 0 1`] = `
 {
-  "format": "double",
   "maximum": 33.333333333333336,
   "minimum": -33.333333333333336,
   "type": "number",
@@ -595,7 +589,6 @@ exports[`Documentation helpers > depictNumber() > should use schema checks for m
 
 exports[`Documentation helpers > depictNumber() > should use schema checks for min/max and exclusiveness 1 1`] = `
 {
-  "format": "int64",
   "maximum": 100,
   "minimum": -100,
   "type": "integer",
@@ -606,7 +599,6 @@ exports[`Documentation helpers > depictNumber() > should use schema checks for m
 {
   "exclusiveMaximum": 16.666666666666668,
   "exclusiveMinimum": -16.666666666666668,
-  "format": "double",
   "type": "number",
 }
 `;
@@ -615,7 +607,6 @@ exports[`Documentation helpers > depictNumber() > should use schema checks for m
 {
   "exclusiveMaximum": 100,
   "exclusiveMinimum": -100,
-  "format": "int64",
   "type": "integer",
 }
 `;

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1286,21 +1286,13 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       zodExample:
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                          subcategories:
-                            $ref: "#/components/schemas/Schema1"
-                        required:
-                          - name
-                          - subcategories
+                        $ref: "#/components/schemas/__schema0"
                     required:
                       - zodExample
                 required:
@@ -1314,8 +1306,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -1334,18 +1326,18 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    Schema1:
-      type: array
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-          subcategories:
-            $ref: "#/components/schemas/Schema1"
-        required:
-          - name
-          - subcategories
+    __schema0:
+      type: object
+      properties:
+        name:
+          type: string
+        subcategories:
+          type: array
+          items:
+            $ref: "#/components/schemas/__schema0"
+      required:
+        - name
+        - subcategories
   responses: {}
   parameters: {}
   examples: {}

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1415,49 +1415,30 @@ paths:
               properties:
                 double:
                   type: number
-                  format: double
-                  minimum: -1.7976931348623157e+308
-                  maximum: 1.7976931348623157e+308
                 doublePositive:
                   type: number
-                  format: double
-                  exclusiveMinimum: 0
-                  maximum: 1.7976931348623157e+308
                 doubleNegative:
                   type: number
-                  format: double
-                  minimum: -1.7976931348623157e+308
-                  exclusiveMaximum: 0
                 doubleLimited:
                   type: number
-                  format: double
                   minimum: -0.5
                   maximum: 0.5
                 int:
                   type: integer
-                  format: int64
-                  minimum: -9007199254740991
-                  maximum: 9007199254740991
+                  exclusiveMinimum: -9007199254740991
+                  exclusiveMaximum: 9007199254740991
                 intPositive:
                   type: integer
-                  format: int64
-                  exclusiveMinimum: 0
-                  maximum: 9007199254740991
+                  exclusiveMaximum: 9007199254740991
                 intNegative:
                   type: integer
-                  format: int64
-                  minimum: -9007199254740991
-                  exclusiveMaximum: 0
+                  exclusiveMinimum: -9007199254740991
                 intLimited:
                   type: integer
-                  format: int64
                   minimum: -100
                   maximum: 100
                 zero:
                   type: integer
-                  format: int64
-                  minimum: 0
-                  maximum: 0
               required:
                 - double
                 - doublePositive
@@ -1477,8 +1458,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -1498,8 +1479,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -1714,8 +1695,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -1737,8 +1718,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2030,9 +2011,7 @@ paths:
                     - type: boolean
                     - type: string
                     - type: integer
-                      format: int64
-                      exclusiveMinimum: 0
-                      maximum: 9007199254740991
+                      exclusiveMaximum: 9007199254740991
                   items:
                     not: {}
               required:
@@ -2049,8 +2028,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2072,8 +2051,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2131,13 +2110,15 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       any:
                         format: any
+                    required:
+                      - any
                 required:
                   - status
                   - data
@@ -2149,8 +2130,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1271,15 +1271,8 @@ paths:
           application/json:
             schema:
               type: object
-              properties:
-                name:
-                  type: string
-                subcategories:
-                  $ref: "#/components/schemas/Schema1"
-              required:
-                - name
-                - subcategories
-        required: true
+              properties: {}
+              required: []
       responses:
         "200":
           description: POST /v1/getSomething Positive response

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -729,7 +729,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              anyOf:
                 - type: object
                   properties:
                     type:
@@ -765,7 +765,7 @@ paths:
                     const: success
                     type: string
                   data:
-                    oneOf:
+                    anyOf:
                       - type: object
                         properties:
                           status:
@@ -1062,7 +1062,7 @@ paths:
               type: object
               properties:
                 union:
-                  oneOf:
+                  anyOf:
                     - type: object
                       properties:
                         one:
@@ -1101,7 +1101,7 @@ paths:
                     type: object
                     properties:
                       or:
-                        oneOf:
+                        anyOf:
                           - type: string
                           - type: integer
                             exclusiveMaximum: 9007199254740991
@@ -1824,7 +1824,7 @@ paths:
                       union:
                         type: object
                         propertyNames:
-                          oneOf:
+                          anyOf:
                             - const: option1
                               type: string
                             - const: option2
@@ -3037,7 +3037,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              anyOf:
                 - type: object
                   properties:
                     id:
@@ -3069,7 +3069,7 @@ paths:
                     const: success
                     type: string
                   data:
-                    oneOf:
+                    anyOf:
                       - type: object
                         properties:
                           id:
@@ -3876,7 +3876,7 @@ paths:
           required: true
           description: parameter of post /v1/:name
           schema:
-            oneOf:
+            anyOf:
               - const: John
                 type: string
               - const: Jane
@@ -3998,7 +3998,7 @@ paths:
 components:
   schemas:
     ParameterOfPostV1NameName:
-      oneOf:
+      anyOf:
         - const: John
           type: string
         - const: Jane
@@ -4068,7 +4068,7 @@ paths:
           required: true
           description: GET /v1/:name Parameter
           schema:
-            oneOf:
+            anyOf:
               - const: John
                 type: string
               - const: Jane
@@ -4154,7 +4154,7 @@ paths:
           required: true
           description: POST /v1/:name Parameter
           schema:
-            oneOf:
+            anyOf:
               - const: John
                 type: string
               - const: Jane

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1288,7 +1288,7 @@ paths:
                     type: object
                     properties:
                       zodExample:
-                        $ref: "#/components/schemas/__schema0"
+                        $ref: "#/components/schemas/Schema1"
                     required:
                       - zodExample
                 required:
@@ -1322,7 +1322,7 @@ paths:
                       message: Sample error message
 components:
   schemas:
-    __schema0:
+    Schema1:
       type: object
       properties:
         name:
@@ -1330,7 +1330,7 @@ components:
         subcategories:
           type: array
           items:
-            $ref: "#/components/schemas/__schema0"
+            $ref: "#/components/schemas/Schema1"
       required:
         - name
         - subcategories

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -2389,8 +2389,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2409,8 +2409,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1786,6 +1786,8 @@ paths:
           application/json:
             schema:
               type: object
+              properties: {}
+              required: []
       responses:
         "200":
           description: POST /v1/getSomething Positive response
@@ -1795,8 +1797,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -1806,9 +1808,8 @@ paths:
                           type: string
                         additionalProperties:
                           type: integer
-                          format: int64
-                          minimum: -9007199254740991
-                          maximum: 9007199254740991
+                          exclusiveMinimum: -9007199254740991
+                          exclusiveMaximum: 9007199254740991
                       stringy:
                         type: object
                         propertyNames:
@@ -1821,38 +1822,36 @@ paths:
                         type: object
                         propertyNames:
                           type: integer
-                          format: int64
-                          minimum: -9007199254740991
-                          maximum: 9007199254740991
+                          exclusiveMinimum: -9007199254740991
+                          exclusiveMaximum: 9007199254740991
                         additionalProperties:
                           type: boolean
                       literal:
                         type: object
-                        properties:
-                          only:
-                            type: boolean
-                        required:
-                          - only
+                        propertyNames:
+                          const: only
+                          type: string
+                        additionalProperties:
+                          type: boolean
                       union:
                         type: object
-                        properties:
-                          option1:
-                            type: boolean
-                          option2:
-                            type: boolean
-                        required:
-                          - option1
-                          - option2
+                        propertyNames:
+                          oneOf:
+                            - const: option1
+                              type: string
+                            - const: option2
+                              type: string
+                        additionalProperties:
+                          type: boolean
                       enum:
                         type: object
-                        properties:
-                          option1:
-                            type: boolean
-                          option2:
-                            type: boolean
-                        required:
-                          - option1
-                          - option2
+                        propertyNames:
+                          enum:
+                            - option1
+                            - option2
+                          type: string
+                        additionalProperties:
+                          type: boolean
                     required:
                       - simple
                       - stringy
@@ -1871,8 +1870,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3161,8 +3160,8 @@ paths:
           required: true
           description: GET /v1/getSomething Parameter
           schema:
-            type: string
             deprecated: true
+            type: string
       responses:
         "200":
           description: GET /v1/getSomething Positive response

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -2656,10 +2656,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -2671,8 +2673,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2744,10 +2746,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -2759,8 +2763,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2830,10 +2834,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -2845,8 +2851,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2894,10 +2900,10 @@ paths:
           required: true
           description: GET /v1/getSomething Parameter
           schema:
+            minItems: 1
             type: array
             items:
               type: string
-            minItems: 1
       responses:
         "200":
           description: GET /v1/getSomething Positive response
@@ -2907,16 +2913,16 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       arr:
+                        minItems: 1
                         type: array
                         items:
                           type: string
-                        minItems: 1
                     required:
                       - arr
                 required:
@@ -2930,8 +2936,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2958,10 +2964,10 @@ paths:
               type: object
               properties:
                 arr:
+                  minItems: 1
                   type: array
                   items:
                     type: string
-                  minItems: 1
               required:
                 - arr
         required: true
@@ -2974,16 +2980,16 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       arr:
+                        minItems: 1
                         type: array
                         items:
                           type: string
-                        minItems: 1
                     required:
                       - arr
                 required:
@@ -2997,8 +3003,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3074,8 +3080,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     oneOf:
                       - type: object
@@ -3107,8 +3113,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3887,7 +3893,9 @@ paths:
           schema:
             oneOf:
               - const: John
+                type: string
               - const: Jane
+                type: string
       requestBody:
         description: the body of request
         content:
@@ -3909,10 +3917,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -3924,8 +3934,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -4005,15 +4015,19 @@ components:
     ParameterOfPostV1NameName:
       oneOf:
         - const: John
+          type: string
         - const: Jane
+          type: string
     SuperPositiveResponseOfV1Name:
       type: object
       properties:
         status:
-          type: string
           const: success
+          type: string
         data:
           type: object
+          properties: {}
+          required: []
       required:
         - status
         - data
@@ -4021,8 +4035,8 @@ components:
       type: object
       properties:
         status:
-          type: string
           const: error
+          type: string
         error:
           type: object
           properties:
@@ -4071,7 +4085,9 @@ paths:
           schema:
             oneOf:
               - const: John
+                type: string
               - const: Jane
+                type: string
         - name: other
           in: query
           required: true
@@ -4087,10 +4103,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -4102,8 +4120,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -4153,7 +4171,9 @@ paths:
           schema:
             oneOf:
               - const: John
+                type: string
               - const: Jane
+                type: string
       requestBody:
         description: POST /v1/:name Request body
         content:
@@ -4175,10 +4195,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -4190,8 +4212,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1156,6 +1156,7 @@ paths:
                   format: bigint
                 boolean:
                   type: boolean
+                  readOnly: true
                 dateIn:
                   description: YYYY-MM-DDTHH:mm:ss.sssZ
                   type: string
@@ -1177,17 +1178,17 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       "null":
                         type: "null"
                       dateOut:
+                        format: date-time
                         description: YYYY-MM-DDTHH:mm:ss.sssZ
                         type: string
-                        format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                     required:
@@ -1204,8 +1205,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -1924,9 +1925,7 @@ paths:
                   type: string
                 two:
                   type: integer
-                  format: int64
-                  exclusiveMinimum: 0
-                  maximum: 9007199254740991
+                  exclusiveMaximum: 9007199254740991
               required:
                 - one
                 - two
@@ -1940,8 +1939,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -1960,8 +1959,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1203,9 +1203,9 @@ paths:
                       "null":
                         type: "null"
                       dateOut:
-                        format: date-time
                         description: YYYY-MM-DDTHH:mm:ss.sssZ
                         type: string
+                        format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                     required:
@@ -2363,12 +2363,14 @@ paths:
           required: true
           description: GET /v1/:name Parameter
           schema:
+            type: string
             summary: My custom schema
         - name: other
           in: query
           required: true
           description: GET /v1/:name Parameter
           schema:
+            type: boolean
             summary: My custom schema
         - name: regular
           in: query
@@ -2391,6 +2393,7 @@ paths:
                     type: object
                     properties:
                       number:
+                        type: number
                         summary: My custom schema
                     required:
                       - number

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1270,9 +1270,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties: {}
-              required: []
+              $ref: "#/components/schemas/Schema2"
       responses:
         "200":
           description: POST /v1/getSomething Positive response
@@ -1331,6 +1329,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Schema1"
+      required:
+        - name
+        - subcategories
+    Schema2:
+      type: object
+      properties:
+        name:
+          type: string
+        subcategories:
+          type: array
+          items:
+            $ref: "#/components/schemas/Schema2"
       required:
         - name
         - subcategories

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -20,10 +20,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -35,8 +37,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -89,10 +91,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -104,8 +108,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -132,6 +136,8 @@ paths:
           application/json:
             schema:
               type: object
+              properties: {}
+              required: []
       responses:
         "200":
           description: POST /v1/getSome/thing Positive response
@@ -141,10 +147,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -156,8 +164,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -210,10 +218,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -225,8 +235,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -257,10 +267,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -272,8 +284,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -340,16 +352,13 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       num:
                         type: number
-                        format: double
-                        minimum: -1.7976931348623157e+308
-                        maximum: 1.7976931348623157e+308
                     required:
                       - num
                 required:
@@ -363,8 +372,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -390,6 +399,8 @@ paths:
           application/json:
             schema:
               type: object
+              properties: {}
+              required: []
       security:
         - HTTP_1: []
           OAUTH2_1:
@@ -403,10 +414,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -418,8 +431,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -445,6 +458,8 @@ paths:
           application/json:
             schema:
               type: object
+              properties: {}
+              required: []
       security:
         - HTTP_2: []
       responses:
@@ -456,10 +471,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -471,8 +488,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -1361,10 +1378,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: OK
+                    type: string
                   result:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - result
@@ -1377,8 +1396,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: NOT OK
+                    type: string
                 required:
                   - status
 components:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -611,14 +611,12 @@ paths:
           required: true
           description: GET /v1/getSomething Parameter
           schema:
+            minItems: 1
+            maxItems: 3
             type: array
             items:
               type: integer
-              format: int64
-              exclusiveMinimum: 0
-              maximum: 9007199254740991
-            minItems: 1
-            maxItems: 3
+              exclusiveMaximum: 9007199254740991
         - name: unlimited
           in: query
           required: true

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -2288,9 +2288,6 @@ paths:
               properties:
                 test:
                   type: number
-                  format: double
-                  minimum: -1.7976931348623157e+308
-                  maximum: 1.7976931348623157e+308
               required:
                 - test
         required: true
@@ -2303,8 +2300,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: ok
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2323,8 +2320,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: kinda
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2340,15 +2337,15 @@ paths:
           content:
             application/json:
               schema:
-                type: string
                 const: error
+                type: string
         "500":
           description: POST /v1/mtpl Negative response 500
           content:
             application/json:
               schema:
-                type: string
                 const: failure
+                type: string
 components:
   schemas: {}
   responses: {}
@@ -2492,8 +2489,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2512,8 +2509,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -2571,8 +2568,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -2591,8 +2588,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3175,10 +3172,12 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
+                    properties: {}
+                    required: []
                 required:
                   - status
                   - data
@@ -3190,8 +3189,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3258,8 +3257,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -3299,8 +3298,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3379,10 +3378,12 @@ components:
       type: object
       properties:
         status:
-          type: string
           const: success
+          type: string
         data:
           type: object
+          properties: {}
+          required: []
       required:
         - status
         - data
@@ -3390,8 +3391,8 @@ components:
       type: object
       properties:
         status:
-          type: string
           const: error
+          type: string
         error:
           type: object
           properties:
@@ -3449,16 +3450,13 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       num:
                         type: number
-                        format: double
-                        minimum: -1.7976931348623157e+308
-                        maximum: 1.7976931348623157e+308
                     required:
                       - num
                     examples:
@@ -3480,8 +3478,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3542,8 +3540,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -3570,8 +3568,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3638,8 +3636,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -3666,8 +3664,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3730,8 +3728,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
@@ -3758,8 +3756,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:
@@ -3818,17 +3816,15 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: success
+                    type: string
                   data:
                     type: object
                     properties:
                       result:
-                        type: integer
-                        format: int64
-                        exclusiveMinimum: 0
-                        maximum: 9007199254740991
                         description: some positive integer
+                        type: integer
+                        exclusiveMaximum: 9007199254740991
                     required:
                       - result
                 required:
@@ -3842,8 +3838,8 @@ paths:
                 type: object
                 properties:
                   status:
-                    type: string
                     const: error
+                    type: string
                   error:
                     type: object
                     properties:

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -17,6 +17,11 @@ import {
   delegate,
 } from "../src/documentation-helpers";
 
+/**
+ * @todo all these functions is now the one, and the tests naming is not relevant anymore
+ * @todo these tests should now be transformed into ones of particular postprocessors and assert exactly what they do.
+ * @todo So we would not test Zod here, but internal methods only.
+ */
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();
   const requestCtx = {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -489,7 +489,7 @@ describe("Documentation helpers", () => {
     test.each([
       z.number().transform((num) => () => num),
       z.number().transform(() => assert.fail("this should be handled")),
-    ])("should handle edge cases", (schema) => {
+    ])("should handle edge cases %#", (schema) => {
       expect(delegate(schema, responseCtx)).toMatchSnapshot();
     });
   });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -5,8 +5,6 @@ import { z } from "zod";
 import { ez } from "../src";
 import {
   OpenAPIContext,
-  depictDateIn,
-  depictDateOut,
   depictExamples,
   depictFile,
   depictParamExamples,
@@ -670,22 +668,22 @@ describe("Documentation helpers", () => {
 
   describe("depictDateIn", () => {
     test("should set type:string, pattern and format", () => {
-      expect(depictDateIn(ez.dateIn(), requestCtx)).toMatchSnapshot();
+      expect(delegate(ez.dateIn(), requestCtx)).toMatchSnapshot();
     });
     test("should throw when ZodDateIn in response", () => {
       expect(() =>
-        depictDateIn(ez.dateIn(), responseCtx),
+        delegate(ez.dateIn(), responseCtx),
       ).toThrowErrorMatchingSnapshot();
     });
   });
 
   describe("depictDateOut", () => {
     test("should set type:string, description and format", () => {
-      expect(depictDateOut(ez.dateOut(), responseCtx)).toMatchSnapshot();
+      expect(delegate(ez.dateOut(), responseCtx)).toMatchSnapshot();
     });
     test("should throw when ZodDateOut in request", () => {
       expect(() =>
-        depictDateOut(ez.dateOut(), requestCtx),
+        delegate(ez.dateOut(), requestCtx),
       ).toThrowErrorMatchingSnapshot();
     });
   });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -688,15 +688,6 @@ describe("Documentation helpers", () => {
     });
   });
 
-  describe("depictDate", () => {
-    test.each([responseCtx, requestCtx])(
-      "should throw clear error %#",
-      (ctx) => {
-        expect(() => delegate(z.date(), ctx)).toThrowErrorMatchingSnapshot();
-      },
-    );
-  });
-
   describe("depictLazy", () => {
     const recursiveArray: z.ZodLazy = z.lazy(() => recursiveArray.array());
     const directlyRecursive: z.ZodLazy = z.lazy(() => directlyRecursive);

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -6,13 +6,11 @@ import { ez } from "../src";
 import {
   OpenAPIContext,
   depictExamples,
-  depictFile,
   depictParamExamples,
   depictRequestParams,
   depictSecurity,
   depictSecurityRefs,
   depictTags,
-  depictRaw,
   depicters,
   ensureShortDescription,
   excludeExamplesFromDepiction,
@@ -142,7 +140,7 @@ describe("Documentation helpers", () => {
   describe("depictRaw()", () => {
     test("should depict the raw property", () => {
       expect(
-        depictRaw(ez.raw({ extra: z.string() }), requestCtx),
+        delegate(ez.raw({ extra: z.string() }), requestCtx),
       ).toMatchSnapshot();
     });
   });
@@ -166,7 +164,7 @@ describe("Documentation helpers", () => {
       ez.file("string"),
       ez.file("buffer"),
     ])("should set type:string and format accordingly %#", (schema) => {
-      expect(depictFile(schema, responseCtx)).toMatchSnapshot();
+      expect(delegate(schema, responseCtx)).toMatchSnapshot();
     });
   });
 

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -29,7 +29,6 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
-    brandHandling: {},
     next: (schema: $ZodType) =>
       walkSchema(schema, {
         rules: depicters,
@@ -43,7 +42,6 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
-    brandHandling: {},
     next: (schema: $ZodType) =>
       walkSchema(schema, {
         rules: depicters,

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -20,17 +20,21 @@ import {
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();
   const requestCtx = {
-    path: "/v1/user/:id",
-    method: "get",
-    isResponse: false,
-    makeRef: makeRefMock,
-  } satisfies OpenAPIContext;
+    ctx: {
+      path: "/v1/user/:id",
+      method: "get",
+      isResponse: false,
+      makeRef: makeRefMock,
+    } satisfies OpenAPIContext,
+  };
   const responseCtx = {
-    path: "/v1/user/:id",
-    method: "get",
-    isResponse: true,
-    makeRef: makeRefMock,
-  } satisfies OpenAPIContext;
+    ctx: {
+      path: "/v1/user/:id",
+      method: "get",
+      isResponse: true,
+      makeRef: makeRefMock,
+    } satisfies OpenAPIContext,
+  };
 
   beforeEach(() => {
     makeRefMock.mockClear();
@@ -574,7 +578,7 @@ describe("Documentation helpers", () => {
           }),
           inputSources: ["query", "params"],
           composition: "inline",
-          ...requestCtx,
+          ...requestCtx.ctx,
         }),
       ).toMatchSnapshot();
     });
@@ -588,7 +592,7 @@ describe("Documentation helpers", () => {
           }),
           inputSources: ["body", "params"],
           composition: "inline",
-          ...requestCtx,
+          ...requestCtx.ctx,
         }),
       ).toMatchSnapshot();
     });
@@ -602,7 +606,7 @@ describe("Documentation helpers", () => {
           }),
           inputSources: ["body"],
           composition: "inline",
-          ...requestCtx,
+          ...requestCtx.ctx,
         }),
       ).toMatchSnapshot();
     });
@@ -619,7 +623,7 @@ describe("Documentation helpers", () => {
           inputSources: ["query", "headers", "params"],
           composition: "inline",
           security: [[{ type: "header", name: "secure" }]],
-          ...requestCtx,
+          ...requestCtx.ctx,
         }),
       ).toMatchSnapshot();
     });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -9,7 +9,6 @@ import {
   depictDateOut,
   depictExamples,
   depictFile,
-  depictNumber,
   depictParamExamples,
   depictPipeline,
   depictRequestParams,
@@ -459,42 +458,10 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictNumber()", () => {
-    test.each([
-      z.number(),
-      z.int(),
-      z.float64(),
-      R.assocPath(["_zod", "def", "format"], "hacked", z.int()),
-    ])(
+    test.each([z.number(), z.int(), z.float64()])(
       "should set min/max values according to JS capabilities %#",
       (schema) => {
-        expect(depictNumber(schema, requestCtx)).toMatchSnapshot();
-      },
-    );
-
-    test.each([z.number(), z.int()])(
-      "should use numericRange when set %#",
-      (schema) => {
-        expect(
-          depictNumber(schema, {
-            ...requestCtx,
-            numericRange: {
-              integer: [-100, 100],
-              float: [-1000 / 3, 1000 / 3],
-            },
-          }),
-        ).toMatchSnapshot();
-      },
-    );
-
-    test.each([z.number(), z.int()])(
-      "should not use numericRange when it is null %#",
-      (schema) => {
-        expect(
-          depictNumber(schema, {
-            ...requestCtx,
-            numericRange: null,
-          }),
-        ).toMatchSnapshot();
+        expect(delegate(schema, requestCtx)).toMatchSnapshot();
       },
     );
 
@@ -512,7 +479,7 @@ describe("Documentation helpers", () => {
     ])(
       "should use schema checks for min/max and exclusiveness %#",
       (schema) => {
-        expect(depictNumber(schema, requestCtx)).toMatchSnapshot();
+        expect(delegate(schema, requestCtx)).toMatchSnapshot();
       },
     );
   });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -12,7 +12,6 @@ import {
   depictFile,
   depictLazy,
   depictNumber,
-  depictObjectProperties,
   depictParamExamples,
   depictPipeline,
   depictRequestParams,
@@ -518,20 +517,6 @@ describe("Documentation helpers", () => {
         expect(depictNumber(schema, requestCtx)).toMatchSnapshot();
       },
     );
-  });
-
-  describe("depictObjectProperties()", () => {
-    test("should wrap next depicters in a shape of object", () => {
-      expect(
-        depictObjectProperties(
-          z.object({
-            one: z.string(),
-            two: z.boolean(),
-          }),
-          requestCtx.next,
-        ),
-      ).toMatchSnapshot();
-    });
   });
 
   describe("depictPipeline", () => {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -24,14 +24,12 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
-    jsonSchema: {},
   } satisfies OpenAPIContext;
   const responseCtx = {
     path: "/v1/user/:id",
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
-    jsonSchema: {},
   } satisfies OpenAPIContext;
 
   beforeEach(() => {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -24,12 +24,14 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
+    jsonSchema: {},
   } satisfies OpenAPIContext;
   const responseCtx = {
     path: "/v1/user/:id",
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
+    jsonSchema: {},
   } satisfies OpenAPIContext;
 
   beforeEach(() => {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -684,32 +684,6 @@ describe("Documentation helpers", () => {
     });
   });
 
-  describe("depictLazy", () => {
-    const recursiveArray: z.ZodLazy = z.lazy(() => recursiveArray.array());
-    const directlyRecursive: z.ZodLazy = z.lazy(() => directlyRecursive);
-    const recursiveObject: z.ZodLazy = z.lazy(() =>
-      z.object({ prop: recursiveObject }),
-    );
-
-    test.each([recursiveArray, directlyRecursive, recursiveObject])(
-      "should handle circular references %#",
-      (schema) => {
-        makeRefMock.mockImplementationOnce(
-          (): ReferenceObject => ({
-            $ref: "#/components/schemas/SomeSchema",
-          }),
-        );
-        expect(makeRefMock).not.toHaveBeenCalled();
-        expect(delegate(schema, responseCtx)).toMatchSnapshot();
-        expect(makeRefMock).toHaveBeenCalledTimes(1);
-        expect(makeRefMock).toHaveBeenCalledWith(
-          schema._zod.def.getter,
-          expect.any(Function),
-        );
-      },
-    );
-  });
-
   describe("depictSecurity()", () => {
     test("should handle Basic, Bearer and Header Securities", () => {
       expect(

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -12,7 +12,6 @@ import {
   depictSecurity,
   depictSecurityRefs,
   depictTags,
-  depictUpload,
   depictRaw,
   depicters,
   ensureShortDescription,
@@ -150,11 +149,11 @@ describe("Documentation helpers", () => {
 
   describe("depictUpload()", () => {
     test("should set format:binary and type:string", () => {
-      expect(depictUpload(ez.upload(), requestCtx)).toMatchSnapshot();
+      expect(delegate(ez.upload(), requestCtx)).toMatchSnapshot();
     });
     test("should throw when using in response", () => {
       expect(() =>
-        depictUpload(ez.upload(), responseCtx),
+        delegate(ez.upload(), responseCtx),
       ).toThrowErrorMatchingSnapshot();
     });
   });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -10,7 +10,6 @@ import {
   depictDateOut,
   depictExamples,
   depictFile,
-  depictLazy,
   depictNumber,
   depictParamExamples,
   depictPipeline,
@@ -751,7 +750,7 @@ describe("Documentation helpers", () => {
           }),
         );
         expect(makeRefMock).not.toHaveBeenCalled();
-        expect(depictLazy(schema, responseCtx)).toMatchSnapshot();
+        expect(delegate(schema, responseCtx)).toMatchSnapshot();
         expect(makeRefMock).toHaveBeenCalledTimes(1);
         expect(makeRefMock).toHaveBeenCalledWith(
           schema._zod.def.getter,

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { ez } from "../src";
 import {
   OpenAPIContext,
-  depictDate,
   depictDateIn,
   depictDateOut,
   depictExamples,
@@ -729,7 +728,7 @@ describe("Documentation helpers", () => {
     test.each([responseCtx, requestCtx])(
       "should throw clear error %#",
       (ctx) => {
-        expect(() => depictDate(z.date(), ctx)).toThrowErrorMatchingSnapshot();
+        expect(() => delegate(z.date(), ctx)).toThrowErrorMatchingSnapshot();
       },
     );
   });

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,5 +1,4 @@
 import type { $ZodType } from "@zod/core";
-import { ReferenceObject } from "openapi3-ts/oas31";
 import * as R from "ramda";
 import { z } from "zod";
 import { ez } from "../src";
@@ -30,6 +29,7 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
+    brandHandling: {},
     next: (schema: $ZodType) =>
       walkSchema(schema, {
         rules: depicters,
@@ -43,6 +43,7 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
+    brandHandling: {},
     next: (schema: $ZodType) =>
       walkSchema(schema, {
         rules: depicters,

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -10,7 +10,6 @@ import {
   depictExamples,
   depictFile,
   depictParamExamples,
-  depictPipeline,
   depictRequestParams,
   depictSecurity,
   depictSecurityRefs,
@@ -490,7 +489,7 @@ describe("Documentation helpers", () => {
       { ctx: requestCtx, expected: "string (in)" },
     ])("should depict as $expected", ({ ctx }) => {
       expect(
-        depictPipeline(z.string().transform(Boolean).pipe(z.boolean()), ctx),
+        delegate(z.string().transform(Boolean).pipe(z.boolean()), ctx),
       ).toMatchSnapshot();
     });
 
@@ -511,14 +510,14 @@ describe("Documentation helpers", () => {
         expected: "string (preprocess)",
       },
     ])("should depict as $expected", ({ schema, ctx }) => {
-      expect(depictPipeline(schema, ctx)).toMatchSnapshot();
+      expect(delegate(schema, ctx)).toMatchSnapshot();
     });
 
     test.each([
       z.number().transform((num) => () => num),
       z.number().transform(() => assert.fail("this should be handled")),
     ])("should handle edge cases", (schema) => {
-      expect(depictPipeline(schema, responseCtx)).toMatchSnapshot();
+      expect(delegate(schema, responseCtx)).toMatchSnapshot();
     });
   });
 

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -310,8 +310,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("depictLiteral()", () => {
-    // @todo wait for external issue fixed
-    test.each(["testng", null /* BigInt(123), undefined */])(
+    test.each(["testng", null, BigInt(123), undefined])(
       "should set type and involve const property %#",
       (value) => {
         expect(delegate(z.literal(value), requestCtx)).toMatchSnapshot();

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,4 +1,3 @@
-import type { $ZodType } from "@zod/core";
 import * as R from "ramda";
 import { z } from "zod";
 import { ez } from "../src";
@@ -10,17 +9,13 @@ import {
   depictSecurity,
   depictSecurityRefs,
   depictTags,
-  depicters,
   ensureShortDescription,
   excludeExamplesFromDepiction,
   excludeParamsFromDepiction,
   defaultIsHeader,
-  onEach,
-  onMissing,
   reformatParamsInPath,
   delegate,
 } from "../src/documentation-helpers";
-import { walkSchema } from "../src/schema-walker";
 
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();
@@ -29,26 +24,12 @@ describe("Documentation helpers", () => {
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
-    next: (schema: $ZodType) =>
-      walkSchema(schema, {
-        rules: depicters,
-        onEach,
-        onMissing,
-        ctx: requestCtx,
-      }),
   } satisfies OpenAPIContext;
   const responseCtx = {
     path: "/v1/user/:id",
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
-    next: (schema: $ZodType) =>
-      walkSchema(schema, {
-        rules: depicters,
-        onEach,
-        onMissing,
-        ctx: responseCtx,
-      }),
   } satisfies OpenAPIContext;
 
   beforeEach(() => {
@@ -65,12 +46,7 @@ describe("Documentation helpers", () => {
         z.record(z.string(), z.string()),
       ),
     ])("should omit specified params %#", (schema) => {
-      const depicted = walkSchema(schema, {
-        ctx: requestCtx,
-        rules: depicters,
-        onEach,
-        onMissing,
-      });
+      const depicted = delegate(schema, requestCtx);
       const [result, hasRequired] = excludeParamsFromDepiction(depicted, ["a"]);
       expect(result).toMatchSnapshot();
       expect(hasRequired).toMatchSnapshot();

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1183,8 +1183,7 @@ describe("Documentation", () => {
   describe("Feature #1470: Custom brands", () => {
     test("should be handled accordingly in request, response and params", () => {
       const deep = Symbol("DEEP");
-      const rule: Depicter = ({}, { jsonSchema }) =>
-        (jsonSchema.type = "boolean");
+      const rule: Depicter = ({ jsonSchema }) => (jsonSchema.type = "boolean");
       const spec = new Documentation({
         config: sampleConfig,
         routing: {
@@ -1203,8 +1202,7 @@ describe("Documentation", () => {
           },
         },
         brandHandling: {
-          CUSTOM: ({}, { jsonSchema }) =>
-            (jsonSchema.summary = "My custom schema"),
+          CUSTOM: ({ jsonSchema }) => (jsonSchema.summary = "My custom schema"),
           [deep]: rule,
         },
         version: "3.4.5",

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1,7 +1,6 @@
 import camelize from "camelize-ts";
 import snakify from "snakify-ts";
 import {
-  Depicter,
   Documentation,
   DocumentationError,
   EndpointsFactory,
@@ -12,7 +11,7 @@ import {
   ResultHandler,
 } from "../src";
 import { contentTypes } from "../src/content-type";
-import { globalRegistry, z } from "zod";
+import { z } from "zod";
 import { givePort } from "../../tools/ports";
 
 describe("Documentation", () => {
@@ -1188,13 +1187,7 @@ describe("Documentation", () => {
   describe("Feature #1470: Custom brands", () => {
     test("should be handled accordingly in request, response and params", () => {
       const deep = Symbol("DEEP");
-      const rule: Depicter = (
-        schema: ReturnType<z.ZodBoolean["brand"]>,
-        { next },
-      ) => {
-        globalRegistry.remove(schema);
-        return next(schema);
-      };
+      const rule = () => ({ type: "boolean" as const });
       const spec = new Documentation({
         config: sampleConfig,
         routing: {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -525,49 +525,6 @@ describe("Documentation", () => {
       expect(spec).toMatchSnapshot();
     });
 
-    test.each([
-      z.undefined(),
-      z.map(z.any(), z.any()),
-      z.set(z.any()),
-      z.promise(z.any()),
-      z.nan(),
-      z.symbol(),
-      z.unknown(),
-      z.never(),
-      z.void(),
-    ])("should throw on unsupported types %#", (zodType) => {
-      expect(
-        () =>
-          new Documentation({
-            config: sampleConfig,
-            routing: {
-              v1: {
-                getSomething: defaultEndpointsFactory.build({
-                  method: "post",
-                  input: z.object({
-                    property: zodType,
-                  }),
-                  output: z.object({}),
-                  handler: async () => ({}),
-                }),
-              },
-            },
-            version: "3.4.5",
-            title: "Testing unsupported types",
-            serverUrl: "https://example.com",
-          }),
-      ).toThrow(
-        new DocumentationError(
-          `Zod type ${zodType.constructor.name} is unsupported.`,
-          {
-            method: "post",
-            path: "/v1/getSomething",
-            isResponse: false,
-          },
-        ),
-      );
-    });
-
     test("should ensure uniq security schema names", () => {
       const mw1 = new Middleware({
         security: {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -492,7 +492,6 @@ describe("Documentation", () => {
           v1: {
             getSomething: defaultEndpointsFactory.build({
               method: "post",
-              input: category,
               output: z.object({
                 zodExample: category,
               }),

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -9,7 +9,7 @@ import {
   defaultEndpointsFactory,
   ez,
   ResultHandler,
-  Depicter,
+  Overrider,
 } from "../src";
 import { contentTypes } from "../src/content-type";
 import { z } from "zod";
@@ -1183,7 +1183,7 @@ describe("Documentation", () => {
   describe("Feature #1470: Custom brands", () => {
     test("should be handled accordingly in request, response and params", () => {
       const deep = Symbol("DEEP");
-      const rule: Depicter = ({ jsonSchema }) => (jsonSchema.type = "boolean");
+      const rule: Overrider = ({ jsonSchema }) => (jsonSchema.type = "boolean");
       const spec = new Documentation({
         config: sampleConfig,
         routing: {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -495,7 +495,7 @@ describe("Documentation", () => {
               method: "post",
               input: category,
               output: z.object({
-                zodExample: category,
+                zodExample: category, // @todo consider external registry to deduplicate it
               }),
               handler: async () => ({
                 zodExample: {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -38,7 +38,6 @@ describe("Documentation", () => {
             }),
           },
         },
-        numericRange: null,
         config: sampleConfig,
         version: "3.4.5",
         title: "Testing DELETE request without body",

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -9,6 +9,7 @@ import {
   defaultEndpointsFactory,
   ez,
   ResultHandler,
+  Depicter,
 } from "../src";
 import { contentTypes } from "../src/content-type";
 import { z } from "zod";
@@ -1182,7 +1183,8 @@ describe("Documentation", () => {
   describe("Feature #1470: Custom brands", () => {
     test("should be handled accordingly in request, response and params", () => {
       const deep = Symbol("DEEP");
-      const rule = () => ({ type: "boolean" as const });
+      const rule: Depicter = ({}, { jsonSchema }) =>
+        (jsonSchema.type = "boolean");
       const spec = new Documentation({
         config: sampleConfig,
         routing: {
@@ -1201,9 +1203,8 @@ describe("Documentation", () => {
           },
         },
         brandHandling: {
-          CUSTOM: () => ({
-            summary: "My custom schema",
-          }),
+          CUSTOM: ({}, { jsonSchema }) =>
+            (jsonSchema.summary = "My custom schema"),
           [deep]: rule,
         },
         version: "3.4.5",

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -493,6 +493,7 @@ describe("Documentation", () => {
           v1: {
             getSomething: defaultEndpointsFactory.build({
               method: "post",
+              input: category,
               output: z.object({
                 zodExample: category,
               }),

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -1,5 +1,7 @@
+import type { $ZodType, JSONSchema } from "@zod/core";
 import { IRouter } from "express";
 import ts from "typescript";
+import { expectTypeOf } from "vitest";
 import { z } from "zod";
 import * as entrypoint from "../src";
 import {
@@ -10,7 +12,7 @@ import {
   CommonConfig,
   CookieSecurity,
   HeaderSecurity,
-  Depicter,
+  Overrider,
   FlatObject,
   IOSchema,
   InputSecurity,
@@ -37,9 +39,9 @@ describe("Index Entrypoint", () => {
     });
 
     test("Convenience types should be exposed", () => {
-      expectTypeOf(() => ({
-        type: "number" as const,
-      })).toExtend<Depicter>();
+      expectTypeOf(
+        ({}: { zodSchema: $ZodType; jsonSchema: JSONSchema.BaseSchema }) => {},
+      ).toExtend<Overrider>();
       expectTypeOf(() =>
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
       ).toExtend<Producer>();


### PR DESCRIPTION
Exploring the possibility to delegate OpenAPI compatible depiction to JSON Schema based method of Zod 4.

Current issues:
- Can not depict `BigInt` with throwing error if it's within `ZodLiteral`
  - https://github.com/colinhacks/zod/issues/4220 
- Numeric limits are wrong:
  - exclusive, while should be inclusive
  - missing at all (`z.number().int().positive()`)
  - https://github.com/colinhacks/zod/pull/4074#discussion_r2048393003
  - suggested fix https://github.com/colinhacks/zod/pull/4224
- Overrides act after default depiction, not before, so that much has to be rewritten 