### PR TITLE
Ref: Move mixing and pulling request examples to postprocessing

### DIFF
--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -90,7 +90,10 @@ export const isSchema = <T extends $ZodType>(
   type: T["_zod"]["def"]["type"],
 ): subject is T => subject._zod.def.type === type;
 
-/** Takes the original unvalidated examples from the properties of ZodObject schema shape */
+/**
+ * Takes the original unvalidated examples from the properties of ZodObject schema shape
+ * @todo replace with using pullExamplesUp() postprocessor
+ * */
 export const pullExampleProps = <T extends $ZodObject>(subject: T) =>
   Object.entries(subject._zod.def.shape).reduce<Partial<z.output<T>>[]>(
     (acc, [key, schema]) => {

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -91,8 +91,9 @@ export const isSchema = <T extends $ZodType>(
 ): subject is T => subject._zod.def.type === type;
 
 /**
- * Takes the original unvalidated examples from the properties of ZodObject schema shape
- * @todo replace with using pullExamplesUp() postprocessor
+ * This one is for response only; for requests:
+ * @see pullExamplesUp
+ * @todo mv to result helpers
  * */
 export const pullExampleProps = <T extends $ZodObject>(subject: T) =>
   Object.entries(subject._zod.def.shape).reduce<Partial<z.output<T>>[]>(

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -1,7 +1,7 @@
-import type { $ZodObject, $ZodTransform, $ZodType } from "zod/v4/core";
 import { Request } from "express";
 import * as R from "ramda";
-import { globalRegistry, z } from "zod/v4";
+import { z } from "zod/v4";
+import type { $ZodTransform, $ZodType } from "zod/v4/core";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
 import { OutputValidationError } from "./errors";
@@ -89,19 +89,6 @@ export const isSchema = <T extends $ZodType>(
   subject: $ZodType,
   type: T["_zod"]["def"]["type"],
 ): subject is T => subject._zod.def.type === type;
-
-/** @see pullRequestExamples */
-export const pullResponseExamples = <T extends $ZodObject>(subject: T) =>
-  Object.entries(subject._zod.def.shape).reduce<Partial<z.output<T>>[]>(
-    (acc, [key, schema]) => {
-      const { examples = [] } = globalRegistry.get(schema) || {};
-      return combinations(acc, examples.map(R.objOf(key)), ([left, right]) => ({
-        ...left,
-        ...right,
-      }));
-    },
-    [],
-  );
 
 export const combinations = <T>(
   a: T[],

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -90,12 +90,8 @@ export const isSchema = <T extends $ZodType>(
   type: T["_zod"]["def"]["type"],
 ): subject is T => subject._zod.def.type === type;
 
-/**
- * This one is for response only; for requests:
- * @see pullExamplesUp
- * @todo mv to result helpers
- * */
-export const pullExampleProps = <T extends $ZodObject>(subject: T) =>
+/** @see pullRequestExamples */
+export const pullResponseExamples = <T extends $ZodObject>(subject: T) =>
   Object.entries(subject._zod.def.shape).reduce<Partial<z.output<T>>[]>(
     (acc, [key, schema]) => {
       const { examples = [] } = globalRegistry.get(schema) || {};

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -645,7 +645,6 @@ export const depictBody = ({
     examples.push(...withoutParams.examples);
     delete withoutParams.examples; // pull up
   }
-  console.log(examples, flattenIO(request));
   const media: MediaTypeObject = {
     schema:
       composition === "components"

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -25,6 +25,7 @@ import * as R from "ramda";
 import { globalRegistry, z } from "zod/v4";
 import { ResponseVariant } from "./api-response";
 import {
+  FlatObject,
   getRoutePathParams,
   getTransformedType,
   isObject,
@@ -644,12 +645,21 @@ export const depictBody = ({
     examples.push(...withoutParams.examples);
     delete withoutParams.examples; // pull up
   }
+  console.log(examples, flattenIO(request));
   const media: MediaTypeObject = {
     schema:
       composition === "components"
         ? makeRef(schema, withoutParams, makeCleanId(description))
         : withoutParams,
-    examples: enumerateExamples(examples),
+    examples: enumerateExamples(
+      examples.length
+        ? examples
+        : flattenIO(request)
+            .examples?.filter(
+              (one): one is FlatObject => isObject(one) && !Array.isArray(one),
+            )
+            .map(R.omit(paramNames)) || [],
+    ),
   };
   const body: RequestBodyObject = {
     description,

--- a/express-zod-api/src/io-schema.ts
+++ b/express-zod-api/src/io-schema.ts
@@ -1,6 +1,5 @@
 import * as R from "ramda";
 import { z } from "zod/v4";
-import { mixExamples } from "./metadata";
 import { AbstractMiddleware } from "./middleware";
 
 type Base = object & { [Symbol.iterator]?: never };
@@ -13,7 +12,7 @@ export type IOSchema = z.ZodType<Base>;
  * @since 07.03.2022 former combineEndpointAndMiddlewareInputSchemas()
  * @since 05.03.2023 is immutable to metadata
  * @since 26.05.2024 uses the regular ZodIntersection
- * @see mixExamples
+ * @since 22.05.2025 does not mix examples in after switching to Zod 4
  */
 export const getFinalEndpointInputSchema = <
   MIN extends IOSchema,
@@ -24,9 +23,7 @@ export const getFinalEndpointInputSchema = <
 ): z.ZodIntersection<MIN, IN> => {
   const allSchemas: IOSchema[] = R.pluck("schema", middlewares);
   allSchemas.push(input);
-  const finalSchema = allSchemas.reduce((acc, schema) => acc.and(schema));
-  return allSchemas.reduce(
-    (acc, schema) => mixExamples(schema, acc),
-    finalSchema,
+  return allSchemas.reduce((acc, schema) =>
+    acc.and(schema),
   ) as z.ZodIntersection<MIN, IN>;
 };

--- a/express-zod-api/src/io-schema.ts
+++ b/express-zod-api/src/io-schema.ts
@@ -20,10 +20,7 @@ export const getFinalEndpointInputSchema = <
 >(
   middlewares: AbstractMiddleware[],
   input: IN,
-): z.ZodIntersection<MIN, IN> => {
-  const allSchemas: IOSchema[] = R.pluck("schema", middlewares);
-  allSchemas.push(input);
-  return allSchemas.reduce((acc, schema) =>
-    acc.and(schema),
-  ) as z.ZodIntersection<MIN, IN>;
-};
+) =>
+  R.pluck("schema", middlewares)
+    .concat(input)
+    .reduce((acc, schema) => acc.and(schema)) as z.ZodIntersection<MIN, IN>;

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -89,6 +89,10 @@ export const flattenIO = (
   return flat;
 };
 
+/**
+ * For requests only; for responses:
+ * @see pullExampleProps
+ * */
 export const pullExamplesUp = (subject: JSONSchema.ObjectSchema) =>
   Object.entries(subject.properties || {}).reduce<FlatObject[]>(
     (acc, [key, { examples = [] }]) =>

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -63,7 +63,7 @@ export const flattenIO = (
       }
     }
     if (!isJsonObjectSchema(entry)) continue;
-    stack.push([isOptional, { examples: pullExamplesUp(entry) }]);
+    stack.push([isOptional, { examples: pullRequestExamples(entry) }]);
     if (entry.properties) {
       flat.properties = (mode === "throw" ? propsMerger : R.mergeDeepRight)(
         flat.properties,
@@ -89,11 +89,8 @@ export const flattenIO = (
   return flat;
 };
 
-/**
- * For requests only; for responses:
- * @see pullExampleProps
- * */
-export const pullExamplesUp = (subject: JSONSchema.ObjectSchema) =>
+/** @see pullResponseExamples */
+export const pullRequestExamples = (subject: JSONSchema.ObjectSchema) =>
   Object.entries(subject.properties || {}).reduce<FlatObject[]>(
     (acc, [key, { examples = [] }]) =>
       combinations(acc, examples.map(R.objOf(key)), ([left, right]) => ({

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -1,38 +1,9 @@
-import type { $ZodType, $ZodObject } from "zod/v4/core";
-import { combinations, isSchema, pullExampleProps } from "./common-helpers";
-import { z } from "zod/v4";
-import * as R from "ramda";
+import type { $ZodType } from "zod/v4/core";
 
 export const metaSymbol = Symbol.for("express-zod-api");
 
-/** @todo move or remove */
-export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
-  src: A,
-  dest: B,
-): B => {
-  const {
-    examples: srcExamples = isSchema<$ZodObject>(src, "object")
-      ? pullExampleProps(src)
-      : undefined,
-  } = src.meta() || {};
-  if (!srcExamples?.length) return dest;
-  const { examples: destExamples = [] } = dest.meta() || {};
-  const examples = combinations<z.output<A> & z.output<B>>(
-    destExamples,
-    srcExamples,
-    ([destExample, srcExample]) =>
-      typeof destExample === "object" &&
-      typeof srcExample === "object" &&
-      destExample &&
-      srcExample
-        ? R.mergeDeepRight(destExample, srcExample)
-        : srcExample, // not supposed to be called on non-object schemas
-  );
-  return dest.meta({ examples });
-};
-
 export const getBrand = (subject: $ZodType) => {
-  const { brand } = subject._zod.bag;
+  const { brand } = subject._zod.bag || {};
   if (
     typeof brand === "symbol" ||
     typeof brand === "string" ||

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -5,6 +5,7 @@ import * as R from "ramda";
 
 export const metaSymbol = Symbol.for("express-zod-api");
 
+/** @todo move or remove */
 export const mixExamples = <A extends z.ZodType, B extends z.ZodType>(
   src: A,
   dest: B,

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -6,12 +6,7 @@ import {
   defaultStatusCodes,
   NormalizedResponse,
 } from "./api-response";
-import {
-  FlatObject,
-  isObject,
-  isSchema,
-  pullResponseExamples,
-} from "./common-helpers";
+import { FlatObject, isObject, isSchema } from "./common-helpers";
 import { contentTypes } from "./content-type";
 import { IOSchema } from "./io-schema";
 import { ActualLogger } from "./logger-helpers";
@@ -21,6 +16,7 @@ import {
   getPublicErrorMessage,
   logServerError,
   normalize,
+  pullResponseExamples,
   ResultSchema,
 } from "./result-helpers";
 

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -10,7 +10,7 @@ import {
   FlatObject,
   isObject,
   isSchema,
-  pullExampleProps,
+  pullResponseExamples,
 } from "./common-helpers";
 import { contentTypes } from "./content-type";
 import { IOSchema } from "./io-schema";
@@ -104,7 +104,7 @@ export const defaultResultHandler = new ResultHandler({
   positive: (output) => {
     const { examples = [] } = globalRegistry.get(output) || {};
     if (!examples.length && isSchema<$ZodObject>(output, "object"))
-      examples.push(...pullExampleProps(output as $ZodObject));
+      examples.push(...pullResponseExamples(output as $ZodObject));
     if (examples.length && !globalRegistry.has(output))
       globalRegistry.add(output, { examples });
     const responseSchema = z.object({

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -3966,6 +3966,10 @@ paths:
                   type: string
               required:
                 - strNum
+            examples:
+              example1:
+                value:
+                  strNum: "123"
         required: true
       responses:
         "200":

--- a/express-zod-api/tests/__snapshots__/json-schema-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/json-schema-helpers.spec.ts.snap
@@ -53,6 +53,41 @@ exports[`JSON Schema helpers > flattenIO() > should pass the object schema throu
 }
 `;
 
+exports[`JSON Schema helpers > flattenIO() > should pull examples up from object schema props 1`] = `
+{
+  "examples": [
+    {
+      "one": "test",
+      "two": 123,
+    },
+    {
+      "one": "jest",
+      "two": 123,
+    },
+  ],
+  "properties": {
+    "one": {
+      "examples": [
+        "test",
+        "jest",
+      ],
+      "type": "string",
+    },
+    "two": {
+      "examples": [
+        123,
+      ],
+      "type": "number",
+    },
+  },
+  "required": [
+    "one",
+    "two",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`JSON Schema helpers > flattenIO() > should return object schema for the intersection of object schemas 1`] = `
 {
   "examples": [

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -6,7 +6,6 @@ import {
   getMessageFromError,
   makeCleanId,
   ensureError,
-  pullResponseExamples,
   getRoutePathParams,
 } from "../src/common-helpers";
 import { z } from "zod/v4";
@@ -196,24 +195,6 @@ describe("Common Helpers", () => {
       expect(
         getMessageFromError(new Error("something went wrong")),
       ).toMatchSnapshot();
-    });
-  });
-
-  describe("pullResponseExamples()", () => {
-    test("handles multiple examples per property", () => {
-      const schema = z.object({
-        a: z.string().example("one").example("two").example("three"),
-        b: z.number().example(1).example(2),
-        c: z.boolean().example(false),
-      });
-      expect(pullResponseExamples(schema)).toEqual([
-        { a: "one", b: 1, c: false },
-        { a: "one", b: 2, c: false },
-        { a: "two", b: 1, c: false },
-        { a: "two", b: 2, c: false },
-        { a: "three", b: 1, c: false },
-        { a: "three", b: 2, c: false },
-      ]);
     });
   });
 

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -6,7 +6,7 @@ import {
   getMessageFromError,
   makeCleanId,
   ensureError,
-  pullExampleProps,
+  pullResponseExamples,
   getRoutePathParams,
 } from "../src/common-helpers";
 import { z } from "zod/v4";
@@ -199,14 +199,14 @@ describe("Common Helpers", () => {
     });
   });
 
-  describe("pullExampleProps()", () => {
+  describe("pullResponseExamples()", () => {
     test("handles multiple examples per property", () => {
       const schema = z.object({
         a: z.string().example("one").example("two").example("three"),
         b: z.number().example(1).example(2),
         c: z.boolean().example(false),
       });
-      expect(pullExampleProps(schema)).toEqual([
+      expect(pullResponseExamples(schema)).toEqual([
         { a: "one", b: 1, c: false },
         { a: "one", b: 2, c: false },
         { a: "two", b: 1, c: false },

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -243,7 +243,8 @@ describe("I/O Schema and related helpers", () => {
       expect(result).toMatchSnapshot();
     });
 
-    test("Should merge examples", () => {
+    /** @todo move or remove */
+    test.skip("Should merge examples", () => {
       const middlewares: AbstractMiddleware[] = [
         new Middleware({
           input: z

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -242,38 +242,5 @@ describe("I/O Schema and related helpers", () => {
       expect(result).toBeInstanceOf(z.ZodIntersection);
       expect(result).toMatchSnapshot();
     });
-
-    /** @todo move or remove */
-    test.skip("Should merge examples", () => {
-      const middlewares: AbstractMiddleware[] = [
-        new Middleware({
-          input: z
-            .object({ one: z.string() })
-            .and(z.object({ two: z.number() }))
-            .example({ one: "test", two: 123 }),
-          handler: vi.fn(),
-        }),
-        new Middleware({
-          input: z
-            .object({ three: z.null() })
-            .or(z.object({ four: z.boolean() }))
-            .example({ three: null, four: true }),
-          handler: vi.fn(),
-        }),
-      ];
-      const endpointInput = z
-        .object({ five: z.string() })
-        .example({ five: "some" });
-      const result = getFinalEndpointInputSchema(middlewares, endpointInput);
-      expect(result.meta()?.examples).toEqual([
-        {
-          one: "test",
-          two: 123,
-          three: null,
-          four: true,
-          five: "some",
-        },
-      ]);
-    });
   });
 });

--- a/express-zod-api/tests/json-schema-helpers.spec.ts
+++ b/express-zod-api/tests/json-schema-helpers.spec.ts
@@ -72,6 +72,24 @@ describe("JSON Schema helpers", () => {
       expect(subject).toMatchSnapshot();
     });
 
+    test("should pull examples up from object schema props", () => {
+      const subject = flattenIO({
+        allOf: [
+          {
+            type: "object",
+            properties: { one: { type: "string", examples: ["test", "jest"] } },
+            required: ["one"],
+          },
+          {
+            type: "object",
+            properties: { two: { type: "number", examples: [123] } },
+            required: ["two"],
+          },
+        ],
+      });
+      expect(subject).toMatchSnapshot();
+    });
+
     test("should handle records", () => {
       const subject = z.toJSONSchema(
         z

--- a/express-zod-api/tests/metadata.spec.ts
+++ b/express-zod-api/tests/metadata.spec.ts
@@ -1,75 +1,14 @@
-import { z } from "zod/v4";
-import { mixExamples } from "../src/metadata";
+import type { $ZodType } from "zod/v4/core";
+import { getBrand } from "../src/metadata";
 
 describe("Metadata", () => {
-  describe("mixExamples()", () => {
-    test("should return the same dest schema in case src one has no meta", () => {
-      const src = z.string();
-      const dest = z.number();
-      const result = mixExamples(src, dest);
-      expect(result).toEqual(dest);
-      expect(result.meta()?.examples).toBeFalsy();
-      expect(dest.meta()?.examples).toBeFalsy();
-    });
-    test("should copy meta from src to dest in case meta is defined", () => {
-      const src = z.string().example("some").describe("test");
-      const dest = z.number().describe("another");
-      const result = mixExamples(src, dest);
-      expect(result).not.toEqual(dest); // immutable
-      expect(result.meta()?.examples).toEqual(src.meta()?.examples);
-      expect(result.meta()?.examples).toEqual(["some"]);
-      expect(result.description).toBe("another"); // preserves it
-    });
-
-    test("should merge the meta from src to dest", () => {
-      const src = z
-        .object({ a: z.string() })
-        .example({ a: "some" })
-        .example({ a: "another" });
-      const dest = z
-        .object({ b: z.number() })
-        .example({ b: 123 })
-        .example({ b: 456 })
-        .example({ b: 789 });
-      const result = mixExamples(src, dest);
-      expect(result.meta()?.examples).toEqual([
-        { a: "some", b: 123 },
-        { a: "another", b: 123 },
-        { a: "some", b: 456 },
-        { a: "another", b: 456 },
-        { a: "some", b: 789 },
-        { a: "another", b: 789 },
-      ]);
-    });
-
-    test("should merge deeply", () => {
-      const src = z
-        .object({ a: z.object({ b: z.string() }) })
-        .example({ a: { b: "some" } })
-        .example({ a: { b: "another" } });
-      const dest = z
-        .object({ a: z.object({ c: z.number() }) })
-        .example({ a: { c: 123 } })
-        .example({ a: { c: 456 } })
-        .example({ a: { c: 789 } });
-      const result = mixExamples(src, dest);
-      expect(result.meta()?.examples).toEqual([
-        { a: { b: "some", c: 123 } },
-        { a: { b: "another", c: 123 } },
-        { a: { b: "some", c: 456 } },
-        { a: { b: "another", c: 456 } },
-        { a: { b: "some", c: 789 } },
-        { a: { b: "another", c: 789 } },
-      ]);
-    });
-
-    test("should avoid non-object examples", () => {
-      const src = z.string().example("a").example("b");
-      const dest = z
-        .object({ items: z.array(z.string()) })
-        .example({ items: ["e", "f", "g"] });
-      const result = mixExamples(src, dest);
-      expect(result.meta()?.examples).toEqual(["a", "b"]);
-    });
+  describe("getBrand", () => {
+    test.each([{ brand: "test" }, {}, undefined])(
+      "should take it from bag",
+      (bag) => {
+        const mock = { _zod: { bag } };
+        expect(getBrand(mock as unknown as $ZodType)).toBe(bag?.brand);
+      },
+    );
   });
 });

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -6,6 +6,7 @@ import {
   getPublicErrorMessage,
   logServerError,
   normalize,
+  pullResponseExamples,
 } from "../src/result-helpers";
 import { makeLoggerMock, makeRequestMock } from "../src/testing";
 
@@ -90,6 +91,24 @@ describe("Result helpers", () => {
       new OutputValidationError(z.string().safeParse(123).error!),
     ])("should handle %s", (error) => {
       expect(ensureHttpError(error)).toMatchSnapshot();
+    });
+  });
+
+  describe("pullResponseExamples()", () => {
+    test("handles multiple examples per property", () => {
+      const schema = z.object({
+        a: z.string().example("one").example("two").example("three"),
+        b: z.number().example(1).example(2),
+        c: z.boolean().example(false),
+      });
+      expect(pullResponseExamples(schema)).toEqual([
+        { a: "one", b: 1, c: false },
+        { a: "one", b: 2, c: false },
+        { a: "two", b: 1, c: false },
+        { a: "two", b: 2, c: false },
+        { a: "three", b: 1, c: false },
+        { a: "three", b: 2, c: false },
+      ]);
     });
   });
 


### PR DESCRIPTION
The need of it discovered during #2649 

Examples set before transformation are not getting to body depiction.
see https://github.com/RobinTail/express-zod-api/pull/2649#discussion_r2101460393

this is because mixing and pulling before in preprocess, while to should be devoted to Zod to depict them first, and then do mixing/pulling in a postprocess, e.g. `flattenIO`
