### PR TITLE
Configuring renovate groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "dependencyDashboard": false,
-  "postUpdateOptions": ["pnpmDedupe"]
+  "postUpdateOptions": ["pnpmDedupe"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript-eslint", "@typescript-eslint/*"]
+    },
+    {
+      "matchPackageNames": ["vitest", "@vitest/*"]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,11 @@
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
+      "groupName": "TypeScript-ESLint and its rule tester (used by migration)",
       "matchPackageNames": ["typescript-eslint", "@typescript-eslint/*"]
     },
     {
+      "groupName": "Vitest and its coverage provider",
       "matchPackageNames": ["vitest", "@vitest/*"]
     }
   ]


### PR DESCRIPTION
Replacement for: https://github.com/RobinTail/express-zod-api/commit/225c3235d37fbf648972678888d96a3a06d2d067

Config can be validating this way:
```shell
npx --yes --package renovate -- renovate-config-validator --strict ./renovate.json
```

Instead of pnpm catalog attempted in #2736 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Renovate configuration to include new package rules for managing updates to TypeScript ESLint and Vitest packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->