### PR TITLE
Removing `depictLiteral`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### v24.2.1
 
 - Removed overrides for depicting enums in the generated `Documentation`:
-  - The better implementation provided by [Zod v3.25.45](https://github.com/colinhacks/zod/releases/tag/v3.25.45).
+  - The better implementation provided by [Zod v3.25.45](https://github.com/colinhacks/zod/releases/tag/v3.25.45);
+- Removed overrides for depicting literals in the generated `Documentation`:
+  - Fixed in [Zod v3.25.49](https://github.com/colinhacks/zod/releases/tag/v3.25.49).
 
 ### v24.2.0
 

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -143,11 +143,6 @@ export const depictNullable: Depicter = ({ jsonSchema }) => {
 const isSupportedType = (subject: string): subject is SchemaObjectType =>
   subject in samples;
 
-export const depictLiteral: Depicter = ({ jsonSchema }) => ({
-  type: typeof (jsonSchema.const || jsonSchema.enum?.[0]),
-  ...jsonSchema,
-});
-
 const ensureCompliance = ({
   $ref,
   type,
@@ -382,7 +377,6 @@ const depicters: Partial<Record<FirstPartyKind | ProprietaryBrand, Depicter>> =
     intersection: depictIntersection,
     tuple: depictTuple,
     pipe: depictPipeline,
-    literal: depictLiteral,
     [ezDateInBrand]: depictDateIn,
     [ezDateOutBrand]: depictDateOut,
     [ezUploadBrand]: depictUpload,

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -190,23 +190,6 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
 }
 `;
 
-exports[`Documentation helpers > depictLiteral() > should set type from either const or enum prop 0 1`] = `
-{
-  "const": "test",
-  "type": "string",
-}
-`;
-
-exports[`Documentation helpers > depictLiteral() > should set type from either const or enum prop 1 1`] = `
-{
-  "enum": [
-    "test",
-    "jest",
-  ],
-  "type": "string",
-}
-`;
-
 exports[`Documentation helpers > depictNullable() > should add null type to the first of anyOf 0 1`] = `
 {
   "type": [

--- a/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
@@ -55,6 +55,7 @@ exports[`Endpoint > .getResponses() > should return the negative responses (read
         },
         "status": {
           "const": "error",
+          "type": "string",
         },
       },
       "required": [
@@ -94,6 +95,7 @@ exports[`Endpoint > .getResponses() > should return the positive responses (read
         },
         "status": {
           "const": "success",
+          "type": "string",
         },
       },
       "required": [

--- a/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`SSE > makeEventSchema() > should make a valid schema of SSE event 1`] =
     },
     "event": {
       "const": "test",
+      "type": "string",
     },
     "id": {
       "type": "string",
@@ -45,6 +46,7 @@ exports[`SSE > makeResultHandler() > should create ResultHandler describing poss
             },
             "event": {
               "const": "test",
+              "type": "string",
             },
             "id": {
               "type": "string",
@@ -69,6 +71,7 @@ exports[`SSE > makeResultHandler() > should create ResultHandler describing poss
             },
             "event": {
               "const": "another",
+              "type": "string",
             },
             "id": {
               "type": "string",
@@ -126,6 +129,7 @@ exports[`SSE > makeResultHandler() > should create ResultHandler describing poss
         },
         "event": {
           "const": "single",
+          "type": "string",
         },
         "id": {
           "type": "string",

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -25,7 +25,6 @@ import {
   depictDateIn,
   depictDateOut,
   depictBody,
-  depictLiteral,
   depictRequest,
 } from "../src/documentation-helpers";
 
@@ -300,17 +299,6 @@ describe("Documentation helpers", () => {
         depictNullable({ zodSchema: z.never(), jsonSchema }, requestCtx),
       ).toMatchSnapshot();
     });
-  });
-
-  describe("depictLiteral()", () => {
-    test.each([{ const: "test" }, { enum: ["test", "jest"] }])(
-      "should set type from either const or enum prop %#",
-      (jsonSchema) => {
-        expect(
-          depictLiteral({ zodSchema: z.never(), jsonSchema }, requestCtx),
-        ).toMatchSnapshot();
-      },
-    );
   });
 
   describe("depictBigInt()", () => {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.0",
     "vitest": "^3.2.0",
-    "zod": "^3.25.48"
+    "zod": "^3.25.49"
   },
   "resolutions": {
     "**/@scarf/scarf": "npm:empty-npm-package@1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,7 +3164,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.25.48:
-  version "3.25.48"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.48.tgz#6c2b536fbb519905e8f4a4ac58743de4d5331bb2"
-  integrity sha512-0X1mz8FtgEIvaxGjdIImYpZEaZMrund9pGXm3M6vM7Reba0e2eI71KPjSCGXBfwKDPwPoywf6waUKc3/tFvX2Q==
+zod@^3.25.49:
+  version "3.25.49"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.49.tgz#e044541aac57bd12d1cec5dbf9309cdc768774c2"
+  integrity sha512-JMMPMy9ZBk3XFEdbM3iL1brx4NUSejd6xr3ELrrGEfGb355gjhiAWtG3K5o+AViV/3ZfkIrCzXsZn6SbLwTR8Q==


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog to reflect the removal of literal and enum overrides in generated documentation, noting dependency on specific Zod versions.

- **Chores**
  - Upgraded Zod dependency to version 3.25.49.

- **Tests**
  - Removed tests related to literal schema depiction, as this functionality has been deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->