### PR TITLE
Reusing `z.object({})` for describing `EmptySchema` and `EmptyObject`

### DIFF
--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -75,7 +75,7 @@
     "express-fileupload": "^1.5.0",
     "http-errors": "^2.0.0",
     "typescript": "^5.1.3",
-    "zod": "^3.25.35"
+    "zod": "^3.25.61"
   },
   "peerDependenciesMeta": {
     "@types/compression": {

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -6,10 +6,11 @@ import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
 import { AuxMethod, Method } from "./method";
 
+/** @since zod 3.25.61 output type fixed */
+export const emptySchema = z.object({});
+export type EmptySchema = typeof emptySchema;
 /** @desc this type does not allow props assignment, but it works for reading them when merged with another interface */
 export type EmptyObject = z.output<EmptySchema>;
-/** Avoiding z.ZodObject<Record<string, never>, $strip>, because its z.output<> is generic "object" (external issue) */
-export type EmptySchema = z.ZodRecord<z.ZodString, z.ZodNever>;
 export type FlatObject = Record<string, unknown>;
 
 /** @link https://stackoverflow.com/a/65492934 */

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -1,6 +1,12 @@
 import { Request, Response } from "express";
 import { z } from "zod/v4";
-import { EmptyObject, EmptySchema, FlatObject, Tag } from "./common-helpers";
+import {
+  EmptyObject,
+  emptySchema,
+  EmptySchema,
+  FlatObject,
+  Tag,
+} from "./common-helpers";
 import { Endpoint, Handler } from "./endpoint";
 import { IOSchema, getFinalEndpointInputSchema } from "./io-schema";
 import { Method } from "./method";
@@ -118,7 +124,7 @@ export class EndpointsFactory<
   }
 
   public build<BOUT extends IOSchema, BIN extends IOSchema = EmptySchema>({
-    input = z.object({}) as unknown as BIN,
+    input = emptySchema as unknown as BIN,
     output: outputSchema,
     operationId,
     scope,
@@ -152,7 +158,7 @@ export class EndpointsFactory<
   }: Omit<BuildProps<BIN, z.ZodVoid, IN, OUT, SCO>, "output">) {
     return this.build({
       ...rest,
-      output: z.object({}),
+      output: emptySchema,
       handler: async (props) => {
         await handler(props);
         return {};

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { z } from "zod/v4";
-import { EmptySchema, FlatObject } from "./common-helpers";
+import { emptySchema, EmptySchema, FlatObject } from "./common-helpers";
 import { InputValidationError } from "./errors";
 import { IOSchema } from "./io-schema";
 import { LogicalContainer } from "./logical-container";
@@ -50,7 +50,7 @@ export class Middleware<
   readonly #handler: Handler<z.output<IN>, OPT, OUT>;
 
   constructor({
-    input = z.object({}) as unknown as IN,
+    input = emptySchema as unknown as IN,
     security,
     handler,
   }: {

--- a/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/common-helpers.spec.ts.snap
@@ -26,6 +26,15 @@ exports[`Common Helpers > defaultInputSources > should be declared in a certain 
 }
 `;
 
+exports[`Common Helpers > emptySchema > should be an object schema with empty shape and strip catcher 1`] = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object",
+}
+`;
+
 exports[`Common Helpers > getMessageFromError() > should compile a string from ZodError 1`] = `"user.id: expected number, got string; user.name: expected string, got number"`;
 
 exports[`Common Helpers > getMessageFromError() > should handle empty path in ZodIssue 1`] = `"Top level refinement issue"`;

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -7,11 +7,32 @@ import {
   makeCleanId,
   ensureError,
   getRoutePathParams,
+  emptySchema,
+  EmptySchema,
+  EmptyObject,
 } from "../src/common-helpers";
 import { z } from "zod/v4";
 import { makeRequestMock } from "../src/testing";
 
 describe("Common Helpers", () => {
+  describe("emptySchema", () => {
+    test("should be an object schema with empty shape and strip catcher", () => {
+      expect(emptySchema).toMatchSnapshot();
+    });
+  });
+
+  describe("EmptySchema", () => {
+    test("should be the type of emptySchema", () => {
+      expectTypeOf<EmptySchema>().toEqualTypeOf(emptySchema);
+    });
+  });
+
+  describe("EmptyObject", () => {
+    test("should be a Record of never", () => {
+      expectTypeOf<EmptyObject>().toEqualTypeOf<Record<string, never>>();
+    });
+  });
+
   describe("defaultInputSources", () => {
     test("should be declared in a certain way", () => {
       expect(defaultInputSources).toMatchSnapshot();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,7 @@ importers:
         specifier: ^5.1.3
         version: 5.8.3
       zod:
-        specifier: ^3.25.35
+        specifier: ^3.25.61
         version: 3.25.64
     devDependencies:
       '@arethetypeswrong/cli':


### PR DESCRIPTION
Fixed in zod 3.25.61: https://github.com/colinhacks/zod/commit/1c2ad877120566adc9db3a8d99c1a575bc58d216#comments

Elevating peer dependency requirement is breaking, therefore addressing to v25