### PR TITLE
Rev: preserving `depictEnum` and `depictLiteral` fallbacks for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### v24.2.1
 
-- Removed overrides for depicting enums in the generated `Documentation`:
-  - The better implementation provided by [Zod v3.25.45](https://github.com/colinhacks/zod/releases/tag/v3.25.45);
-- Removed overrides for depicting literals in the generated `Documentation`:
-  - Fixed in [Zod v3.25.49](https://github.com/colinhacks/zod/releases/tag/v3.25.49).
+- Prioritizing Zod native depiction for `z.enum()` and `z.literal()` by the `Documentation` generator:
+  - Enum `type` implemented in [Zod v3.25.45](https://github.com/colinhacks/zod/releases/tag/v3.25.45);
+  - Literal `type` implemented in [Zod v3.25.49](https://github.com/colinhacks/zod/releases/tag/v3.25.49).
 
 ### v24.2.0
 

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -143,6 +143,24 @@ export const depictNullable: Depicter = ({ jsonSchema }) => {
 const isSupportedType = (subject: string): subject is SchemaObjectType =>
   subject in samples;
 
+/**
+ * @todo remove in v25
+ * @since zod 3.25.45
+ */
+export const depictEnum: Depicter = ({ jsonSchema }) => {
+  jsonSchema.type ??= typeof jsonSchema.enum?.[0];
+  return jsonSchema;
+};
+
+/**
+ * @todo remove in v25
+ * @since zod 3.25.49
+ * */
+export const depictLiteral: Depicter = ({ jsonSchema }) => {
+  jsonSchema.type ??= typeof (jsonSchema.const || jsonSchema.enum?.[0]);
+  return jsonSchema;
+};
+
 const ensureCompliance = ({
   $ref,
   type,
@@ -377,6 +395,8 @@ const depicters: Partial<Record<FirstPartyKind | ProprietaryBrand, Depicter>> =
     intersection: depictIntersection,
     tuple: depictTuple,
     pipe: depictPipeline,
+    literal: depictLiteral,
+    enum: depictEnum,
     [ezDateInBrand]: depictDateIn,
     [ezDateOutBrand]: depictDateOut,
     [ezUploadBrand]: depictUpload,

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -106,6 +106,16 @@ DocumentationError({
 })
 `;
 
+exports[`Documentation helpers > depictEnum() > should set type 1`] = `
+{
+  "enum": [
+    "test",
+    "jest",
+  ],
+  "type": "string",
+}
+`;
+
 exports[`Documentation helpers > depictIntersection() > should NOT flatten object schemas having conflicting props 1`] = `
 {
   "allOf": [
@@ -187,6 +197,23 @@ exports[`Documentation helpers > depictIntersection() > should merge examples de
     },
   },
   "type": "object",
+}
+`;
+
+exports[`Documentation helpers > depictLiteral() > should set type from either const or enum prop 0 1`] = `
+{
+  "const": "test",
+  "type": "string",
+}
+`;
+
+exports[`Documentation helpers > depictLiteral() > should set type from either const or enum prop 1 1`] = `
+{
+  "enum": [
+    "test",
+    "jest",
+  ],
+  "type": "string",
 }
 `;
 

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -25,6 +25,8 @@ import {
   depictDateIn,
   depictDateOut,
   depictBody,
+  depictEnum,
+  depictLiteral,
   depictRequest,
 } from "../src/documentation-helpers";
 
@@ -299,6 +301,28 @@ describe("Documentation helpers", () => {
         depictNullable({ zodSchema: z.never(), jsonSchema }, requestCtx),
       ).toMatchSnapshot();
     });
+  });
+
+  describe("depictEnum()", () => {
+    test("should set type", () => {
+      expect(
+        depictEnum(
+          { zodSchema: z.never(), jsonSchema: { enum: ["test", "jest"] } },
+          requestCtx,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("depictLiteral()", () => {
+    test.each([{ const: "test" }, { enum: ["test", "jest"] }])(
+      "should set type from either const or enum prop %#",
+      (jsonSchema) => {
+        expect(
+          depictLiteral({ zodSchema: z.never(), jsonSchema }, requestCtx),
+        ).toMatchSnapshot();
+      },
+    );
   });
 
   describe("depictBigInt()", () => {


### PR DESCRIPTION
Partially reverts #2697 and #2698 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog entry to clarify that the documentation generator now prioritizes Zod's native depiction for enums and literals.

- **New Features**
  - Improved handling of enums and literals in generated documentation, ensuring more accurate type representation.

- **Tests**
  - Added new test cases to validate the depiction of enums and literals in the documentation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->