### PR TITLE
Ref: no reassigning meta

### DIFF
--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -13,9 +13,9 @@ export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
     src.meta()?.examples ||
     (isSchema<$ZodObject>(src, "object") ? pullExampleProps(src) : undefined);
   if (!srcExamples?.length) return dest;
-  const destMeta = dest.meta();
+  const destExamples = dest.meta()?.examples || [];
   const examples = combinations<z.output<A> & z.output<B>>(
-    destMeta?.examples || [],
+    destExamples,
     srcExamples,
     ([destExample, srcExample]) =>
       typeof destExample === "object" &&
@@ -25,7 +25,7 @@ export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
         ? R.mergeDeepRight(destExample, srcExample)
         : srcExample, // not supposed to be called on non-object schemas
   );
-  return dest.meta({ ...destMeta, examples }); // @todo might not be required to spread since .meta() does it now
+  return dest.meta({ examples });
 };
 
 export const getBrand = (subject: $ZodType) => {

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -9,11 +9,13 @@ export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
   src: A,
   dest: B,
 ): B => {
-  const srcExamples =
-    src.meta()?.examples ||
-    (isSchema<$ZodObject>(src, "object") ? pullExampleProps(src) : undefined);
+  const {
+    examples: srcExamples = isSchema<$ZodObject>(src, "object")
+      ? pullExampleProps(src)
+      : undefined,
+  } = src.meta() || {};
   if (!srcExamples?.length) return dest;
-  const destExamples = dest.meta()?.examples || [];
+  const { examples: destExamples = [] } = dest.meta() || {};
   const examples = combinations<z.output<A> & z.output<B>>(
     destExamples,
     srcExamples,

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -103,10 +103,7 @@ const deprecationSetter = function (this: z.ZodType) {
 };
 
 const labelSetter = function (this: z.ZodDefault, defaultLabel: string) {
-  return this.meta({
-    ...this.meta(), // @todo this may no longer be required since it seems that .meta() merges now, not just overrides
-    default: defaultLabel,
-  });
+  return this.meta({ default: defaultLabel });
 };
 
 const brandSetter = function (

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -89,10 +89,10 @@ const $EZBrandCheck = z.core.$constructor<$EZBrandCheck>(
 );
 
 const exampleSetter = function (this: z.ZodType, value: z.output<typeof this>) {
-  const { examples = [], ...rest } = this.meta() || {};
+  const { examples = [] } = this.meta() || {};
   const copy = examples.slice();
   copy.push(value);
-  return this.meta({ ...rest, examples: copy });
+  return this.meta({ examples: copy });
 };
 
 const deprecationSetter = function (this: z.ZodType) {

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -96,10 +96,7 @@ const exampleSetter = function (this: z.ZodType, value: z.output<typeof this>) {
 };
 
 const deprecationSetter = function (this: z.ZodType) {
-  return this.meta({
-    ...this.meta(),
-    deprecated: true,
-  });
+  return this.meta({ deprecated: true });
 };
 
 const labelSetter = function (this: z.ZodDefault, defaultLabel: string) {

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -128,10 +128,7 @@ describe("Environment checks", () => {
       expect(boolSchema.isNullable()).toBeTruthy();
     });
 
-    /**
-     * @link https://github.com/colinhacks/zod/issues/4274
-     * @todo this fact can be used for switching to native examples
-     * */
+    /** @link https://github.com/colinhacks/zod/issues/4274 */
     test.each(["input", "output"] as const)(
       "%s examples of transformations",
       (io) => {


### PR DESCRIPTION
The stable Zod 4 merges metadata, not replaces it.
So it's now safe to set only one entry without spreading the prev state.