### PR TITLE
Brand is the only the metadata that withstands refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
   - The `brandHandling` should consist of postprocessing functions altering the depiction made by Zod 4;
   - The `Depicter` type changed to `Overrider` having different signature;
 - The `optionalPropStyle` option removed from `Integration` class constructor:
-  - Use the new `z.interface()` schema to describe key-optional objects: https://v4.zod.dev/v4#zinterface.
+  - Use the new `z.interface()` schema to describe key-optional objects: https://v4.zod.dev/v4#zinterface;
+- Changes to the plugin:
+  - Brand is the only kind of metadata that withstands refinements and checks.
 
 ## Version 23
 

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -148,7 +148,10 @@ if (!(metaSymbol in globalThis)) {
           ) {
             /** @link https://v4.zod.dev/metadata#register */
             return originalCheck.apply(this, args).register(globalRegistry, {
-              [metaSymbol]: this.meta()?.[metaSymbol],
+              [metaSymbol]: {
+                examples: [],
+                brand: this.meta()?.[metaSymbol]?.brand,
+              },
             });
           };
         },

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -44,17 +44,6 @@ describe("Zod Runtime Plugin", () => {
         "test3",
       ]);
     });
-
-    test("should withstand refinements", () => {
-      const schema = z.string();
-      const schemaWithMeta = schema.example("test");
-      expect(schemaWithMeta.meta()?.[metaSymbol]?.examples).toEqual(["test"]);
-      expect(
-        schemaWithMeta.regex(/@example.com$/).meta()?.[metaSymbol],
-      ).toEqual({
-        examples: ["test"],
-      });
-    });
   });
 
   describe(".deprecated()", () => {
@@ -88,6 +77,18 @@ describe("Zod Runtime Plugin", () => {
       expect(z.string().brand("test").meta()?.[metaSymbol]?.brand).toEqual(
         "test",
       );
+    });
+
+    test("should withstand refinements", () => {
+      const schema = z.string();
+      const schemaWithMeta = schema.brand("test");
+      expect(schemaWithMeta.meta()?.[metaSymbol]).toHaveProperty(
+        "brand",
+        "test",
+      );
+      expect(
+        schemaWithMeta.regex(/@example.com$/).meta()?.[metaSymbol],
+      ).toHaveProperty("brand", "test");
     });
   });
 


### PR DESCRIPTION
Withstanding was necessary for brand only, for deep checks. But it does not make sense for examples and other stuff that should rather be placed properly.