### PR TITLE
Exp: native storage for input examples

### DIFF
--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -107,10 +107,10 @@ paths:
           required: true
           description: PATCH /v1/user/:id Parameter
           schema:
-            type: string
-            minLength: 1
             examples:
               - "1234567890"
+            type: string
+            minLength: 1
           examples:
             example1:
               value: "1234567890"
@@ -133,15 +133,15 @@ paths:
               type: object
               properties:
                 key:
-                  type: string
-                  minLength: 1
                   examples:
                     - 1234-5678-90
-                name:
                   type: string
                   minLength: 1
+                name:
                   examples:
                     - John Doe
+                  type: string
+                  minLength: 1
                 birthday:
                   description: YYYY-MM-DDTHH:mm:ss.sssZ
                   type: string
@@ -179,9 +179,9 @@ paths:
                     type: object
                     properties:
                       name:
-                        type: string
                         examples:
                           - John Doe
+                        type: string
                       createdAt:
                         description: YYYY-MM-DDTHH:mm:ss.sssZ
                         type: string

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -5,7 +5,6 @@ import { globalRegistry, z } from "zod";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
 import { OutputValidationError } from "./errors";
-import { metaSymbol } from "./metadata";
 import { AuxMethod, Method } from "./method";
 
 /** @desc this type does not allow props assignment, but it works for reading them when merged with another interface */
