### PR TITLE
Optionals: Restore `undefined`, but depending on `optionality`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - The `brandHandling` should consist of postprocessing functions altering the depiction made by Zod 4;
   - The `Depicter` type signature changed;
 - The `optionalPropStyle` option removed from `Integration` class constructor:
-  - Use `.optional()` to add question mark to the object property;
+  - Use `.optional()` to add question mark to the object property as well as `undefined` to its type;
   - Use `.or(z.undefined())` to add `undefined` to the type of the object property;
   - Reasoning: https://x.com/colinhacks/status/1919292504861491252;
   - `z.any()` and `z.unknown()` are not optional, details: https://v4.zod.dev/v4/changelog#changes-zunknown-optionality.

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -1,6 +1,6 @@
 type Type1 = {
   title: string;
-  features?: Type1[];
+  features?: Type1[] | undefined;
 };
 
 type SomeOf<T> = T[keyof T];
@@ -265,15 +265,15 @@ interface PostV1AvatarRawNegativeResponseVariants {
 /** get /v1/events/stream */
 type GetV1EventsStreamInput = {
   /** @deprecated for testing error response */
-  trigger?: string;
+  trigger?: string | undefined;
 };
 
 /** get /v1/events/stream */
 type GetV1EventsStreamPositiveVariant1 = {
   data: number;
   event: "time";
-  id?: string;
-  retry?: number;
+  id?: string | undefined;
+  retry?: number | undefined;
 };
 
 /** get /v1/events/stream */

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -142,11 +142,17 @@ export const makeInterfaceProp = (
     comment,
   }: { isOptional?: boolean; isDeprecated?: boolean; comment?: string } = {},
 ) => {
+  const propType = ensureTypeNode(value);
   const node = f.createPropertySignature(
     undefined,
     makePropertyIdentifier(name),
     isOptional ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
-    ensureTypeNode(value),
+    isOptional
+      ? f.createUnionTypeNode([
+          propType,
+          ensureTypeNode(ts.SyntaxKind.UndefinedKeyword),
+        ])
+      : propType,
   );
   const jsdoc = R.reject(R.isNil, [
     isDeprecated ? "@deprecated" : undefined,

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -282,14 +282,14 @@ exports[`Integration > Should treat optionals the same way as z.infer() by defau
 
 /** post /v1/test-with-dashes */
 type PostV1TestWithDashesInput = {
-  opt?: string;
+  opt?: string | undefined;
 };
 
 /** post /v1/test-with-dashes */
 type PostV1TestWithDashesPositiveVariant1 = {
   status: "success";
   data: {
-    similar?: number;
+    similar?: number | undefined;
   };
 };
 

--- a/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
@@ -22,14 +22,14 @@ exports[`zod-to-ts > Example > should produce the expected results 1`] = `
     any: any;
     unknown: any;
     never: any;
-    optionalString?: string;
+    optionalString?: string | undefined;
     nullablePartialObject: {
-        string?: string;
-        number?: number;
-        fixedArrayOfString?: string[];
+        string?: string | undefined;
+        number?: number | undefined;
+        fixedArrayOfString?: string[] | undefined;
         object?: {
             string: string;
-        };
+        } | undefined;
     } | null;
     tuple: [
         string,
@@ -57,7 +57,7 @@ exports[`zod-to-ts > Example > should produce the expected results 1`] = `
     set: any;
     intersection: (string & number) | bigint;
     promise: any;
-    optDefaultString?: string;
+    optDefaultString?: string | undefined;
     refinedStringWithSomeBullshit: (string | number) & (bigint | null);
     nativeEnum: "A" | "apple" | "banana" | "cantaloupe" | 5;
     lazy: SomeType;
@@ -127,7 +127,7 @@ exports[`zod-to-ts > Issue #2352: intersection of objects having same prop %# > 
 "{
     query: string;
 } & {
-    query?: string;
+    query?: string | undefined;
 }"
 `;
 
@@ -135,7 +135,7 @@ exports[`zod-to-ts > Issue #2352: intersection of objects having same prop %# > 
 "{
     query: string;
 } & {
-    query?: string;
+    query?: string | undefined;
 }"
 `;
 
@@ -272,7 +272,7 @@ exports[`zod-to-ts > z.optional() > Zod 4: does not add undefined to it, unwrap 
 
 exports[`zod-to-ts > z.optional() > Zod 4: should add question mark only to optional props 1`] = `
 "{
-    optional?: string;
+    optional?: string | undefined;
     required: string;
     transform: number;
     or: number | string;
@@ -280,9 +280,9 @@ exports[`zod-to-ts > z.optional() > Zod 4: should add question mark only to opti
         string,
         number,
         {
-            optional?: string;
+            optional?: string | undefined;
             required: string;
         }
-    ];
+    ] | undefined;
 }"
 `;

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -1,6 +1,5 @@
 import createHttpError from "http-errors";
 import * as R from "ramda";
-import { expectTypeOf } from "vitest";
 import { z } from "zod";
 
 describe("Environment checks", () => {

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -1,5 +1,6 @@
 import createHttpError from "http-errors";
 import * as R from "ramda";
+import { expectTypeOf } from "vitest";
 import { z } from "zod";
 
 describe("Environment checks", () => {
@@ -122,6 +123,18 @@ describe("Environment checks", () => {
       expect(schema._zod.def.shape.three._zod.optionality).toBe("defaulted");
       /** @link https://github.com/colinhacks/zod/issues/4322 */
       expect(schema._zod.def.shape.four._zod.optionality).not.toBe("optional"); // <— undefined
+      expectTypeOf<z.input<typeof schema>>().toEqualTypeOf<{
+        one: boolean;
+        two?: boolean | undefined;
+        three?: boolean | undefined;
+        four: boolean | undefined;
+      }>();
+      expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<{
+        one: boolean;
+        two?: boolean | undefined;
+        three: boolean;
+        four: boolean;
+      }>();
     });
 
     test("coerce is safe for nullable and optional", () => {


### PR DESCRIPTION
Partially reverts 773b212f51921da7704105c8a45cf2373908e752 from #2604 
But this implementation does it depending on `optionality` which in its turn depends on direction.
This takes Collin explanaition into account https://x.com/colinhacks/status/1919292504861491252
And adds env test to ensure that.