### PR TITLE
Minimizing `any` in client types

### DIFF
--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -212,6 +212,9 @@ const producers: HandlingRules<
   undefined: onPrimitive(ts.SyntaxKind.UndefinedKeyword),
   [ezDateInBrand]: onPrimitive(ts.SyntaxKind.StringKeyword),
   [ezDateOutBrand]: onPrimitive(ts.SyntaxKind.StringKeyword),
+  never: onPrimitive(ts.SyntaxKind.NeverKeyword),
+  void: onPrimitive(ts.SyntaxKind.UndefinedKeyword),
+  unknown: onPrimitive(ts.SyntaxKind.UnknownKeyword),
   null: onNull,
   array: onArray,
   tuple: onTuple,
@@ -244,6 +247,6 @@ export const zodToTs = (
 ) =>
   walkSchema(schema, {
     rules: { ...brandHandling, ...producers },
-    onMissing: () => ensureTypeNode(ts.SyntaxKind.AnyKeyword), // @todo UnknownKeyword
+    onMissing: ({}, { isResponse }) => getFallback(isResponse),
     ctx,
   });

--- a/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
@@ -18,10 +18,10 @@ exports[`zod-to-ts > Example > should produce the expected results 1`] = `
     date: any;
     undefined: undefined;
     null: null;
-    void: any;
+    void: undefined;
     any: any;
-    unknown: any;
-    never: any;
+    unknown: unknown;
+    never: never;
     optionalString?: string | undefined;
     nullablePartialObject: {
         string?: string | undefined;
@@ -139,7 +139,7 @@ exports[`zod-to-ts > Issue #2352: intersection of objects having same prop %# > 
 }"
 `;
 
-exports[`zod-to-ts > PrimitiveSchema > outputs correct typescript 1`] = `
+exports[`zod-to-ts > PrimitiveSchema (isResponse=false) > outputs correct typescript 1`] = `
 "{
     string: string;
     number: number;
@@ -147,10 +147,25 @@ exports[`zod-to-ts > PrimitiveSchema > outputs correct typescript 1`] = `
     date: any;
     undefined: undefined;
     null: null;
-    void: any;
+    void: undefined;
     any: any;
-    unknown: any;
-    never: any;
+    unknown: unknown;
+    never: never;
+}"
+`;
+
+exports[`zod-to-ts > PrimitiveSchema (isResponse=true) > outputs correct typescript 1`] = `
+"{
+    string: string;
+    number: number;
+    boolean: boolean;
+    date: unknown;
+    undefined: undefined;
+    null: null;
+    void: undefined;
+    any: any;
+    unknown: unknown;
+    never: never;
 }"
 `;
 
@@ -272,6 +287,8 @@ exports[`zod-to-ts > z.optional() > Zod 4: should add question mark only to opti
 `;
 
 exports[`zod-to-ts > z.pipe() > transformations > should handle an error within the transformation 1`] = `"unknown"`;
+
+exports[`zod-to-ts > z.pipe() > transformations > should handle preprocess error in request 1`] = `"any"`;
 
 exports[`zod-to-ts > z.pipe() > transformations > should handle unsupported transformation in response 1`] = `"unknown"`;
 

--- a/express-zod-api/tests/zts.spec.ts
+++ b/express-zod-api/tests/zts.spec.ts
@@ -328,25 +328,28 @@ describe("zod-to-ts", () => {
     );
   });
 
-  describe("PrimitiveSchema", () => {
-    const primitiveSchema = z.object({
-      string: z.string(),
-      number: z.number(),
-      boolean: z.boolean(),
-      date: z.date(),
-      undefined: z.undefined(),
-      null: z.null(),
-      void: z.void(),
-      any: z.any(),
-      unknown: z.unknown(),
-      never: z.never(),
-    });
-    const node = zodToTs(primitiveSchema, { ctx });
+  describe.each([true, false])(
+    "PrimitiveSchema (isResponse=%s)",
+    (isResponse) => {
+      const primitiveSchema = z.object({
+        string: z.string(),
+        number: z.number(),
+        boolean: z.boolean(),
+        date: z.date(),
+        undefined: z.undefined(),
+        null: z.null(),
+        void: z.void(),
+        any: z.any(),
+        unknown: z.unknown(),
+        never: z.never(),
+      });
+      const node = zodToTs(primitiveSchema, { ctx: { ...ctx, isResponse } });
 
-    test("outputs correct typescript", () => {
-      expect(printNodeTest(node)).toMatchSnapshot();
-    });
-  });
+      test("outputs correct typescript", () => {
+        expect(printNodeTest(node)).toMatchSnapshot();
+      });
+    },
+  );
 
   describe("z.discriminatedUnion()", () => {
     const shapeSchema = z.discriminatedUnion("kind", [
@@ -390,6 +393,13 @@ describe("zod-to-ts", () => {
         expect(
           printNodeTest(zodToTs(schema, { ctx: { ...ctx, isResponse: true } })),
         ).toMatchSnapshot();
+      });
+
+      test("should handle preprocess error in request", () => {
+        const schema = z.preprocess(() => {
+          throw new Error("intentional");
+        }, z.number());
+        expect(printNodeTest(zodToTs(schema, { ctx }))).toMatchSnapshot();
       });
 
       test("should handle an error within the transformation", () => {


### PR DESCRIPTION
AI led me to realization that I have to much `any` in the generated client types.
I'd like to fix it to prevent possible issues with such a broad type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Zod types `never`, `void`, and `unknown`, which now map to their respective TypeScript types.
- **Bug Fixes**
  - Improved fallback typing behavior to better distinguish between response and non-response contexts.
- **Tests**
  - Enhanced test coverage for primitive schema handling and error scenarios in schema processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->