### PR TITLE
Fix: avoid double raw check by Documentation

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -31,7 +31,7 @@ import {
 import { InputSource } from "./config-type";
 import { DateInSchema, ezDateInBrand } from "./date-in-schema";
 import { DateOutSchema, ezDateOutBrand } from "./date-out-schema";
-import { hasRaw } from "./deep-checks";
+import { contentTypes } from "./content-type";
 import { DocumentationError } from "./errors";
 import { FileSchema, ezFileBrand } from "./file-schema";
 import { extractObjectSchema, IOSchema } from "./io-schema";
@@ -923,7 +923,7 @@ export const depictBody = ({
     description,
     content: { [mimeType]: media },
   };
-  if (hasRequired || hasRaw(schema)) body.required = true;
+  if (hasRequired || mimeType === contentTypes.raw) body.required = true;
   return body;
 };
 

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -49,6 +49,7 @@ import {
   onEach,
   onMissing,
   reformatParamsInPath,
+  depictBody,
 } from "../src/documentation-helpers";
 import { walkSchema } from "../src/schema-walker";
 
@@ -728,6 +729,19 @@ describe("Documentation helpers", () => {
           examples: ["test"],
         }),
       ).toMatchSnapshot();
+    });
+  });
+
+  describe("depictBody", () => {
+    test("should mark ez.raw() body as required", () => {
+      const body = depictBody({
+        ...requestCtx,
+        schema: ez.raw(),
+        composition: "inline",
+        mimeType: "application/octet-stream", // raw content type
+        paramNames: [],
+      });
+      expect(body.required).toBe(true);
     });
   });
 


### PR DESCRIPTION
cherry-picked 8d4b9d382e15d9b0e6bf49da87d56015d261574c

found during my work on #2589 

The suggested approach works because the input MIME type is already set after figuring out if it's raw or not.