### PR TITLE
Branding: no altering refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
   - Use `.or(z.undefined())` to add `undefined` to the type of the object property;
   - Reasoning: https://x.com/colinhacks/status/1919292504861491252;
   - `z.any()` and `z.unknown()` are not optional, details: https://v4.zod.dev/v4/changelog#changes-zunknown-optionality.
-- Changes to the plugin:
-  - Brand is the only kind of metadata that withstands refinements and checks.
 - Consider the automated migration using the built-in ESLint rule.
 
 ```js

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -1,12 +1,11 @@
 import type { $ZodType, JSONSchema } from "zod/v4/core";
 import * as R from "ramda";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import { ezDateInBrand } from "./date-in-schema";
 import { ezDateOutBrand } from "./date-out-schema";
 import { DeepCheckError } from "./errors";
 import { ezFormBrand } from "./form-schema";
 import { IOSchema } from "./io-schema";
-import { metaSymbol } from "./metadata";
 import { FirstPartyKind } from "./schema-walker";
 import { ezUploadBrand } from "./upload-schema";
 import { ezRawBrand } from "./raw-schema";
@@ -61,7 +60,7 @@ export const hasCycle = (
 export const findRequestTypeDefiningSchema = (subject: IOSchema) =>
   findNestedSchema(subject, {
     condition: (schema) => {
-      const { brand } = globalRegistry.get(schema)?.[metaSymbol] || {};
+      const { brand } = schema._zod.bag;
       return (
         typeof brand === "symbol" &&
         [ezUploadBrand, ezRawBrand, ezFormBrand].includes(brand)
@@ -88,7 +87,7 @@ export const findJsonIncompatible = (
   findNestedSchema(subject, {
     io,
     condition: (zodSchema) => {
-      const { brand } = globalRegistry.get(zodSchema)?.[metaSymbol] || {};
+      const { brand } = zodSchema._zod.bag;
       const { type } = zodSchema._zod.def;
       if (unsupported.includes(type)) return true;
       if (io === "input") {

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -6,6 +6,7 @@ import { ezDateOutBrand } from "./date-out-schema";
 import { DeepCheckError } from "./errors";
 import { ezFormBrand } from "./form-schema";
 import { IOSchema } from "./io-schema";
+import { getBrand } from "./metadata";
 import { FirstPartyKind } from "./schema-walker";
 import { ezUploadBrand } from "./upload-schema";
 import { ezRawBrand } from "./raw-schema";
@@ -60,7 +61,7 @@ export const hasCycle = (
 export const findRequestTypeDefiningSchema = (subject: IOSchema) =>
   findNestedSchema(subject, {
     condition: (schema) => {
-      const { brand } = schema._zod.bag;
+      const brand = getBrand(schema);
       return (
         typeof brand === "symbol" &&
         [ezUploadBrand, ezRawBrand, ezFormBrand].includes(brand)
@@ -87,7 +88,7 @@ export const findJsonIncompatible = (
   findNestedSchema(subject, {
     io,
     condition: (zodSchema) => {
-      const { brand } = zodSchema._zod.bag;
+      const brand = getBrand(zodSchema);
       const { type } = zodSchema._zod.def;
       if (unsupported.includes(type)) return true;
       if (io === "input") {

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -463,8 +463,7 @@ const depict = (
       unrepresentable: "any",
       io: ctx.isResponse ? "output" : "input",
       override: (zodCtx) => {
-        const { brand } =
-          globalRegistry.get(zodCtx.zodSchema)?.[metaSymbol] ?? {};
+        const { brand } = zodCtx.zodSchema._zod.bag;
         const depicter =
           rules[
             brand && brand in rules ? brand : zodCtx.zodSchema._zod.def.type

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -47,7 +47,7 @@ import { ezFileBrand } from "./file-schema";
 import { IOSchema } from "./io-schema";
 import { flattenIO } from "./json-schema-helpers";
 import { Alternatives } from "./logical-container";
-import { metaSymbol } from "./metadata";
+import { getBrand, metaSymbol } from "./metadata";
 import { Method } from "./method";
 import { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand } from "./raw-schema";
@@ -463,15 +463,10 @@ const depict = (
       unrepresentable: "any",
       io: ctx.isResponse ? "output" : "input",
       override: (zodCtx) => {
-        const { brand } = zodCtx.zodSchema._zod.bag;
+        const brand = getBrand(zodCtx.zodSchema);
         const depicter =
           rules[
-            (typeof brand === "symbol" ||
-              typeof brand === "string" ||
-              typeof brand === "number") &&
-            brand in rules
-              ? brand
-              : zodCtx.zodSchema._zod.def.type
+            brand && brand in rules ? brand : zodCtx.zodSchema._zod.def.type
           ];
         if (depicter) {
           const overrides = { ...depicter(zodCtx, ctx) };

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -466,7 +466,12 @@ const depict = (
         const { brand } = zodCtx.zodSchema._zod.bag;
         const depicter =
           rules[
-            brand && brand in rules ? brand : zodCtx.zodSchema._zod.def.type
+            (typeof brand === "symbol" ||
+              typeof brand === "string" ||
+              typeof brand === "number") &&
+            brand in rules
+              ? brand
+              : zodCtx.zodSchema._zod.def.type
           ];
         if (depicter) {
           const overrides = { ...depicter(zodCtx, ctx) };

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import * as R from "ramda";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import { NormalizedResponse, ResponseVariant } from "./api-response";
 import { findRequestTypeDefiningSchema } from "./deep-checks";
 import {
@@ -20,7 +20,6 @@ import { IOSchema } from "./io-schema";
 import { lastResortHandler } from "./last-resort";
 import { ActualLogger } from "./logger-helpers";
 import { LogicalContainer } from "./logical-container";
-import { metaSymbol } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import { ContentType } from "./content-type";
@@ -144,7 +143,7 @@ export class Endpoint<
   public override get requestType() {
     const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
     if (found) {
-      const { brand } = globalRegistry.get(found)?.[metaSymbol] || {};
+      const { brand } = found._zod.bag;
       if (brand === ezUploadBrand) return "upload";
       if (brand === ezRawBrand) return "raw";
       if (brand === ezFormBrand) return "form";

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -20,6 +20,7 @@ import { IOSchema } from "./io-schema";
 import { lastResortHandler } from "./last-resort";
 import { ActualLogger } from "./logger-helpers";
 import { LogicalContainer } from "./logical-container";
+import { getBrand } from "./metadata";
 import { AuxMethod, Method } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import { ContentType } from "./content-type";
@@ -143,7 +144,7 @@ export class Endpoint<
   public override get requestType() {
     const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
     if (found) {
-      const { brand } = found._zod.bag;
+      const brand = getBrand(found);
       if (brand === ezUploadBrand) return "upload";
       if (brand === ezRawBrand) return "raw";
       if (brand === ezFormBrand) return "form";

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -35,9 +35,7 @@ export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
   });
 };
 
-export const getBrand = (
-  subject: $ZodType,
-): string | number | symbol | undefined => {
+export const getBrand = (subject: $ZodType) => {
   const { brand } = subject._zod.bag;
   if (
     typeof brand === "symbol" ||

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -1,3 +1,4 @@
+import type { $ZodType } from "zod/v4/core";
 import { combinations } from "./common-helpers";
 import { z } from "zod/v4";
 import * as R from "ramda";
@@ -32,4 +33,17 @@ export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
     ...destMeta,
     [metaSymbol]: { ...destMeta?.[metaSymbol], examples },
   });
+};
+
+export const getBrand = (
+  subject: $ZodType,
+): string | number | symbol | undefined => {
+  const { brand } = subject._zod.bag;
+  if (
+    typeof brand === "symbol" ||
+    typeof brand === "string" ||
+    typeof brand === "number"
+  )
+    return brand;
+  return undefined;
 };

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -8,7 +8,6 @@ export interface Metadata {
   examples: unknown[];
   /** @override ZodDefault::_zod.def.defaultValue() in depictDefault */
   defaultLabel?: string;
-  brand?: string | number | symbol;
 }
 
 export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -1,7 +1,5 @@
 import type { $ZodType, $ZodTypeDef } from "zod/v4/core";
-import { globalRegistry } from "zod/v4";
 import type { EmptyObject, FlatObject } from "./common-helpers";
-import { metaSymbol } from "./metadata";
 
 export type FirstPartyKind = $ZodTypeDef["type"];
 
@@ -51,7 +49,7 @@ export const walkSchema = <
     onMissing: SchemaHandler<U, Context, "last">;
   },
 ): U => {
-  const brand = globalRegistry.get(schema)?.[metaSymbol]?.brand;
+  const { brand } = schema._zod.bag;
   const handler =
     brand && brand in rules
       ? rules[brand as keyof typeof rules]

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -1,5 +1,6 @@
 import type { $ZodType, $ZodTypeDef } from "zod/v4/core";
 import type { EmptyObject, FlatObject } from "./common-helpers";
+import { getBrand } from "./metadata";
 
 export type FirstPartyKind = $ZodTypeDef["type"];
 
@@ -49,12 +50,9 @@ export const walkSchema = <
     onMissing: SchemaHandler<U, Context, "last">;
   },
 ): U => {
-  const { brand } = schema._zod.bag;
+  const brand = getBrand(schema);
   const handler =
-    (typeof brand === "symbol" ||
-      typeof brand === "string" ||
-      typeof brand === "number") &&
-    brand in rules
+    brand && brand in rules
       ? rules[brand as keyof typeof rules]
       : rules[schema._zod.def.type];
   const next = (subject: $ZodType) =>

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -51,7 +51,10 @@ export const walkSchema = <
 ): U => {
   const { brand } = schema._zod.bag;
   const handler =
-    brand && brand in rules
+    (typeof brand === "symbol" ||
+      typeof brand === "string" ||
+      typeof brand === "number") &&
+    brand in rules
       ? rules[brand as keyof typeof rules]
       : rules[schema._zod.def.type];
   const next = (subject: $ZodType) =>

--- a/express-zod-api/tests/date-in-schema.spec.ts
+++ b/express-zod-api/tests/date-in-schema.spec.ts
@@ -1,13 +1,14 @@
 import { z } from "zod/v4";
 import { ezDateInBrand } from "../src/date-in-schema";
 import { ez } from "../src";
+import { getBrand } from "../src/metadata";
 
 describe("ez.dateIn()", () => {
   describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateIn();
       expect(schema).toBeInstanceOf(z.ZodPipe);
-      expect(schema._zod.bag).toHaveProperty("brand", ezDateInBrand);
+      expect(getBrand(schema)).toBe(ezDateInBrand);
     });
   });
 

--- a/express-zod-api/tests/date-in-schema.spec.ts
+++ b/express-zod-api/tests/date-in-schema.spec.ts
@@ -1,14 +1,13 @@
 import { z } from "zod/v4";
 import { ezDateInBrand } from "../src/date-in-schema";
 import { ez } from "../src";
-import { metaSymbol } from "../src/metadata";
 
 describe("ez.dateIn()", () => {
   describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateIn();
       expect(schema).toBeInstanceOf(z.ZodPipe);
-      expect(schema.meta()?.[metaSymbol]?.brand).toEqual(ezDateInBrand);
+      expect(schema._zod.bag).toHaveProperty("brand", ezDateInBrand);
     });
   });
 

--- a/express-zod-api/tests/date-out-schema.spec.ts
+++ b/express-zod-api/tests/date-out-schema.spec.ts
@@ -1,14 +1,13 @@
 import { z } from "zod/v4";
 import { ezDateOutBrand } from "../src/date-out-schema";
 import { ez } from "../src";
-import { metaSymbol } from "../src/metadata";
 
 describe("ez.dateOut()", () => {
   describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateOut();
       expect(schema).toBeInstanceOf(z.ZodPipe);
-      expect(schema.meta()?.[metaSymbol]?.brand).toEqual(ezDateOutBrand);
+      expect(schema._zod.bag).toHaveProperty("brand", ezDateOutBrand);
     });
   });
 

--- a/express-zod-api/tests/date-out-schema.spec.ts
+++ b/express-zod-api/tests/date-out-schema.spec.ts
@@ -1,13 +1,14 @@
 import { z } from "zod/v4";
 import { ezDateOutBrand } from "../src/date-out-schema";
 import { ez } from "../src";
+import { getBrand } from "../src/metadata";
 
 describe("ez.dateOut()", () => {
   describe("creation", () => {
     test("should create an instance", () => {
       const schema = ez.dateOut();
       expect(schema).toBeInstanceOf(z.ZodPipe);
-      expect(schema._zod.bag).toHaveProperty("brand", ezDateOutBrand);
+      expect(getBrand(schema)).toBe(ezDateOutBrand);
     });
   });
 

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -1,15 +1,14 @@
 import { UploadedFile } from "express-fileupload";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import type { $brand, $ZodType } from "zod/v4/core";
 import { ez } from "../src";
 import { findNestedSchema, hasCycle } from "../src/deep-checks";
-import { metaSymbol } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {
     const condition = (subject: $ZodType) =>
-      globalRegistry.get(subject)?.[metaSymbol]?.brand === ezUploadBrand;
+      subject._zod.bag.brand === ezUploadBrand;
 
     test("should return true for given argument satisfying condition", () => {
       expect(
@@ -25,7 +24,7 @@ describe("Checks", () => {
       ez.upload().nullable(),
       ez.upload().default({} as UploadedFile & $brand<symbol>),
       z.record(z.string(), ez.upload()),
-      // ez.upload().refine(() => true), // @todo skipped
+      ez.upload().refine(() => true),
       z.array(ez.upload()),
     ])("should return true for wrapped needle %#", (subject) => {
       expect(

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -25,7 +25,7 @@ describe("Checks", () => {
       ez.upload().nullable(),
       ez.upload().default({} as UploadedFile & $brand<symbol>),
       z.record(z.string(), ez.upload()),
-      ez.upload().refine(() => true),
+      // ez.upload().refine(() => true), // @todo skipped
       z.array(ez.upload()),
     ])("should return true for wrapped needle %#", (subject) => {
       expect(

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -3,12 +3,13 @@ import { z } from "zod/v4";
 import type { $brand, $ZodType } from "zod/v4/core";
 import { ez } from "../src";
 import { findNestedSchema, hasCycle } from "../src/deep-checks";
+import { getBrand } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {
     const condition = (subject: $ZodType) =>
-      subject._zod.bag.brand === ezUploadBrand;
+      getBrand(subject) === ezUploadBrand;
 
     test("should return true for given argument satisfying condition", () => {
       expect(

--- a/express-zod-api/tests/file-schema.spec.ts
+++ b/express-zod-api/tests/file-schema.spec.ts
@@ -2,14 +2,13 @@ import { z } from "zod/v4";
 import { ezFileBrand } from "../src/file-schema";
 import { ez } from "../src";
 import { readFile } from "node:fs/promises";
-import { metaSymbol } from "../src/metadata";
 
 describe("ez.file()", () => {
   describe("creation", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
-      expect(schema.meta()?.[metaSymbol]?.brand).toBe(ezFileBrand);
+      expect(schema._zod.bag).toHaveProperty("brand", ezFileBrand);
     });
 
     test("should create a string file", () => {

--- a/express-zod-api/tests/file-schema.spec.ts
+++ b/express-zod-api/tests/file-schema.spec.ts
@@ -2,13 +2,14 @@ import { z } from "zod/v4";
 import { ezFileBrand } from "../src/file-schema";
 import { ez } from "../src";
 import { readFile } from "node:fs/promises";
+import { getBrand } from "../src/metadata";
 
 describe("ez.file()", () => {
   describe("creation", () => {
     test("should create an instance being string by default", () => {
       const schema = ez.file();
       expect(schema).toBeInstanceOf(z.ZodString);
-      expect(schema._zod.bag).toHaveProperty("brand", ezFileBrand);
+      expect(getBrand(schema)).toBe(ezFileBrand);
     });
 
     test("should create a string file", () => {

--- a/express-zod-api/tests/form-schema.spec.ts
+++ b/express-zod-api/tests/form-schema.spec.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
 import { ezFormBrand } from "../src/form-schema";
+import { getBrand } from "../src/metadata";
 
 describe("ez.form()", () => {
   describe("creation", () => {
@@ -9,7 +10,7 @@ describe("ez.form()", () => {
       (base) => {
         const schema = ez.form(base);
         expect(schema).toBeInstanceOf(z.ZodObject);
-        expect(schema._zod.bag).toHaveProperty("brand", ezFormBrand);
+        expect(getBrand(schema)).toBe(ezFormBrand);
         expect(schema._zod.def.shape).toHaveProperty(
           "name",
           expect.any(z.ZodString),

--- a/express-zod-api/tests/form-schema.spec.ts
+++ b/express-zod-api/tests/form-schema.spec.ts
@@ -1,7 +1,6 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
 import { ezFormBrand } from "../src/form-schema";
-import { metaSymbol } from "../src/metadata";
 
 describe("ez.form()", () => {
   describe("creation", () => {
@@ -10,7 +9,7 @@ describe("ez.form()", () => {
       (base) => {
         const schema = ez.form(base);
         expect(schema).toBeInstanceOf(z.ZodObject);
-        expect(schema.meta()?.[metaSymbol]?.brand).toBe(ezFormBrand);
+        expect(schema._zod.bag).toHaveProperty("brand", ezFormBrand);
         expect(schema._zod.def.shape).toHaveProperty(
           "name",
           expect.any(z.ZodString),

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -108,7 +108,7 @@ describe("Integration", () => {
         schema: ReturnType<z.ZodType["brand"]>,
         { next },
       ) => {
-        globalRegistry.remove(schema);
+        delete schema._zod.bag.brand;
         return next(schema);
       };
       const client = new Integration({

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import {
   EndpointsFactory,
   Integration,

--- a/express-zod-api/tests/raw-schema.spec.ts
+++ b/express-zod-api/tests/raw-schema.spec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
+import { getBrand } from "../src/metadata";
 import { ezRawBrand } from "../src/raw-schema";
 
 describe("ez.raw()", () => {
@@ -7,7 +8,7 @@ describe("ez.raw()", () => {
     test("should be an instance of branded object", () => {
       const schema = ez.raw();
       expect(schema).toBeInstanceOf(z.ZodObject);
-      expect(schema._zod.bag).toHaveProperty("brand", ezRawBrand);
+      expect(getBrand(schema)).toBe(ezRawBrand);
     });
   });
 

--- a/express-zod-api/tests/raw-schema.spec.ts
+++ b/express-zod-api/tests/raw-schema.spec.ts
@@ -1,6 +1,5 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
-import { metaSymbol } from "../src/metadata";
 import { ezRawBrand } from "../src/raw-schema";
 
 describe("ez.raw()", () => {
@@ -8,7 +7,7 @@ describe("ez.raw()", () => {
     test("should be an instance of branded object", () => {
       const schema = ez.raw();
       expect(schema).toBeInstanceOf(z.ZodObject);
-      expect(schema.meta()?.[metaSymbol]?.brand).toBe(ezRawBrand);
+      expect(schema._zod.bag).toHaveProperty("brand", ezRawBrand);
     });
   });
 

--- a/express-zod-api/tests/upload-schema.spec.ts
+++ b/express-zod-api/tests/upload-schema.spec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
+import { getBrand } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
 
 describe("ez.upload()", () => {
@@ -7,7 +8,7 @@ describe("ez.upload()", () => {
     test("should create an instance", () => {
       const schema = ez.upload();
       expect(schema).toBeInstanceOf(z.ZodCustom);
-      expect(schema._zod.bag).toHaveProperty("brand", ezUploadBrand);
+      expect(getBrand(schema)).toBe(ezUploadBrand);
     });
   });
 

--- a/express-zod-api/tests/upload-schema.spec.ts
+++ b/express-zod-api/tests/upload-schema.spec.ts
@@ -1,6 +1,5 @@
 import { z } from "zod/v4";
 import { ez } from "../src";
-import { metaSymbol } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
 
 describe("ez.upload()", () => {
@@ -8,7 +7,7 @@ describe("ez.upload()", () => {
     test("should create an instance", () => {
       const schema = ez.upload();
       expect(schema).toBeInstanceOf(z.ZodCustom);
-      expect(schema.meta()?.[metaSymbol]?.brand).toBe(ezUploadBrand);
+      expect(schema._zod.bag).toHaveProperty("brand", ezUploadBrand);
     });
   });
 

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -79,7 +79,7 @@ describe("Zod Runtime Plugin", () => {
       );
     });
 
-    test("should withstand refinements", () => {
+    test.skip("should withstand refinements", () => {
       const schema = z.string();
       const schemaWithMeta = schema.brand("test");
       expect(schemaWithMeta.meta()?.[metaSymbol]).toHaveProperty(

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -1,6 +1,6 @@
 import camelize from "camelize-ts";
 import { z } from "zod/v4";
-import { metaSymbol } from "../src/metadata";
+import { getBrand, metaSymbol } from "../src/metadata";
 
 describe("Zod Runtime Plugin", () => {
   describe(".example()", () => {
@@ -74,22 +74,19 @@ describe("Zod Runtime Plugin", () => {
 
   describe(".brand()", () => {
     test("should set the brand", () => {
-      expect(z.string().brand("test")._zod.bag).toHaveProperty("brand", "test");
+      expect(getBrand(z.string().brand("test"))).toBe("test");
     });
 
     test("should withstand refinements", () => {
       const schema = z.string();
       const schemaWithMeta = schema.brand("test");
-      expect(schemaWithMeta._zod.bag).toHaveProperty("brand", "test");
-      expect(schemaWithMeta.regex(/@example.com$/)._zod.bag).toHaveProperty(
-        "brand",
-        "test",
-      );
+      expect(getBrand(schemaWithMeta)).toBe("test");
+      expect(getBrand(schemaWithMeta.regex(/@example.com$/))).toBe("test");
     });
 
     test("should withstand describing", () => {
       const schema = z.string().brand("test").describe("something");
-      expect(schema._zod.bag).toHaveProperty("brand", "test");
+      expect(getBrand(schema)).toBe("test");
     });
   });
 

--- a/express-zod-api/tests/zod-plugin.spec.ts
+++ b/express-zod-api/tests/zod-plugin.spec.ts
@@ -74,26 +74,22 @@ describe("Zod Runtime Plugin", () => {
 
   describe(".brand()", () => {
     test("should set the brand", () => {
-      expect(z.string().brand("test").meta()?.[metaSymbol]?.brand).toEqual(
-        "test",
-      );
+      expect(z.string().brand("test")._zod.bag).toHaveProperty("brand", "test");
     });
 
-    test.skip("should withstand refinements", () => {
+    test("should withstand refinements", () => {
       const schema = z.string();
       const schemaWithMeta = schema.brand("test");
-      expect(schemaWithMeta.meta()?.[metaSymbol]).toHaveProperty(
+      expect(schemaWithMeta._zod.bag).toHaveProperty("brand", "test");
+      expect(schemaWithMeta.regex(/@example.com$/)._zod.bag).toHaveProperty(
         "brand",
         "test",
       );
-      expect(
-        schemaWithMeta.regex(/@example.com$/).meta()?.[metaSymbol],
-      ).toHaveProperty("brand", "test");
     });
 
     test("should withstand describing", () => {
       const schema = z.string().brand("test").describe("something");
-      expect(schema.meta()?.[metaSymbol]?.brand).toBe("test");
+      expect(schema._zod.bag).toHaveProperty("brand", "test");
     });
   });
 

--- a/express-zod-api/vitest.setup.ts
+++ b/express-zod-api/vitest.setup.ts
@@ -2,6 +2,7 @@ import "./src/zod-plugin"; // required for tests importing sources using the plu
 import type { NewPlugin } from "@vitest/pretty-format";
 import { z } from "zod/v4";
 import { ResultHandlerError } from "./src/errors";
+import { getBrand } from "./src/metadata";
 
 /** Takes cause and certain props of custom errors into account */
 const errorSerializer: NewPlugin = {
@@ -29,7 +30,7 @@ const schemaSerializer: NewPlugin = {
       unrepresentable: "any",
       override: ({ zodSchema, jsonSchema }) => {
         if (zodSchema._zod.def.type === "custom")
-          jsonSchema["x-brand"] = zodSchema._zod.bag.brand;
+          jsonSchema["x-brand"] = getBrand(zodSchema);
       },
     });
     return printer(serialization, config, indentation, depth, refs);

--- a/express-zod-api/vitest.setup.ts
+++ b/express-zod-api/vitest.setup.ts
@@ -1,8 +1,7 @@
 import "./src/zod-plugin"; // required for tests importing sources using the plugin methods
 import type { NewPlugin } from "@vitest/pretty-format";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import { ResultHandlerError } from "./src/errors";
-import { metaSymbol } from "./src/metadata";
 
 /** Takes cause and certain props of custom errors into account */
 const errorSerializer: NewPlugin = {
@@ -29,11 +28,8 @@ const schemaSerializer: NewPlugin = {
     const serialization = z.toJSONSchema(entity, {
       unrepresentable: "any",
       override: ({ zodSchema, jsonSchema }) => {
-        if (zodSchema._zod.def.type === "custom") {
-          jsonSchema["x-brand"] = globalRegistry
-            .get(zodSchema)
-            ?.[metaSymbol]?.brand?.toString();
-        }
+        if (zodSchema._zod.def.type === "custom")
+          jsonSchema["x-brand"] = zodSchema._zod.bag.brand;
       },
     });
     return printer(serialization, config, indentation, depth, refs);


### PR DESCRIPTION
For that, brand should not be a part of metadata, but somewhere else.
Presumably, in `def` because it withstands `.clone()`.
Or in `_zod.bag` as suggested by Colin.