### PR TITLE
Ref: Unify flatten and intersect

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -146,7 +146,7 @@ const approaches = {
     R.union(left, right),
   examples: ({ examples: left = [] }, { examples: right = [] }) =>
     combinations(left.filter(isObject), right.filter(isObject), ([a, b]) =>
-      R.mergeDeepRight({ ...a }, { ...b }),
+      R.mergeDeepRight(a, b),
     ),
   description: ({ description: left }, { description: right }) => left || right,
 } satisfies {

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -152,7 +152,7 @@ export const depictIntersection = R.tryCatch<Depicter>(
       if (entry.type !== "object") throw "not objects";
       if (!canMerge(entry)) throw "can not merge";
     }
-    return flattenIO(jsonSchema, "suggestive");
+    return flattenIO(jsonSchema, "throw");
   },
   (_err, { jsonSchema }) => jsonSchema,
 );

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -132,26 +132,10 @@ export const depictUnion: Depicter = ({ zodSchema, jsonSchema }) => {
   };
 };
 
-const canMerge = R.pipe(
-  Object.keys,
-  R.without([
-    "type",
-    "properties",
-    "required",
-    "examples",
-    "description",
-  ] satisfies Array<keyof JSONSchema.ObjectSchema>),
-  R.isEmpty,
-);
-
 export const depictIntersection = R.tryCatch<Depicter>(
   ({ jsonSchema }) => {
     if (!jsonSchema.allOf) throw "no allOf";
-    for (const entry of jsonSchema.allOf) {
-      unref(entry); // @todo move those things into flattenIO under suggestive flag
-      if (entry.type !== "object") throw "not objects";
-      if (!canMerge(entry)) throw "can not merge";
-    }
+    for (const entry of jsonSchema.allOf) unref(entry);
     return flattenIO(jsonSchema, "throw");
   },
   (_err, { jsonSchema }) => jsonSchema,

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -382,7 +382,7 @@ export const depictRequestParams = ({
             ? depicted.examples // own examples or from the flat:
             : R.pluck(
                 name,
-                flat.examples.filter(R.both(isObject, R.has(name))),
+                flat.examples?.filter(R.both(isObject, R.has(name))) || [],
               ),
         ),
       });
