### PR TITLE
Fixing recursive prop issue and supporting `ZodNonOptional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 24
 
+### v24.2.0
+
+- Supporting `z.nonoptional()` schema by `Integration` generator.
+
 ### v24.1.0
 
 - Supporting the new `z.templateLiteral()` schema by the `Integration` (client side types generator);

--- a/example/endpoints/retrieve-user.ts
+++ b/example/endpoints/retrieve-user.ts
@@ -29,11 +29,7 @@ export const retrieveUserEndpoint = defaultEndpointsFactory
     output: z.object({
       id: z.int().nonnegative(),
       name: z.string(),
-      /**
-       * @todo rm .optional() when external bug fixed
-       * @link https://github.com/colinhacks/zod/issues/4592
-       */
-      features: feature.array().optional(),
+      features: feature.shape.features.nonoptional(), // @link https://github.com/colinhacks/zod/issues/4592
     }),
     handler: async ({ input: { id }, options: { method }, logger }) => {
       logger.debug(`Requested id: ${id}, method ${method}`);

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -17,7 +17,7 @@ type GetV1UserRetrievePositiveVariant1 = {
   data: {
     id: number;
     name: string;
-    features?: Type1[] | undefined;
+    features: Type1[];
   };
 };
 

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -40,12 +40,11 @@ paths:
                       name:
                         type: string
                       features:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/Schema1"
+                        $ref: "#/components/schemas/Schema1"
                     required:
                       - id
                       - name
+                      - features
                     additionalProperties: false
                 required:
                   - status
@@ -744,17 +743,17 @@ paths:
 components:
   schemas:
     Schema1:
-      type: object
-      properties:
-        title:
-          type: string
-        features:
-          type: array
-          items:
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          features:
             $ref: "#/components/schemas/Schema1"
-      required:
-        - title
-      additionalProperties: false
+        required:
+          - title
+        additionalProperties: false
   responses: {}
   parameters: {}
   examples: {}

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -7,6 +7,7 @@ import type {
   $ZodIntersection,
   $ZodLazy,
   $ZodLiteral,
+  $ZodNonOptional,
   $ZodNullable,
   $ZodObject,
   $ZodOptional,
@@ -147,9 +148,6 @@ const onSomeUnion: Producer = (
 const makeSample = (produced: ts.TypeNode) =>
   samples?.[produced.kind as keyof typeof samples];
 
-const onOptional: Producer = ({ _zod: { def } }: $ZodOptional, { next }) =>
-  next(def.innerType);
-
 const onNullable: Producer = ({ _zod: { def } }: $ZodNullable, { next }) =>
   f.createUnionTypeNode([next(def.innerType), makeLiteralType(null)]);
 
@@ -189,7 +187,9 @@ const onPrimitive =
     ensureTypeNode(syntaxKind);
 
 const onWrapped: Producer = (
-  { _zod: { def } }: $ZodReadonly | $ZodCatch | $ZodDefault,
+  {
+    _zod: { def },
+  }: $ZodReadonly | $ZodCatch | $ZodDefault | $ZodOptional | $ZodNonOptional,
   { next },
 ) => next(def.innerType);
 
@@ -259,7 +259,8 @@ const producers: HandlingRules<
   union: onSomeUnion,
   default: onWrapped,
   enum: onEnum,
-  optional: onOptional,
+  optional: onWrapped,
+  nonoptional: onWrapped,
   nullable: onNullable,
   catch: onWrapped,
   pipe: onPipeline,


### PR DESCRIPTION
Related to #2691 
Implementing a better workaround for https://github.com/colinhacks/zod/issues/4592 which turned out to be a limitation of Zod 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The user data response now always includes the features property, ensuring it is required rather than optional.
  - Updated the user data schema to reflect features as a required property and adjusted its structure for consistency.

- **Documentation**
  - Added a changelog entry for version 24.2.0, highlighting improved support for non-optional schemas in integration generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->