### PR TITLE
Using `R.renameKeys()` for zod-plugin's method `remap()`

### DIFF
--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -28,6 +28,15 @@ import type {
   $strip,
 } from "zod/v4/core";
 
+/** @todo remove when typed, https://github.com/ramda/types/pull/140 */
+declare module "ramda" {
+  function renameKeys<
+    V extends string,
+    T extends object,
+    U extends { [P in keyof T]?: V },
+  >(mapping: U): (subject: T) => Remap<T, U, V>;
+}
+
 declare module "zod/v4/core" {
   interface GlobalMeta {
     default?: unknown; // can be an actual value or a label like "Today"
@@ -125,13 +134,7 @@ const objectMapper = function (
     | (<T>(subject: T) => { [P in string | keyof T]: T[keyof T] }),
 ) {
   const transformer =
-    typeof tool === "function"
-      ? tool
-      : R.pipe(
-          R.toPairs, // eslint-disable-line no-restricted-syntax -- strict key type required
-          R.map(([key, value]) => R.pair(tool[String(key)] || key, value)),
-          R.fromPairs,
-        );
+    typeof tool === "function" ? tool : R.renameKeys(R.reject(R.isNil, tool)); // rejecting undefined
   const nextShape = transformer(
     R.map(R.invoker(0, "clone"), this._zod.def.shape), // immutable, changed from R.clone due to failure
   );


### PR DESCRIPTION
The new method introduced in Ramda 0.31, see #2764 
For the edge case of `undefined` value in tooling it behaves a little different, so I'm addressing it using `R.reject(R.isNil())`