### PR TITLE
Removing deprecated alias `ZodTypeAny`

### DIFF
--- a/express-zod-api/src/api-response.ts
+++ b/express-zod-api/src/api-response.ts
@@ -11,7 +11,7 @@ export const responseVariants = Object.keys(
 ) as ResponseVariant[];
 
 /** @public this is the user facing configuration */
-export interface ApiResponse<S extends z.ZodTypeAny> {
+export interface ApiResponse<S extends z.ZodType> {
   schema: S;
   /** @default 200 for a positive and 400 for a negative response */
   statusCode?: number | [number, ...number[]];
@@ -31,7 +31,7 @@ export interface ApiResponse<S extends z.ZodTypeAny> {
  * @see normalize
  * */
 export interface NormalizedResponse {
-  schema: z.ZodTypeAny;
+  schema: z.ZodType;
   statusCodes: [number, ...number[]];
   mimeTypes: [string, ...string[]] | null;
 }

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -45,7 +45,7 @@ interface IntegrationParams {
    * @desc The schema to use for responses without body such as 204
    * @default z.undefined()
    * */
-  noContent?: z.ZodTypeAny;
+  noContent?: z.ZodType;
   /**
    * @desc Handling rules for your own branded schemas.
    * @desc Keys: brands (recommended to use unique symbols).

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -30,7 +30,7 @@ type Handler<RES = unknown> = (params: {
   logger: ActualLogger;
 }) => void | Promise<void>;
 
-export type Result<S extends z.ZodTypeAny = z.ZodTypeAny> =
+export type Result<S extends z.ZodType = z.ZodType> =
   | S // plain schema, default status codes applied
   | ApiResponse<S> // single response definition, status code(s) customizable
   | ApiResponse<S>[]; // Feature #1431: different responses for different status codes (non-empty, prog. check!)

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -11,7 +11,7 @@ import {
   logServerError,
 } from "./result-helpers";
 
-type EventsMap = Record<string, z.ZodTypeAny>;
+type EventsMap = Record<string, z.ZodType>;
 
 export interface Emitter<E extends EventsMap> extends FlatObject {
   /** @desc Returns true when the connection was closed or terminated */
@@ -20,7 +20,7 @@ export interface Emitter<E extends EventsMap> extends FlatObject {
   emit: <K extends keyof E>(event: K, data: z.input<E[K]>) => void;
 }
 
-export const makeEventSchema = (event: string, data: z.ZodTypeAny) =>
+export const makeEventSchema = (event: string, data: z.ZodType) =>
   z.object({
     data,
     event: z.literal(event),

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -256,7 +256,7 @@ const producers: HandlingRules<
 };
 
 export const zodToTs = (
-  schema: z.ZodTypeAny,
+  schema: z.ZodType,
   {
     brandHandling,
     ctx,

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -88,9 +88,7 @@ describe("Index Entrypoint", () => {
         type: "openid";
         url: string;
       }>().toEqualTypeOf<OpenIdSecurity>();
-      expectTypeOf({ schema: z.string() }).toExtend<
-        ApiResponse<z.ZodTypeAny>
-      >();
+      expectTypeOf({ schema: z.string() }).toExtend<ApiResponse<z.ZodString>>();
     });
 
     test("Extended Zod prototypes", () => {

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../src";
 
 describe("Integration", () => {
-  const recursive1: z.ZodTypeAny = z.lazy(() =>
+  const recursive1: z.ZodType = z.lazy(() =>
     z.object({
       name: z.string(),
       features: recursive1,


### PR DESCRIPTION
https://v4.zod.dev/v4/changelog

> The need for z.ZodTypeAny has been eliminated; just use z.ZodType instead.

Part of rethinking #2574
