### PR TITLE
Moving `deprecated` to the top level of global registry

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -706,7 +706,7 @@ export const depictRequestParams = ({
       return acc.concat({
         name,
         in: location,
-        deprecated: globalRegistry.get(paramSchema)?.[metaSymbol]?.isDeprecated,
+        deprecated: globalRegistry.get(paramSchema)?.deprecated,
         required: !(paramSchema as z.ZodType).isOptional(),
         description: depicted.description || description,
         schema: result,
@@ -769,7 +769,7 @@ export const onEach: SchemaHandler<
     schema.isNullable();
   const result: SchemaObject = {};
   if (description) result.description = description;
-  if (schema.meta()?.[metaSymbol]?.isDeprecated) result.deprecated = true;
+  if (schema.meta()?.deprecated) result.deprecated = true;
   if (isActuallyNullable) result.type = makeNullableType(prev);
   if (!shouldAvoidParsing) {
     const examples = getExamples({

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -9,7 +9,6 @@ export interface Metadata {
   /** @override ZodDefault::_zod.def.defaultValue() in depictDefault */
   defaultLabel?: string;
   brand?: string | number | symbol;
-  isDeprecated?: boolean;
 }
 
 export const copyMeta = <A extends z.ZodType, B extends z.ZodType>(

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -17,6 +17,7 @@ import type { $ZodType, $ZodShape } from "@zod/core";
 declare module "@zod/core" {
   interface GlobalMeta {
     [metaSymbol]?: Metadata;
+    deprecated?: boolean;
   }
 }
 
@@ -66,11 +67,8 @@ const exampleSetter = function (this: z.ZodType, value: z.input<typeof this>) {
 const deprecationSetter = function (this: z.ZodType) {
   return this.meta({
     description: this.description,
-    [metaSymbol]: {
-      examples: [],
-      ...this.meta()?.[metaSymbol],
-      isDeprecated: true,
-    },
+    deprecated: true,
+    [metaSymbol]: this.meta()?.[metaSymbol],
   });
 };
 

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -22,7 +22,6 @@ import { hasCoercion, getTransformedType } from "./common-helpers";
 import { ezDateInBrand } from "./date-in-schema";
 import { ezDateOutBrand } from "./date-out-schema";
 import { ezFileBrand, FileSchema } from "./file-schema";
-import { metaSymbol } from "./metadata";
 import { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand, RawSchema } from "./raw-schema";
 import { FirstPartyKind, HandlingRules, walkSchema } from "./schema-walker";
@@ -83,11 +82,12 @@ const onObject: Producer = (
           : value instanceof z.ZodPromise
             ? false
             : (value as z.ZodType).isOptional();
-      const { description: comment, ...meta } = globalRegistry.get(value) || {};
+      const { description: comment, deprecated: isDeprecated } =
+        globalRegistry.get(value) || {};
       return makeInterfaceProp(key, next(value), {
         comment,
+        isDeprecated,
         isOptional: isOptional && hasQuestionMark,
-        isDeprecated: meta[metaSymbol]?.isDeprecated,
       });
     },
   );

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -67,10 +67,7 @@ describe("Zod Runtime Plugin", () => {
     test("should set the corresponding metadata in the schema definition", () => {
       const schema = z.string();
       const schemaWithMeta = schema.deprecated();
-      expect(schemaWithMeta.meta()?.[metaSymbol]).toHaveProperty(
-        "isDeprecated",
-        true,
-      );
+      expect(schemaWithMeta.meta()).toHaveProperty("deprecated", true);
     });
   });
 


### PR DESCRIPTION
`deprecated` is a valid JSON Schema and OpenAPI prop.
Therefore it should be stored directly there.