### PR TITLE
feat(v24): metadata argument for `ez.dateIn()` and `ez.dateOut()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - The argument has to be the output type of the schema (used to be the opposite):
     - This change is only breaking for transforming schemas;
     - In order to specify an input example for a transforming schema the `.example()` method must be called before it;
+- The transforming proprietary schemas `ez.dateIn()` and `ez.dateOut()` now accept metadata as its argument:
+  - This allows to set examples before transformation (`ez.dateIn()`) and to avoid the examples "branding";
 - Generating Documentation is mostly delegated to Zod 4 `z.toJSONSchema()`:
   - The basic depiction of each schema is now natively performed by Zod 4;
   - Express Zod API implements some overrides and improvements to fit it into OpenAPI 3.1 that extends JSON Schema;
@@ -55,6 +57,11 @@ export default [
     .transform(Number)
 -   .example("123")
 +   .example(123)
+```
+
+```diff
+- ez.dateIn().example("2021-12-31");
++ ez.dateIn({ examples: ["2021-12-31"] });
 ```
 
 ## Version 23

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ in actual response by calling
 which in turn calls
 [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
 It is also impossible to transmit the `Date` in its original form to your endpoints within JSON. Therefore, there is
-confusion with original method ~~z.date()~~ that should not be used within IO schemas of your API.
+confusion with original method ~~z.date()~~ that is not recommended to use without transformations.
 
 In order to solve this problem, the framework provides two custom methods for dealing with dates: `ez.dateIn()` and
 `ez.dateOut()` for using within input and output schemas accordingly.
@@ -577,7 +577,7 @@ provides your endpoint handler or middleware with a `Date`. It supports the foll
 ```
 
 `ez.dateOut()`, on the contrary, accepts a `Date` and provides `ResultHandler` with a `string` representation in ISO
-format for the response transmission. Consider the following simplified example for better understanding:
+format for the response transmission. Both schemas accept metadata as an argument. Consider the following example:
 
 ```typescript
 import { z } from "zod/v4";
@@ -587,10 +587,10 @@ const updateUserEndpoint = defaultEndpointsFactory.build({
   method: "post",
   input: z.object({
     userId: z.string(),
-    birthday: ez.dateIn(), // string -> Date in handler
+    birthday: ez.dateIn({ examples: ["1963-04-21"] }), // string -> Date in handler
   }),
   output: z.object({
-    createdAt: ez.dateOut(), // Date -> string in response
+    createdAt: ez.dateOut({ examples: ["2021-12-31"] }), // Date -> string in response
   }),
   handler: async ({ input }) => ({
     createdAt: new Date("2022-01-22"), // 2022-01-22T00:00:00.000Z

--- a/example/endpoints/update-user.ts
+++ b/example/endpoints/update-user.ts
@@ -10,8 +10,6 @@ import { keyAndTokenAuthenticatedEndpointsFactory } from "../factories";
  * @todo remove if fixed:
  * @see https://github.com/colinhacks/zod/issues/4441
  * */
-const birthdaySchema = ez.dateIn();
-const birthday = birthdaySchema.example(birthdaySchema.parse("1963-04-21"));
 const createdAtSchema = ez.dateOut();
 const createdAt = createdAtSchema.example(
   createdAtSchema.parse(new Date("2021-12-31")),
@@ -29,7 +27,7 @@ export const updateUserEndpoint =
         .transform((value) => parseInt(value, 10))
         .refine((value) => value >= 0, "should be greater than or equal to 0"),
       name: z.string().nonempty().example("John Doe"),
-      birthday,
+      birthday: ez.dateIn({ examples: ["1963-04-21"] }),
     }),
     output: z.object({
       name: z.string().example("John Doe"),

--- a/example/endpoints/update-user.ts
+++ b/example/endpoints/update-user.ts
@@ -4,17 +4,6 @@ import { z } from "zod/v4";
 import { ez } from "express-zod-api";
 import { keyAndTokenAuthenticatedEndpointsFactory } from "../factories";
 
-/**
- * Examples on branded schemas have also to be branded
- * @see https://zod.dev/api?id=branded-types
- * @todo remove if fixed:
- * @see https://github.com/colinhacks/zod/issues/4441
- * */
-const createdAtSchema = ez.dateOut();
-const createdAt = createdAtSchema.example(
-  createdAtSchema.parse(new Date("2021-12-31")),
-);
-
 export const updateUserEndpoint =
   keyAndTokenAuthenticatedEndpointsFactory.build({
     tag: "users",
@@ -31,7 +20,7 @@ export const updateUserEndpoint =
     }),
     output: z.object({
       name: z.string().example("John Doe"),
-      createdAt,
+      createdAt: ez.dateOut({ examples: ["2021-12-31"] }),
     }),
     handler: async ({
       input: { id, name },

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -153,7 +153,7 @@ paths:
                   externalDocs:
                     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                   examples:
-                    - 1963-04-21T00:00:00.000Z
+                    - 1963-04-21
               required:
                 - key
                 - name
@@ -163,7 +163,6 @@ paths:
                 value:
                   key: 1234-5678-90
                   name: John Doe
-                  birthday: 1963-04-21T00:00:00.000Z
         required: true
       security:
         - APIKEY_1: []

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -163,6 +163,7 @@ paths:
                 value:
                   key: 1234-5678-90
                   name: John Doe
+                  birthday: 1963-04-21
         required: true
       security:
         - APIKEY_1: []

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -191,14 +191,11 @@ paths:
                         format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
-                        examples:
-                          - 2021-12-31T00:00:00.000Z
                     required:
                       - name
                       - createdAt
                     examples:
                       - name: John Doe
-                        createdAt: 2021-12-31T00:00:00.000Z
                 required:
                   - status
                   - data
@@ -208,7 +205,6 @@ paths:
                     status: success
                     data:
                       name: John Doe
-                      createdAt: 2021-12-31T00:00:00.000Z
         "400":
           description: PATCH /v1/user/:id Negative response
           content:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -191,11 +191,14 @@ paths:
                         format: date-time
                         externalDocs:
                           url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+                        examples:
+                          - 2021-12-31
                     required:
                       - name
                       - createdAt
                     examples:
                       - name: John Doe
+                        createdAt: 2021-12-31
                 required:
                   - status
                   - data
@@ -205,6 +208,7 @@ paths:
                     status: success
                     data:
                       name: John Doe
+                      createdAt: 2021-12-31
         "400":
           description: PATCH /v1/user/:id Negative response
           content:

--- a/express-zod-api/src/date-in-schema.ts
+++ b/express-zod-api/src/date-in-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4";
 
 export const ezDateInBrand = Symbol("DateIn");
 
-export const dateIn = () => {
+export const dateIn = (meta: Parameters<z.ZodString["meta"]>[0] = {}) => {
   const schema = z.union([
     z.iso.date(),
     z.iso.datetime(),
@@ -10,6 +10,7 @@ export const dateIn = () => {
   ]) as unknown as z.ZodUnion<[z.ZodString, z.ZodString, z.ZodString]>; // this fixes DTS build for ez export
 
   return schema
+    .meta(meta)
     .transform((str) => new Date(str))
     .pipe(z.date())
     .brand(ezDateInBrand as symbol);

--- a/express-zod-api/src/date-out-schema.ts
+++ b/express-zod-api/src/date-out-schema.ts
@@ -2,10 +2,11 @@ import { z } from "zod/v4";
 
 export const ezDateOutBrand = Symbol("DateOut");
 
-export const dateOut = () =>
+export const dateOut = (meta: Parameters<z.ZodString["meta"]>[0] = {}) =>
   z
     .date()
     .transform((date) => date.toISOString())
+    .meta(meta)
     .brand(ezDateOutBrand as symbol);
 
 export type DateOutSchema = ReturnType<typeof dateOut>;

--- a/express-zod-api/src/date-out-schema.ts
+++ b/express-zod-api/src/date-out-schema.ts
@@ -2,11 +2,17 @@ import { z } from "zod/v4";
 
 export const ezDateOutBrand = Symbol("DateOut");
 
-export const dateOut = (meta: Parameters<z.ZodString["meta"]>[0] = {}) =>
+export const dateOut = ({
+  examples,
+  ...rest
+}: Parameters<z.ZodString["meta"]>[0] = {}) =>
   z
     .date()
     .transform((date) => date.toISOString())
-    .meta(meta)
-    .brand(ezDateOutBrand as symbol);
+    .brand(ezDateOutBrand as symbol)
+    .meta({
+      ...rest,
+      examples: examples as Array<string & z.$brand> | undefined,
+    });
 
 export type DateOutSchema = ReturnType<typeof dateOut>;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -22,7 +22,7 @@ import {
   TagObject,
 } from "openapi3-ts/oas31";
 import * as R from "ramda";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
 import { ResponseVariant } from "./api-response";
 import {
   getRoutePathParams,
@@ -175,7 +175,7 @@ const ensureCompliance = ({
   return valid;
 };
 
-export const depictDateIn: Depicter = ({ zodSchema }, ctx) => {
+export const depictDateIn: Depicter = ({ jsonSchema: { examples } }, ctx) => {
   if (ctx.isResponse)
     throw new DocumentationError("Please use ez.dateOut() for output.", ctx);
   const jsonSchema: JSONSchema.StringSchema = {
@@ -185,10 +185,6 @@ export const depictDateIn: Depicter = ({ zodSchema }, ctx) => {
     pattern: /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)?Z?$/.source,
     externalDocs: { url: isoDateDocumentationUrl },
   };
-  const examples = globalRegistry
-    .get(zodSchema) // zod::toJSONSchema() does not provide examples for the input size of a pipe
-    ?.examples?.filter((one) => one instanceof Date)
-    .map((one) => one.toISOString());
   if (examples?.length) jsonSchema.examples = examples;
   return jsonSchema;
 };

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -36,7 +36,7 @@ exports[`Documentation helpers > depictDateIn > should set type:string, pattern 
 {
   "description": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "examples": [
-    "2024-01-01T00:00:00.000Z",
+    "2024-01-01",
   ],
   "externalDocs": {
     "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -509,10 +509,7 @@ describe("Documentation helpers", () => {
     ])("should set type:string, pattern and format %#", ({ examples }) => {
       expect(
         depictDateIn(
-          {
-            zodSchema: ez.dateIn({ examples }),
-            jsonSchema: { anyOf: [], examples },
-          },
+          { zodSchema: z.never(), jsonSchema: { anyOf: [], examples } },
           requestCtx,
         ),
       ).toMatchSnapshot();

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,4 +1,4 @@
-import { $brand, JSONSchema } from "zod/v4/core";
+import { JSONSchema } from "zod/v4/core";
 import { SchemaObject } from "openapi3-ts/oas31";
 import * as R from "ramda";
 import { z } from "zod/v4";
@@ -505,14 +505,12 @@ describe("Documentation helpers", () => {
     test.each([
       { examples: undefined },
       { examples: [] },
-      { examples: [new Date("2024-01-01")] },
+      { examples: ["2024-01-01"] },
     ])("should set type:string, pattern and format %#", ({ examples }) => {
       expect(
         depictDateIn(
           {
-            zodSchema: ez
-              .dateIn()
-              .meta({ examples: examples as Array<Date & $brand> }),
+            zodSchema: ez.dateIn({ examples }),
             jsonSchema: { anyOf: [], examples },
           },
           requestCtx,


### PR DESCRIPTION
This should bypass the need for parsing examples OR using `$brand` to set them