@@ -705,10 +705,10 @@ export const depictBody = ({
       examples.length
         ? examples
         : flattenIO(request)
-            .examples.filter(
+            .examples?.filter(
               (one): one is FlatObject => isObject(one) && !Array.isArray(one),
             )
-            .map(R.omit(paramNames)),
+            .map(R.omit(paramNames)) || [],
     ),
   };
   const body: RequestBodyObject = {

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -374,7 +374,7 @@ export const depictRequestParams = ({
         name,
         in: location,
         deprecated: jsonSchema.deprecated,
-        required: flat.required.includes(name),
+        required: flat.required?.includes(name) || false,
         description: depicted.description || description,
         schema: result,
         examples: enumerateExamples(

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -29,17 +29,13 @@ export const flattenIO = (
   mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [{ entry: jsonSchema, isOptional: false }];
-  const flat: Pick<JSONSchema.ObjectSchema, "description"> &
+  const flat: Pick<JSONSchema.ObjectSchema, "description" | "examples"> &
     Required<
-      Pick<
-        JSONSchema.ObjectSchema,
-        "type" | "properties" | "required" | "examples"
-      >
+      Pick<JSONSchema.ObjectSchema, "type" | "properties" | "required">
     > = {
     type: "object",
     properties: {},
     required: [],
-    examples: [],
   };
   while (stack.length) {
     const { entry, isOptional } = stack.shift()!;
@@ -72,12 +68,12 @@ export const flattenIO = (
       if (!isOptional && entry.required)
         flat.required = R.union(flat.required, entry.required);
     }
-    if (entry.examples) {
+    if (entry.examples?.length) {
       if (isOptional) {
-        flat.examples.push(...entry.examples);
+        flat.examples = R.concat(flat.examples || [], entry.examples);
       } else {
         flat.examples = combinations(
-          flat.examples.filter(isObject),
+          flat.examples?.filter(isObject) || [],
           entry.examples.filter(isObject),
           ([a, b]) => R.mergeDeepRight(a, b),
         );

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -29,11 +29,8 @@ export const flattenIO = (
   mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [{ entry: jsonSchema, isOptional: false }];
-  const flat: Pick<
-    JSONSchema.ObjectSchema,
-    "description" | "examples" | "required"
-  > &
-    Required<Pick<JSONSchema.ObjectSchema, "type" | "properties">> = {
+  const flat: JSONSchema.ObjectSchema &
+    Required<Pick<JSONSchema.ObjectSchema, "properties">> = {
     type: "object",
     properties: {},
   };

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -29,12 +29,13 @@ export const flattenIO = (
   mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [{ entry: jsonSchema, isOptional: false }];
-  const flat: Required<
-    Pick<
-      JSONSchema.ObjectSchema,
-      "type" | "properties" | "required" | "examples"
-    >
-  > = {
+  const flat: Pick<JSONSchema.ObjectSchema, "description"> &
+    Required<
+      Pick<
+        JSONSchema.ObjectSchema,
+        "type" | "properties" | "required" | "examples"
+      >
+    > = {
     type: "object",
     properties: {},
     required: [],
@@ -42,6 +43,7 @@ export const flattenIO = (
   };
   while (stack.length) {
     const { entry, isOptional } = stack.shift()!;
+    if (entry.description) flat.description ??= entry.description;
     if (entry.allOf) {
       stack.push(
         ...entry.allOf.map((one) => {

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -61,10 +61,9 @@ export const flattenIO = (jsonSchema: JSONSchema.BaseSchema) => {
         );
       }
       const value = { ...Object(entry.additionalProperties) }; // it can be bool
-      for (const key of keys) flat.properties[key] = value;
-      if (!isOptional) flat.required.push(...keys);
+      for (const key of keys) flat.properties[key] ??= value;
+      if (!isOptional) flat.required = R.union(flat.required, keys);
     }
   }
-  if (flat.required.length > 1) flat.required = [...new Set(flat.required)]; // drop duplicates
   return flat;
 };

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -29,13 +29,13 @@ export const flattenIO = (
   mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [{ entry: jsonSchema, isOptional: false }];
-  const flat: Pick<JSONSchema.ObjectSchema, "description" | "examples"> &
-    Required<
-      Pick<JSONSchema.ObjectSchema, "type" | "properties" | "required">
-    > = {
+  const flat: Pick<
+    JSONSchema.ObjectSchema,
+    "description" | "examples" | "required"
+  > &
+    Required<Pick<JSONSchema.ObjectSchema, "type" | "properties">> = {
     type: "object",
     properties: {},
-    required: [],
   };
   while (stack.length) {
     const { entry, isOptional } = stack.shift()!;
@@ -65,8 +65,8 @@ export const flattenIO = (
         flat.properties,
         entry.properties,
       );
-      if (!isOptional && entry.required)
-        flat.required = R.union(flat.required, entry.required);
+      if (!isOptional && entry.required?.length)
+        flat.required = R.union(flat.required || [], entry.required);
     }
     if (entry.examples?.length) {
       if (isOptional) {
@@ -90,7 +90,7 @@ export const flattenIO = (
       }
       const value = { ...Object(entry.additionalProperties) }; // it can be bool
       for (const key of keys) flat.properties[key] ??= value;
-      if (!isOptional) flat.required = R.union(flat.required, keys);
+      if (!isOptional) flat.required = R.union(flat.required || [], keys);
     }
   }
   return flat;

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@zod/core";
+import * as R from "ramda";
 import { combinations, isObject } from "./common-helpers";
 
 const isJsonObjectSchema = (
@@ -35,8 +36,9 @@ export const flattenIO = (jsonSchema: JSONSchema.BaseSchema) => {
     }
     if (!isJsonObjectSchema(entry)) continue;
     if (entry.properties) {
-      Object.assign(flat.properties, entry.properties);
-      if (!isOptional && entry.required) flat.required.push(...entry.required);
+      flat.properties = R.mergeDeepRight(flat.properties, entry.properties); // @todo or mergeDeepWith?
+      if (!isOptional && entry.required)
+        flat.required = R.union(flat.required, entry.required);
     }
     if (entry.examples) {
       if (isOptional) {
@@ -45,7 +47,7 @@ export const flattenIO = (jsonSchema: JSONSchema.BaseSchema) => {
         flat.examples = combinations(
           flat.examples.filter(isObject),
           entry.examples.filter(isObject),
-          ([a, b]) => ({ ...a, ...b }),
+          ([a, b]) => R.mergeDeepRight(a, b),
         );
       }
     }

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -12,10 +12,9 @@ const propsMerger = R.mergeDeepWith((a: unknown, b: unknown) => {
   throw new Error("Can not flatten properties");
 });
 
-/** @todo DNRY with intersect() */
 export const flattenIO = (
   jsonSchema: JSONSchema.BaseSchema,
-  mode: "coercive" | "suggestive" = "coercive", // throws in suggestive mode
+  mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [{ entry: jsonSchema, isOptional: false }];
   const flat: Required<
@@ -45,7 +44,7 @@ export const flattenIO = (
     }
     if (!isJsonObjectSchema(entry)) continue;
     if (entry.properties) {
-      flat.properties = (mode === "coercive" ? R.mergeDeepRight : propsMerger)(
+      flat.properties = (mode === "throw" ? propsMerger : R.mergeDeepRight)(
         flat.properties,
         entry.properties,
       );

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -122,18 +122,20 @@ exports[`Documentation helpers > depictIntersection() > should NOT flatten objec
 
 exports[`Documentation helpers > depictIntersection() > should flatten objects with same prop of same type 1`] = `
 {
+  "examples": [],
   "properties": {
     "one": {
       "type": "number",
     },
   },
+  "required": [],
   "type": "object",
 }
 `;
 
 exports[`Documentation helpers > depictIntersection() > should flatten two object schemas 1`] = `
 {
-  "description": "some",
+  "examples": [],
   "properties": {
     "one": {
       "type": "number",
@@ -142,18 +144,23 @@ exports[`Documentation helpers > depictIntersection() > should flatten two objec
       "type": "number",
     },
   },
+  "required": [],
   "type": "object",
 }
 `;
 
 exports[`Documentation helpers > depictIntersection() > should maintain uniqueness in the array of required props 1`] = `
 {
+  "examples": [],
   "properties": {
     "test": {
       "const": 5,
       "type": "number",
     },
   },
+  "required": [
+    "test",
+  ],
   "type": "object",
 }
 `;
@@ -174,6 +181,7 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
       "type": "number",
     },
   },
+  "required": [],
   "type": "object",
 }
 `;

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -127,7 +127,6 @@ exports[`Documentation helpers > depictIntersection() > should flatten objects w
       "type": "number",
     },
   },
-  "required": [],
   "type": "object",
 }
 `;
@@ -143,7 +142,6 @@ exports[`Documentation helpers > depictIntersection() > should flatten two objec
       "type": "number",
     },
   },
-  "required": [],
   "type": "object",
 }
 `;
@@ -179,7 +177,6 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
       "type": "number",
     },
   },
-  "required": [],
   "type": "object",
 }
 `;

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -135,6 +135,7 @@ exports[`Documentation helpers > depictIntersection() > should flatten objects w
 
 exports[`Documentation helpers > depictIntersection() > should flatten two object schemas 1`] = `
 {
+  "description": "some",
   "examples": [],
   "properties": {
     "one": {

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -122,7 +122,6 @@ exports[`Documentation helpers > depictIntersection() > should NOT flatten objec
 
 exports[`Documentation helpers > depictIntersection() > should flatten objects with same prop of same type 1`] = `
 {
-  "examples": [],
   "properties": {
     "one": {
       "type": "number",
@@ -136,7 +135,6 @@ exports[`Documentation helpers > depictIntersection() > should flatten objects w
 exports[`Documentation helpers > depictIntersection() > should flatten two object schemas 1`] = `
 {
   "description": "some",
-  "examples": [],
   "properties": {
     "one": {
       "type": "number",
@@ -152,7 +150,6 @@ exports[`Documentation helpers > depictIntersection() > should flatten two objec
 
 exports[`Documentation helpers > depictIntersection() > should maintain uniqueness in the array of required props 1`] = `
 {
-  "examples": [],
   "properties": {
     "test": {
       "const": 5,

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -863,6 +863,7 @@ paths:
                   required:
                     - one
                     - two
+                  examples: []
               required:
                 - intersection
         required: true
@@ -891,6 +892,7 @@ paths:
                         required:
                           - five
                           - six
+                        examples: []
                     required:
                       - and
                 required:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -863,7 +863,6 @@ paths:
                   required:
                     - one
                     - two
-                  examples: []
               required:
                 - intersection
         required: true
@@ -892,7 +891,6 @@ paths:
                         required:
                           - five
                           - six
-                        examples: []
                     required:
                       - and
                 required:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -400,7 +400,6 @@ paths:
             schema:
               type: object
               properties: {}
-              required: []
       security:
         - HTTP_1: []
           OAUTH2_1:
@@ -459,7 +458,6 @@ paths:
             schema:
               type: object
               properties: {}
-              required: []
       security:
         - HTTP_2: []
       responses:

--- a/express-zod-api/tests/__snapshots__/json-schema-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/json-schema-helpers.spec.ts.snap
@@ -30,7 +30,6 @@ exports[`JSON Schema helpers > flattenIO() > should handle records 1`] = `
       "type": "string",
     },
   },
-  "required": [],
   "type": "object",
 }
 `;
@@ -96,7 +95,6 @@ exports[`JSON Schema helpers > flattenIO() > should return object schema for the
       "type": "number",
     },
   },
-  "required": [],
   "type": "object",
 }
 `;

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -254,8 +254,16 @@ describe("Documentation helpers", () => {
     test("should maintain uniqueness in the array of required props", () => {
       const jsonSchema: JSONSchema.BaseSchema = {
         allOf: [
-          { type: "object", properties: { test: { type: "number" } } },
-          { type: "object", properties: { test: { const: 5 } } },
+          {
+            type: "object",
+            properties: { test: { type: "number" } },
+            required: ["test"],
+          },
+          {
+            type: "object",
+            properties: { test: { const: 5 } },
+            required: ["test"],
+          },
         ],
       };
       expect(


### PR DESCRIPTION
Caused by #2595 
`flattenIO` and `intersect` are doing very similar things.
first one is coercive, last one is suggestive.
Seeking for a way to unify them into one