### PR TITLE
Exp: Using `pnpm` alias approach instead of min catalog

### DIFF
--- a/compat-test/package.json
+++ b/compat-test/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "@express-zod-api/migration": "workspace:*",
     "express-zod-api": "workspace:*",
-    "express": "catalog:min",
-    "typescript": "catalog:min",
-    "http-errors": "catalog:min",
-    "zod": "catalog:min"
+    "express": "npm:express@5.1.0",
+    "typescript": "npm:typescript@5.1.3",
+    "http-errors": "npm:http-errors@2.0.0",
+    "zod": "npm:zod@3.25.35"
   },
   "devDependencies": {
-    "eslint": "catalog:min",
-    "typescript-eslint": "catalog:min"
+    "eslint": "npm:eslint@9.0.0",
+    "typescript-eslint": "npm:typescript-eslint@8.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,25 +9,6 @@ catalogs:
     undici:
       specifier: ^6.19.8
       version: 6.21.3
-  min:
-    eslint:
-      specifier: 9.0.0
-      version: 9.0.0
-    express:
-      specifier: 5.1.0
-      version: 5.1.0
-    http-errors:
-      specifier: 2.0.0
-      version: 2.0.0
-    typescript:
-      specifier: 5.1.3
-      version: 5.1.3
-    typescript-eslint:
-      specifier: 8.0.0
-      version: 8.0.0
-    zod:
-      specifier: 3.25.35
-      version: 3.25.35
   peer:
     '@types/compression':
       specifier: ^1.7.5
@@ -131,26 +112,26 @@ importers:
         specifier: workspace:*
         version: link:../migration
       express:
-        specifier: catalog:min
+        specifier: npm:express@5.1.0
         version: 5.1.0
       express-zod-api:
         specifier: workspace:*
         version: link:../express-zod-api
       http-errors:
-        specifier: catalog:min
+        specifier: npm:http-errors@2.0.0
         version: 2.0.0
       typescript:
-        specifier: catalog:min
+        specifier: npm:typescript@5.1.3
         version: 5.1.3
       zod:
-        specifier: catalog:min
+        specifier: npm:zod@3.25.35
         version: 3.25.35
     devDependencies:
       eslint:
-        specifier: catalog:min
+        specifier: npm:eslint@9.0.0
         version: 9.0.0
       typescript-eslint:
-        specifier: catalog:min
+        specifier: npm:typescript-eslint@8.0.0
         version: 8.0.0(eslint@9.0.0)(typescript@5.1.3)
 
   esm-test:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,13 +18,6 @@ publicHoistPattern:
   - "@types/qs" # used by index.ts, fixes TS2742 for attachRouting
   - "@types/express-serve-static-core" # used by index.ts, fixes TS2742 for attachRouting
 catalogs:
-  min:
-    "express": "5.1.0"
-    "typescript": "5.1.3"
-    "http-errors": "2.0.0"
-    "zod": "3.25.35"
-    "eslint": "9.0.0"
-    "typescript-eslint": "8.0.0"
   peer:
     "@types/compression": "^1.7.5"
     "@types/express": "^5.0.0"

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "dependencyDashboard": false,
   "postUpdateOptions": ["pnpmDedupe"],
+  "ignorePaths": ["**/compat-test/**"],
   "packageRules": [
     {
       "groupName": "TypeScript-ESLint and its rule tester (used by migration)",
@@ -11,30 +12,6 @@
     {
       "groupName": "Vitest and its coverage provider",
       "matchPackageNames": ["vitest", "@vitest/*"]
-    },
-    {
-      "groupName": "Disallow eslint bump in compat-test",
-      "matchPackageNames": ["eslint"],
-      "matchCurrentVersion": "9.0.0",
-      "allowedVersions": "9.0.0"
-    },
-    {
-      "groupName": "Disallow zod bump in compat-test",
-      "matchPackageNames": ["zod"],
-      "matchCurrentVersion": "3.25.35",
-      "allowedVersions": "3.25.35"
-    },
-    {
-      "groupName": "Disallow typescript bump in compat-test",
-      "matchPackageNames": ["typescript"],
-      "matchCurrentVersion": "5.1.3",
-      "allowedVersions": "5.1.3"
-    },
-    {
-      "groupName": "Disallow typescript-eslint bump in compat-test",
-      "matchPackageNames": ["typescript-eslint"],
-      "matchCurrentVersion": "8.0.0",
-      "allowedVersions": "8.0.0"
     }
   ]
 }


### PR DESCRIPTION
I'm trying to exclude `compat-test` workspace from renovate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency versions in the compatibility test package to use explicit versions.
  - Removed the minimum version catalog from workspace configuration.
  - Simplified Renovate configuration by excluding the compatibility test directory from automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->