@@ -89,8 +88,7 @@ export const getMessageFromError = (error: Error): string => {
 export const pullExampleProps = <T extends z.ZodObject>(subject: T) =>
   Object.entries(subject.shape).reduce<Partial<z.input<T>>[]>(
     (acc, [key, schema]) => {
-      const examples =
-        (schema as z.ZodType).meta()?.[metaSymbol]?.examples || [];
+      const examples = (schema as z.ZodType).meta()?.examples || [];
       return combinations(acc, examples.map(R.objOf(key)), ([left, right]) => ({
         ...left,
         ...right,
@@ -127,7 +125,7 @@ export const getExamples = <
    * */
   pullProps?: boolean;
 }): ReadonlyArray<V extends "parsed" ? z.output<T> : z.input<T>> => {
-  let examples = globalRegistry.get(schema)?.[metaSymbol]?.examples || [];
+  let examples = globalRegistry.get(schema)?.examples || [];
   if (!examples.length && pullProps && schema instanceof z.ZodObject)
     examples = pullExampleProps(schema);
   if (!validate && variant === "original") return examples;

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -112,6 +112,7 @@ export const getExamples = <
    * @example "parsed" — for the case when possible schema transformations should be applied
    * @default "original"
    * @override validate: variant "parsed" activates validation as well
+   * @todo revisit the need of it
    * */
   variant?: V;
   /**
@@ -124,12 +125,12 @@ export const getExamples = <
    * @default false
    * */
   pullProps?: boolean;
-}): ReadonlyArray<V extends "parsed" ? z.output<T> : z.input<T>> => {
+}): ReadonlyArray<z.output<T>> => {
   let examples = globalRegistry.get(schema)?.examples || [];
   if (!examples.length && pullProps && schema instanceof z.ZodObject)
     examples = pullExampleProps(schema);
   if (!validate && variant === "original") return examples;
-  const result: Array<z.input<T> | z.output<T>> = [];
+  const result: Array<z.output<T>> = [];
   for (const example of examples) {
     const parsedExample = z.safeParse(schema, example);
     if (parsedExample.success)

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -442,6 +442,7 @@ const onEach: Overrider = ({ zodSchema, jsonSchema }, { isResponse }) => {
     zodSchema.isNullable();
   if (acceptsNull)
     Object.assign(jsonSchema, { type: makeNullableType(jsonSchema) });
+  // @todo revisit the need of it
   const examples = getExamples({
     schema: zodSchema,
     variant: isResponse ? "parsed" : "original",

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -5,7 +5,6 @@ import * as R from "ramda";
 export const metaSymbol = Symbol.for("express-zod-api");
 
 export interface Metadata {
-  examples: unknown[];
   /** @override ZodDefault::_zod.def.defaultValue() in depictDefault */
   defaultLabel?: string;
   brand?: string | number | symbol;
@@ -15,21 +14,22 @@ export const copyMeta = <A extends z.ZodType, B extends z.ZodType>(
   src: A,
   dest: B,
 ): B => {
-  const srcMeta = src.meta()?.[metaSymbol];
-  const destMeta = dest.meta()?.[metaSymbol];
+  const srcMeta = src.meta();
+  const destMeta = dest.meta();
   if (!srcMeta) return dest; // ensure metadata in src below
   return dest.meta({
     description: dest.description,
-    [metaSymbol]: {
-      ...destMeta,
-      examples: combinations(
-        destMeta?.examples || [],
-        srcMeta.examples || [],
-        ([destExample, srcExample]) =>
-          typeof destExample === "object" && typeof srcExample === "object"
-            ? R.mergeDeepRight({ ...destExample }, { ...srcExample })
-            : srcExample, // not supposed to be called on non-object schemas
-      ),
-    },
+    examples: combinations(
+      destMeta?.examples || [],
+      srcMeta.examples || [],
+      ([destExample, srcExample]) =>
+        typeof destExample === "object" &&
+        typeof srcExample === "object" &&
+        destExample &&
+        srcExample
+          ? R.mergeDeepRight(destExample, srcExample)
+          : srcExample, // not supposed to be called on non-object schemas
+    ),
+    [metaSymbol]: destMeta?.[metaSymbol],
   });
 };

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -23,11 +23,8 @@ declare module "@zod/core" {
 
 declare module "zod" {
   interface ZodType {
-    /**
-     * @todo this should be changed to z.output
-     * @desc Add an example value (before any transformations, can be called multiple times)
-     * */
-    example(example: z.input<this>): this;
+    /** @desc Shorthand for .meta({examples}), it can be called multiple times */
+    example(example: z.output<this>): this;
     deprecated(): this;
   }
   interface ZodDefault<T extends $ZodType = $ZodType> extends ZodType {

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -3172,6 +3172,11 @@ paths:
                   status:
                     const: success
                   data:
+                    examples:
+                      - a: first
+                        b: prefix_first
+                      - a: second
+                        b: prefix_second
                     type: object
                     properties:
                       a:
@@ -3181,11 +3186,6 @@ paths:
                     required:
                       - a
                       - b
-                    examples:
-                      - a: first
-                        b: prefix_first
-                      - a: second
-                        b: prefix_second
                 required:
                   - status
                   - data
@@ -3361,14 +3361,14 @@ paths:
                   status:
                     const: success
                   data:
+                    examples:
+                      - num: 123
                     type: object
                     properties:
                       num:
                         type: number
                     required:
                       - num
-                    examples:
-                      - num: 123
                 required:
                   - status
                   - data
@@ -3449,14 +3449,14 @@ paths:
                   status:
                     const: success
                   data:
+                    examples:
+                      - numericStr: "123"
                     type: object
                     properties:
                       numericStr:
                         type: string
                     required:
                       - numericStr
-                    examples:
-                      - numericStr: "123"
                 required:
                   - status
                   - data
@@ -3543,14 +3543,14 @@ paths:
                   status:
                     const: success
                   data:
+                    examples:
+                      - numericStr: "123"
                     type: object
                     properties:
                       numericStr:
                         type: string
                     required:
                       - numericStr
-                    examples:
-                      - numericStr: "123"
                 required:
                   - status
                   - data

--- a/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
@@ -21,6 +21,14 @@ exports[`Endpoint > .getResponses() > should return the negative responses (read
       "application/json",
     ],
     "schema": {
+      "examples": [
+        {
+          "error": {
+            "message": "Sample error message",
+          },
+          "status": "error",
+        },
+      ],
       "properties": {
         "error": {
           "properties": {

--- a/express-zod-api/tests/__snapshots__/endpoints-factory.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoints-factory.spec.ts.snap
@@ -85,6 +85,7 @@ exports[`EndpointsFactory > .build() > Should create an endpoint with refined ob
       "type": "object",
     },
   ],
+  "examples": [],
 }
 `;
 

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -5,7 +5,6 @@ import {
   extractObjectSchema,
   getFinalEndpointInputSchema,
 } from "../src/io-schema";
-import { metaSymbol } from "../src/metadata";
 import { AbstractMiddleware } from "../src/middleware";
 
 describe("I/O Schema and related helpers", () => {
@@ -288,7 +287,7 @@ describe("I/O Schema and related helpers", () => {
         .object({ five: z.string() })
         .example({ five: "some" });
       const result = getFinalEndpointInputSchema(middlewares, endpointInput);
-      expect(result.meta()?.[metaSymbol]?.examples).toEqual([
+      expect(result.meta()?.examples).toEqual([
         {
           one: "test",
           two: 123,

--- a/express-zod-api/tests/metadata.spec.ts
+++ b/express-zod-api/tests/metadata.spec.ts
@@ -15,10 +15,7 @@ describe("Metadata", () => {
       const src = z.string().example("some");
       const dest = z.number();
       const result = copyMeta(src, dest);
-      expect(result.meta()?.[metaSymbol]).toBeTruthy();
-      expect(result.meta()?.[metaSymbol]?.examples).toEqual(
-        src.meta()?.[metaSymbol]?.examples,
-      );
+      expect(result.meta()?.examples).toEqual(src.meta()?.examples);
     });
 
     test("should merge the meta from src to dest", () => {
@@ -32,8 +29,7 @@ describe("Metadata", () => {
         .example({ b: 456 })
         .example({ b: 789 });
       const result = copyMeta(src, dest);
-      expect(result.meta()?.[metaSymbol]).toBeTruthy();
-      expect(result.meta()?.[metaSymbol]?.examples).toEqual([
+      expect(result.meta()?.examples).toEqual([
         { a: "some", b: 123 },
         { a: "another", b: 123 },
         { a: "some", b: 456 },
@@ -54,8 +50,7 @@ describe("Metadata", () => {
         .example({ a: { c: 456 } })
         .example({ a: { c: 789 } });
       const result = copyMeta(src, dest);
-      expect(result.meta()?.[metaSymbol]).toBeTruthy();
-      expect(result.meta()?.[metaSymbol]?.examples).toEqual([
+      expect(result.meta()?.examples).toEqual([
         { a: { b: "some", c: 123 } },
         { a: { b: "another", c: 123 } },
         { a: { b: "some", c: 456 } },
@@ -71,7 +66,7 @@ describe("Metadata", () => {
         .object({ items: z.array(z.string()) })
         .example({ items: ["e", "f", "g"] });
       const result = copyMeta(src, dest);
-      expect(result.meta()?.[metaSymbol]?.examples).toEqual(["a", "b"]);
+      expect(result.meta()?.examples).toEqual(["a", "b"]);
     });
   });
 });

--- a/express-zod-api/tests/result-handler.spec.ts
+++ b/express-zod-api/tests/result-handler.spec.ts
@@ -8,7 +8,6 @@ import {
   ResultHandler,
 } from "../src";
 import { ResultHandlerError } from "../src/errors";
-import { metaSymbol } from "../src/metadata";
 import { AbstractResultHandler, Result } from "../src/result-handler";
 import {
   makeLoggerMock,
@@ -197,13 +196,13 @@ describe("ResultHandler", () => {
           }),
       );
       expect(apiResponse).toHaveLength(1);
-      expect(apiResponse[0].schema.meta()?.[metaSymbol]).toMatchSnapshot();
+      expect(apiResponse[0].schema.meta()).toMatchSnapshot();
     });
 
     test("should generate negative response example", () => {
       const apiResponse = subject.getNegativeResponse();
       expect(apiResponse).toHaveLength(1);
-      expect(apiResponse[0].schema.meta()?.[metaSymbol]).toMatchSnapshot();
+      expect(apiResponse[0].schema.meta()).toMatchSnapshot();
     });
   });
 

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -13,23 +13,17 @@ describe("Zod Runtime Plugin", () => {
     test("should set the corresponding metadata in the schema definition", () => {
       const schema = z.string();
       const schemaWithMeta = schema.example("test");
-      expect(schemaWithMeta.meta()?.[metaSymbol]).toHaveProperty("examples", [
-        "test",
-      ]);
+      expect(schemaWithMeta.meta()).toHaveProperty("examples", ["test"]);
     });
 
     test("Issue 827: should be immutable", () => {
       const schema = z.string();
       const schemaWithExample = schema.example("test");
-      expect(schemaWithExample.meta()?.[metaSymbol]?.examples).toEqual([
-        "test",
-      ]);
+      expect(schemaWithExample.meta()?.examples).toEqual(["test"]);
       expect(schema.meta()?.[metaSymbol]).toBeUndefined();
       const second = schemaWithExample.example("test2");
-      expect(second.meta()?.[metaSymbol]?.examples).toEqual(["test", "test2"]);
-      expect(schemaWithExample.meta()?.[metaSymbol]?.examples).toEqual([
-        "test",
-      ]);
+      expect(second.meta()?.examples).toEqual(["test", "test2"]);
+      expect(schemaWithExample.meta()?.examples).toEqual(["test"]);
     });
 
     test("can be used multiple times", () => {
@@ -38,7 +32,7 @@ describe("Zod Runtime Plugin", () => {
         .example("test1")
         .example("test2")
         .example("test3");
-      expect(schemaWithMeta.meta()?.[metaSymbol]?.examples).toEqual([
+      expect(schemaWithMeta.meta()?.examples).toEqual([
         "test1",
         "test2",
         "test3",
@@ -48,12 +42,11 @@ describe("Zod Runtime Plugin", () => {
     test("should withstand refinements", () => {
       const schema = z.string();
       const schemaWithMeta = schema.example("test");
-      expect(schemaWithMeta.meta()?.[metaSymbol]?.examples).toEqual(["test"]);
-      expect(
-        schemaWithMeta.regex(/@example.com$/).meta()?.[metaSymbol],
-      ).toEqual({
-        examples: ["test"],
-      });
+      expect(schemaWithMeta.meta()?.examples).toEqual(["test"]);
+      expect(schemaWithMeta.regex(/@example.com$/).meta()).toHaveProperty(
+        "examples",
+        ["test"],
+      );
     });
   });
 


### PR DESCRIPTION
New metadata system of Zod 4 finally supports examples.
However, those examples are typed as `z.output<T>`, while the proprietary ones used to be `z.input<T>`, so that the could be transformed when necessary or taken as is depending on the case.

this requires investigation.