### PR TITLE
rm `depictEnum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 24
 
+### v24.2.1
+
+- Removed overrides for depicting enums in the generated `Documentation`:
+  - The better implementation provided by [Zod v3.25.45](https://github.com/colinhacks/zod/releases/tag/v3.25.45).
+
 ### v24.2.0
 
 - Supporting `z.nonoptional()` schema by `Integration` generator.

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -143,11 +143,6 @@ export const depictNullable: Depicter = ({ jsonSchema }) => {
 const isSupportedType = (subject: string): subject is SchemaObjectType =>
   subject in samples;
 
-export const depictEnum: Depicter = ({ jsonSchema }) => ({
-  type: typeof jsonSchema.enum?.[0],
-  ...jsonSchema,
-});
-
 export const depictLiteral: Depicter = ({ jsonSchema }) => ({
   type: typeof (jsonSchema.const || jsonSchema.enum?.[0]),
   ...jsonSchema,
@@ -388,7 +383,6 @@ const depicters: Partial<Record<FirstPartyKind | ProprietaryBrand, Depicter>> =
     tuple: depictTuple,
     pipe: depictPipeline,
     literal: depictLiteral,
-    enum: depictEnum,
     [ezDateInBrand]: depictDateIn,
     [ezDateOutBrand]: depictDateOut,
     [ezUploadBrand]: depictUpload,

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -106,16 +106,6 @@ DocumentationError({
 })
 `;
 
-exports[`Documentation helpers > depictEnum() > should set type 1`] = `
-{
-  "enum": [
-    "test",
-    "jest",
-  ],
-  "type": "string",
-}
-`;
-
 exports[`Documentation helpers > depictIntersection() > should NOT flatten object schemas having conflicting props 1`] = `
 {
   "allOf": [

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -25,7 +25,6 @@ import {
   depictDateIn,
   depictDateOut,
   depictBody,
-  depictEnum,
   depictLiteral,
   depictRequest,
 } from "../src/documentation-helpers";
@@ -299,17 +298,6 @@ describe("Documentation helpers", () => {
     ])("should not add null type when it's already there %#", (jsonSchema) => {
       expect(
         depictNullable({ zodSchema: z.never(), jsonSchema }, requestCtx),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe("depictEnum()", () => {
-    test("should set type", () => {
-      expect(
-        depictEnum(
-          { zodSchema: z.never(), jsonSchema: { enum: ["test", "jest"] } },
-          requestCtx,
-        ),
       ).toMatchSnapshot();
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to reflect the removal of custom enum depiction in favor of improved native support.
- **Refactor**
  - Removed custom logic for enum depiction in documentation helpers.
- **Tests**
  - Removed tests related to the deprecated enum depiction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->