### PR TITLE
Cleanup: rm `depictObject`

### DIFF
--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -128,6 +128,7 @@ export const getTransformedType = R.tryCatch(
   R.always(undefined),
 );
 
+/** @todo check usage */
 export const isOptional = (
   { _zod: { optin, optout } }: $ZodType,
   { isResponse }: { isResponse: boolean },

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -1,5 +1,4 @@
 import type {
-  $ZodObject,
   $ZodPipe,
   $ZodTransform,
   $ZodTuple,
@@ -30,7 +29,6 @@ import {
   getRoutePathParams,
   getTransformedType,
   isObject,
-  isOptional,
   isSchema,
   makeCleanId,
   routePathParamsRegex,
@@ -152,23 +150,6 @@ export const depictLiteral: Depicter = ({ jsonSchema }) => ({
   type: typeof (jsonSchema.const || jsonSchema.enum?.[0]),
   ...jsonSchema,
 });
-
-/** @todo might no longer be required */
-export const depictObject: Depicter = (
-  { zodSchema, jsonSchema },
-  { isResponse },
-) => {
-  if (isResponse) return jsonSchema;
-  if (!isSchema<$ZodObject>(zodSchema, "object")) return jsonSchema;
-  const { required = [] } = jsonSchema as JSONSchema.ObjectSchema;
-  const result: string[] = [];
-  for (const key of required) {
-    const valueSchema = zodSchema._zod.def.shape[key];
-    if (valueSchema && !isOptional(valueSchema, { isResponse }))
-      result.push(key);
-  }
-  return { ...jsonSchema, required: result };
-};
 
 const ensureCompliance = ({
   $ref,
@@ -400,7 +381,6 @@ const depicters: Partial<Record<FirstPartyKind | ProprietaryBrand, Depicter>> =
     pipe: depictPipeline,
     literal: depictLiteral,
     enum: depictEnum,
-    object: depictObject,
     [ezDateInBrand]: depictDateIn,
     [ezDateOutBrand]: depictDateOut,
     [ezUploadBrand]: depictUpload,

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -282,41 +282,6 @@ exports[`Documentation helpers > depictNullable() > should not add null type whe
 }
 `;
 
-exports[`Documentation helpers > depictObject() > should remove optional props from required for request 0 1`] = `
-{
-  "properties": {
-    "a": {
-      "type": "number",
-    },
-    "b": {
-      "type": "string",
-    },
-  },
-  "required": [
-    "a",
-    "b",
-  ],
-  "type": "object",
-}
-`;
-
-exports[`Documentation helpers > depictObject() > should remove optional props from required for request 1 1`] = `
-{
-  "properties": {
-    "a": {
-      "type": "number",
-    },
-    "b": {
-      "type": "string",
-    },
-  },
-  "required": [
-    "b",
-  ],
-  "type": "object",
-}
-`;
-
 exports[`Documentation helpers > depictPipeline > should depict as 'number (out)' 1`] = `
 {
   "type": "number",

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -1496,6 +1496,8 @@ paths:
                   type: integer
                   minimum: 0
                   maximum: 0
+                coercedNum:
+                  type: number
               required:
                 - double
                 - doublePositive
@@ -1505,6 +1507,7 @@ paths:
                 - intPositive
                 - intNegative
                 - intLimited
+                - coercedNum
         required: true
       responses:
         "200":

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -28,7 +28,6 @@ import {
   depictEnum,
   depictLiteral,
   depictRequest,
-  depictObject,
 } from "../src/documentation-helpers";
 
 describe("Documentation helpers", () => {
@@ -327,34 +326,6 @@ describe("Documentation helpers", () => {
       (jsonSchema) => {
         expect(
           depictLiteral({ zodSchema: z.never(), jsonSchema }, requestCtx),
-        ).toMatchSnapshot();
-      },
-    );
-  });
-
-  describe("depictObject()", () => {
-    test.each([
-      {
-        zodSchema: z.object({ a: z.number(), b: z.string() }),
-        jsonSchema: {
-          type: "object",
-          properties: { a: { type: "number" }, b: { type: "string" } },
-          required: ["a", "b"],
-        },
-      },
-      {
-        zodSchema: z.object({ a: z.number().optional(), b: z.coerce.string() }),
-        jsonSchema: {
-          type: "object",
-          properties: { a: { type: "number" }, b: { type: "string" } },
-          required: ["b"], // Zod 4: coerce remains
-        },
-      },
-    ])(
-      "should remove optional props from required for request %#",
-      ({ zodSchema, jsonSchema }) => {
-        expect(
-          depictObject({ zodSchema, jsonSchema }, requestCtx),
         ).toMatchSnapshot();
       },
     );

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -330,6 +330,7 @@ describe("Documentation", () => {
                 intNegative: z.int().negative(),
                 intLimited: z.int().min(-100).max(100),
                 zero: z.int().nonnegative().nonpositive().optional(),
+                coercedNum: z.coerce.number(), // required prop in zod 4
               }),
               output: z.object({
                 bigint: z.bigint(),


### PR DESCRIPTION
Added in 9366d0ff0843efd14f1df31e4ccb62df9907b110 as part of #2595 for better treating optionals and required props.

But it seems that stable Zod 4 does the good job without it.

