### PR TITLE
Adjust error message format in response

### DIFF
--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -71,10 +71,10 @@ export const ensureError = (subject: unknown): Error =>
 export const getMessageFromError = (error: Error): string => {
   if (error instanceof z.ZodError) {
     return error.issues
-      .map(
-        ({ path, message }) =>
-          `${path.length ? z.core.toDotPath(path) + ": " : ""}${message}`,
-      )
+      .map(({ path, message }) => {
+        const prefix = path.length ? `${z.core.toDotPath(path)}: ` : "";
+        return `${prefix}${message}`;
+      })
       .join("; ");
   }
   return error.message;

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -72,8 +72,9 @@ export const ensureError = (subject: unknown): Error =>
 export const getMessageFromError = (error: Error): string => {
   if (error instanceof z.ZodError) {
     return error.issues
-      .map(({ path, message }) =>
-        (path.length ? [path.join("/")] : []).concat(message).join(": "),
+      .map(
+        ({ path, message }) =>
+          `${path.length ? z.core.toDotPath(path) + ": " : ""}${message}`,
       )
       .join("; ");
   }

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -4,7 +4,6 @@ import { z } from "zod/v4";
 import type { $ZodTransform, $ZodType } from "zod/v4/core";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
-import { OutputValidationError } from "./errors";
 import { AuxMethod, Method } from "./method";
 
 /** @desc this type does not allow props assignment, but it works for reading them when merged with another interface */
@@ -77,10 +76,6 @@ export const getMessageFromError = (error: Error): string => {
           `${path.length ? z.core.toDotPath(path) + ": " : ""}${message}`,
       )
       .join("; ");
-  }
-  if (error instanceof OutputValidationError) {
-    const hasFirstField = error.cause.issues[0]?.path.length > 0;
-    return `output${hasFirstField ? "/" : ": "}${error.message}`;
   }
   return error.message;
 };

--- a/express-zod-api/src/errors.ts
+++ b/express-zod-api/src/errors.ts
@@ -55,17 +55,13 @@ export class OutputValidationError extends IOSchemaError {
   public override name = "OutputValidationError";
 
   constructor(public override readonly cause: z.ZodError) {
-    super(
-      getMessageFromError(
-        new z.ZodError(
-          cause.issues.map(({ path, ...rest }) => ({
-            ...rest,
-            path: ["output", ...path],
-          })),
-        ),
-      ),
-      { cause },
+    const prefixedPath = new z.ZodError(
+      cause.issues.map(({ path, ...rest }) => ({
+        ...rest,
+        path: ["output", ...path],
+      })),
     );
+    super(getMessageFromError(prefixedPath), { cause });
   }
 }
 

--- a/express-zod-api/src/errors.ts
+++ b/express-zod-api/src/errors.ts
@@ -55,7 +55,17 @@ export class OutputValidationError extends IOSchemaError {
   public override name = "OutputValidationError";
 
   constructor(public override readonly cause: z.ZodError) {
-    super(getMessageFromError(cause), { cause });
+    super(
+      getMessageFromError(
+        new z.ZodError(
+          cause.issues.map(({ path, ...rest }) => ({
+            ...rest,
+            path: ["output", ...path],
+          })),
+        ),
+      ),
+      { cause },
+    );
   }
 }
 

--- a/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
@@ -26,7 +26,11 @@ exports[`Common Helpers > defaultInputSources > should be declared in a certain 
 }
 `;
 
-exports[`Common Helpers > getMessageFromError() > should compile a string from ZodError 1`] = `"user/id: expected number, got string; user/name: expected string, got number"`;
+exports[`Common Helpers > getMessageFromError() > should compile a string from ZodError 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
+
+exports[`Common Helpers > getMessageFromError() > should handle composite error 0 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
+
+exports[`Common Helpers > getMessageFromError() > should handle composite error 1 1`] = `"output/user.id: expected number, got string; user.name: expected string, got number"`;
 
 exports[`Common Helpers > getMessageFromError() > should handle empty path in ZodIssue 1`] = `"Top level refinement issue"`;
 

--- a/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
@@ -28,10 +28,6 @@ exports[`Common Helpers > defaultInputSources > should be declared in a certain 
 
 exports[`Common Helpers > getMessageFromError() > should compile a string from ZodError 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
 
-exports[`Common Helpers > getMessageFromError() > should handle composite error 0 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
-
-exports[`Common Helpers > getMessageFromError() > should handle composite error 1 1`] = `"output.user.id: expected number, got string; output.user.name: expected string, got number"`;
-
 exports[`Common Helpers > getMessageFromError() > should handle empty path in ZodIssue 1`] = `"Top level refinement issue"`;
 
 exports[`Common Helpers > getMessageFromError() > should pass message from other error types 1`] = `"something went wrong"`;

--- a/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`Common Helpers > getMessageFromError() > should compile a string from Z
 
 exports[`Common Helpers > getMessageFromError() > should handle composite error 0 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
 
-exports[`Common Helpers > getMessageFromError() > should handle composite error 1 1`] = `"output/user.id: expected number, got string; user.name: expected string, got number"`;
+exports[`Common Helpers > getMessageFromError() > should handle composite error 1 1`] = `"output.user.id: expected number, got string; output.user.name: expected string, got number"`;
 
 exports[`Common Helpers > getMessageFromError() > should handle empty path in ZodIssue 1`] = `"Top level refinement issue"`;
 

--- a/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
@@ -14,6 +14,15 @@ exports[`Endpoint > #handleResult > Should handle errors within ResultHandler 1`
 ]
 `;
 
+exports[`Endpoint > #parseOutput > Should throw on output validation failure 1`] = `
+{
+  "error": {
+    "message": "output.email: Invalid email address",
+  },
+  "status": "error",
+}
+`;
+
 exports[`Endpoint > .getResponses() > should return the negative responses (readonly) 1`] = `
 [
   {

--- a/express-zod-api/tests/__snapshots__/result-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-helpers.spec.ts.snap
@@ -31,7 +31,7 @@ NotFoundError({
 })
 `;
 
-exports[`Result helpers > ensureHttpError() > should handle OutputValidationError: Invalid input: expected string, received number 1`] = `
+exports[`Result helpers > ensureHttpError() > should handle OutputValidationError: output: Invalid input: expected string, received number 1`] = `
 InternalServerError({
   "cause": ZodError({
     "issues": [

--- a/express-zod-api/tests/__snapshots__/system.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/system.spec.ts.snap
@@ -180,7 +180,7 @@ exports[`App in production mode > Validation > Should fail on handler output typ
           },
         ],
       }),
-      "message": "output/anything: Too small: expected number to be >0",
+      "message": "output.anything: Too small: expected number to be >0",
     }),
     "payload": {
       "key": "123",

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -1,5 +1,4 @@
 import createHttpError from "http-errors";
-import { InputValidationError, OutputValidationError } from "../src";
 import {
   combinations,
   defaultInputSources,
@@ -157,47 +156,36 @@ describe("Common Helpers", () => {
   });
 
   describe("getMessageFromError()", () => {
-    const error = new z.ZodError([
-      {
-        code: "invalid_type",
-        path: ["user", "id"],
-        message: "expected number, got string",
-        expected: "number",
-        input: "test",
-      },
-      {
-        code: "invalid_type",
-        path: ["user", "name"],
-        message: "expected string, got number",
-        expected: "string",
-        input: 123,
-      },
-    ]);
-
     test("should compile a string from ZodError", () => {
+      const error = new z.ZodError([
+        {
+          code: "invalid_type",
+          path: ["user", "id"],
+          message: "expected number, got string",
+          expected: "number",
+          input: "test",
+        },
+        {
+          code: "invalid_type",
+          path: ["user", "name"],
+          message: "expected string, got number",
+          expected: "string",
+          input: 123,
+        },
+      ]);
       expect(getMessageFromError(error)).toMatchSnapshot();
     });
 
-    test.each([InputValidationError, OutputValidationError])(
-      "should handle composite error %#",
-      (Cls) => {
-        expect(getMessageFromError(new Cls(error))).toMatchSnapshot();
-      },
-    );
-
     test("should handle empty path in ZodIssue", () => {
-      expect(
-        getMessageFromError(
-          new z.ZodError([
-            {
-              code: "custom",
-              path: [],
-              message: "Top level refinement issue",
-              input: "test",
-            },
-          ]),
-        ),
-      ).toMatchSnapshot();
+      const error = new z.ZodError([
+        {
+          code: "custom",
+          path: [],
+          message: "Top level refinement issue",
+          input: "test",
+        },
+      ]);
+      expect(getMessageFromError(error)).toMatchSnapshot();
     });
 
     test("should pass message from other error types", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -140,10 +140,7 @@ describe("Endpoint", () => {
       });
       const { responseMock } = await testEndpoint({ endpoint });
       expect(responseMock._getStatusCode()).toBe(500);
-      expect(responseMock._getJSONData()).toEqual({
-        status: "error",
-        error: { message: "output/email: Invalid email address" },
-      });
+      expect(responseMock._getJSONData()).toMatchSnapshot();
     });
 
     test("Should throw on output parsing non-Zod error", async () => {

--- a/express-zod-api/tests/errors.spec.ts
+++ b/express-zod-api/tests/errors.spec.ts
@@ -83,7 +83,15 @@ describe("Errors", () => {
   });
 
   describe("OutputValidationError", () => {
-    const zodError = new z.ZodError([]);
+    const zodError = new z.ZodError([
+      {
+        code: "invalid_type",
+        path: ["test"],
+        message: "expected string, received number",
+        expected: "string",
+        input: 123,
+      },
+    ]);
     const error = new OutputValidationError(zodError);
 
     test("should be an instance of IOSchemaError and Error", () => {
@@ -95,13 +103,27 @@ describe("Errors", () => {
       expect(error.name).toBe("OutputValidationError");
     });
 
+    test("the message should be formatted and contain prefixed path", () => {
+      expect(error.message).toBe(
+        "output.test: expected string, received number",
+      );
+    });
+
     test("should have .cause property matching the one used for constructing", () => {
       expect(error.cause).toEqual(zodError);
     });
   });
 
   describe("InputValidationError", () => {
-    const zodError = new z.ZodError([]);
+    const zodError = new z.ZodError([
+      {
+        code: "invalid_type",
+        path: ["test"],
+        message: "expected string, received number",
+        expected: "string",
+        input: 123,
+      },
+    ]);
     const error = new InputValidationError(zodError);
 
     test("should be an instance of IOSchemaError and Error", () => {
@@ -111,6 +133,10 @@ describe("Errors", () => {
 
     test("should have the name matching its class", () => {
       expect(error.name).toBe("InputValidationError");
+    });
+
+    test("the message should be formatted", () => {
+      expect(error.message).toBe("test: expected string, received number");
     });
 
     test("should have .cause property matching the one used for constructing", () => {

--- a/express-zod-api/tests/errors.spec.ts
+++ b/express-zod-api/tests/errors.spec.ts
@@ -10,6 +10,16 @@ import {
 } from "../src/errors";
 
 describe("Errors", () => {
+  const zodError = new z.ZodError([
+    {
+      code: "invalid_type",
+      path: ["test"],
+      message: "expected string, received number",
+      expected: "string",
+      input: 123,
+    },
+  ]);
+
   describe("RoutingError", () => {
     const error = new RoutingError("test", "get", "/v1/test");
 
@@ -83,15 +93,6 @@ describe("Errors", () => {
   });
 
   describe("OutputValidationError", () => {
-    const zodError = new z.ZodError([
-      {
-        code: "invalid_type",
-        path: ["test"],
-        message: "expected string, received number",
-        expected: "string",
-        input: 123,
-      },
-    ]);
     const error = new OutputValidationError(zodError);
 
     test("should be an instance of IOSchemaError and Error", () => {
@@ -115,15 +116,6 @@ describe("Errors", () => {
   });
 
   describe("InputValidationError", () => {
-    const zodError = new z.ZodError([
-      {
-        code: "invalid_type",
-        path: ["test"],
-        message: "expected string, received number",
-        expected: "string",
-        input: 123,
-      },
-    ]);
     const error = new InputValidationError(zodError);
 
     test("should be an instance of IOSchemaError and Error", () => {


### PR DESCRIPTION
Switching to zod core's `toDotPath()` in `getMessageFromError()`.

I'm not using `z.prettifyError()` because its prettiness to me is questionable due to:
- icons/symbols
- new lines
- offsets 

In my opinion such formatting should be delegated to UI.
For that I'm planning #2663 