### PR TITLE
Making `EndpointsFactory::#create()` an instance method

### DIFF
--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -74,12 +74,12 @@ export class EndpointsFactory<
   protected middlewares: AbstractMiddleware[] = [];
   constructor(protected resultHandler: AbstractResultHandler) {}
 
-  static #create<
+  #create<
     CIN extends IOSchema | undefined,
     COUT extends FlatObject,
     CSCO extends string,
-  >(middlewares: AbstractMiddleware[], resultHandler: AbstractResultHandler) {
-    const factory = new EndpointsFactory<CIN, COUT, CSCO>(resultHandler);
+  >(middlewares: AbstractMiddleware[]) {
+    const factory = new EndpointsFactory<CIN, COUT, CSCO>(this.resultHandler);
     factory.middlewares = middlewares;
     return factory;
   }
@@ -93,7 +93,7 @@ export class EndpointsFactory<
       | Middleware<OUT, AOUT, ASCO, AIN>
       | ConstructorParameters<typeof Middleware<OUT, AOUT, ASCO, AIN>>[0],
   ) {
-    return EndpointsFactory.#create<
+    return this.#create<
       ConditionalIntersection<IN, AIN>,
       OUT & AOUT,
       SCO & ASCO
@@ -101,7 +101,6 @@ export class EndpointsFactory<
       this.middlewares.concat(
         subject instanceof Middleware ? subject : new Middleware(subject),
       ),
-      this.resultHandler,
     );
   }
 
@@ -112,16 +111,14 @@ export class EndpointsFactory<
     S extends Response,
     AOUT extends FlatObject = EmptyObject,
   >(...params: ConstructorParameters<typeof ExpressMiddleware<R, S, AOUT>>) {
-    return EndpointsFactory.#create<IN, OUT & AOUT, SCO>(
+    return this.#create<IN, OUT & AOUT, SCO>(
       this.middlewares.concat(new ExpressMiddleware(...params)),
-      this.resultHandler,
     );
   }
 
   public addOptions<AOUT extends FlatObject>(getOptions: () => Promise<AOUT>) {
-    return EndpointsFactory.#create<IN, OUT & AOUT, SCO>(
+    return this.#create<IN, OUT & AOUT, SCO>(
       this.middlewares.concat(new Middleware({ handler: getOptions })),
-      this.resultHandler,
     );
   }
 

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -78,9 +78,9 @@ export class EndpointsFactory<
     CIN extends IOSchema | undefined,
     COUT extends FlatObject,
     CSCO extends string,
-  >(middlewares: AbstractMiddleware[]) {
+  >(middleware: AbstractMiddleware) {
     const factory = new EndpointsFactory<CIN, COUT, CSCO>(this.resultHandler);
-    factory.middlewares = middlewares;
+    factory.middlewares = this.middlewares.concat(middleware);
     return factory;
   }
 
@@ -97,11 +97,7 @@ export class EndpointsFactory<
       ConditionalIntersection<IN, AIN>,
       OUT & AOUT,
       SCO & ASCO
-    >(
-      this.middlewares.concat(
-        subject instanceof Middleware ? subject : new Middleware(subject),
-      ),
-    );
+    >(subject instanceof Middleware ? subject : new Middleware(subject));
   }
 
   public use = this.addExpressMiddleware;
@@ -111,14 +107,12 @@ export class EndpointsFactory<
     S extends Response,
     AOUT extends FlatObject = EmptyObject,
   >(...params: ConstructorParameters<typeof ExpressMiddleware<R, S, AOUT>>) {
-    return this.#create<IN, OUT & AOUT, SCO>(
-      this.middlewares.concat(new ExpressMiddleware(...params)),
-    );
+    return this.#create<IN, OUT & AOUT, SCO>(new ExpressMiddleware(...params));
   }
 
   public addOptions<AOUT extends FlatObject>(getOptions: () => Promise<AOUT>) {
     return this.#create<IN, OUT & AOUT, SCO>(
-      this.middlewares.concat(new Middleware({ handler: getOptions })),
+      new Middleware({ handler: getOptions }),
     );
   }
 


### PR DESCRIPTION
I think it's a legacy that it used to be static.
It could be simplified now.

I'd like to reuse it for #2777 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for endpoint factory creation to enhance maintainability. No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->