### PR TITLE
Removing plural noop props from ApiResponse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 24
 
+### v24.3.2
+
+- Removed previously deprecated plural properties from `ApiResponse` interface: `statusCodes`, `mimeTypes`.
+
 ### v24.3.1
 
 - Compatibility fix for Zod 3.25.60.

--- a/express-zod-api/src/api-response.ts
+++ b/express-zod-api/src/api-response.ts
@@ -20,10 +20,6 @@ export interface ApiResponse<S extends z.ZodType> {
    * @default "application/json"
    * */
   mimeType?: string | [string, ...string[]] | null;
-  /** @deprecated use statusCode */
-  statusCodes?: never;
-  /** @deprecated use mimeType */
-  mimeTypes?: never;
 }
 
 /**


### PR DESCRIPTION
Noop since v21.0.0.
Can't believe I forget to remove them. Should have been adding "todo"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed deprecated plural properties from the response configuration interface. This change does not affect existing usage of supported properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->