### PR TITLE
Replacing `R.union()`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ const performanceConcerns = [
     message: "flatMap() is about 1.3x slower than R.chain()",
   },
   {
-    selector: "MemberExpression[object.name='R'] > Identifier[name='union']",
+    selector: "MemberExpression[object.name='R'] > Identifier[name='union']", // #2599
     message: "R.union() is 1.5x slower than [...Set().add()]",
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,10 @@ const performanceConcerns = [
     selector: "CallExpression[callee.property.name='flatMap']", // #2209
     message: "flatMap() is about 1.3x slower than R.chain()",
   },
+  {
+    selector: "MemberExpression[object.name='R'] > Identifier[name='union']",
+    message: "R.union() is 1.5x slower than [...Set().add()]",
+  },
 ];
 
 const tsFactoryConcerns = [

--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -1,7 +1,7 @@
 import * as R from "ramda";
 import { bench } from "vitest";
 
-describe("Experiment for key lookup", () => {
+describe("Experiment for unique elements", () => {
   const current = ["one", "two"];
 
   bench("set", () => {

--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -2,30 +2,13 @@ import * as R from "ramda";
 import { bench } from "vitest";
 
 describe("Experiment for key lookup", () => {
-  const subject = {
-    a: 1,
-    b: 2,
-    c: 3,
-  };
+  const current = ["one", "two"];
 
-  bench("in", () => {
-    return void ("a" in subject && "b" in subject && "c" in subject);
+  bench("set", () => {
+    return void [...new Set(current).add("null")];
   });
 
-  bench("R.has", () => {
-    return void (
-      R.has("a", subject) &&
-      R.has("b", subject) &&
-      R.has("c", subject)
-    );
-  });
-
-  bench("Object.keys + includes", () => {
-    const keys = Object.keys(subject);
-    return void (
-      keys.includes("a") &&
-      keys.includes("b") &&
-      keys.includes("c")
-    );
+  bench("R.union", () => {
+    return void R.union(current, ["null"]);
   });
 });

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -36,6 +36,7 @@ export const flattenIO = (
     type: "object",
     properties: {},
   };
+  const flatRequired: string[] = [];
   while (stack.length) {
     const [isOptional, entry] = stack.shift()!;
     if (entry.description) flat.description ??= entry.description;
@@ -56,8 +57,7 @@ export const flattenIO = (
         flat.properties,
         entry.properties,
       );
-      if (!isOptional && entry.required?.length)
-        flat.required = R.union(flat.required || [], entry.required);
+      if (!isOptional && entry.required) flatRequired.push(...entry.required);
     }
     if (entry.examples?.length) {
       if (isOptional) {
@@ -81,8 +81,9 @@ export const flattenIO = (
       }
       const value = { ...Object(entry.additionalProperties) }; // it can be bool
       for (const key of keys) flat.properties[key] ??= value;
-      if (!isOptional) flat.required = R.union(flat.required || [], keys);
+      if (!isOptional) flatRequired.push(...keys);
     }
   }
+  if (flatRequired.length) flat.required = [...new Set(flatRequired)];
   return flat;
 };


### PR DESCRIPTION
```
 ✓ bench/experiment.bench.ts > Experiment for key lookup 4612ms
     name               hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · set      4,577,119.53  0.0002  0.7375  0.0002  0.0002  0.0003  0.0003  0.0006  ±0.87%  2288560   fastest
   · R.union  2,958,612.29  0.0003  0.2822  0.0003  0.0003  0.0004  0.0006  0.0007  ±0.83%  1479307

 BENCH  Summary

  set - bench/experiment.bench.ts > Experiment for key lookup
    1.55x faster than R.union
```