### PR TITLE
Disabling `autoInstallPeers`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,6 +39,8 @@ jobs:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ matrix.node-version }}
         parallel: true
+    - name: Migration test
+      run: pnpm test:migration
     - name: Build
       run: pnpm build
     - name: Example test

--- a/cjs-test/package.json
+++ b/cjs-test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "vitest run --globals"
   },
-  "dependencies": {
+  "devDependencies": {
     "express-zod-api": "workspace:*",
     "zod": "catalog:dev"
   }

--- a/cjs-test/package.json
+++ b/cjs-test/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "express-zod-api": "workspace:*",
-    "zod": "catalog:peer"
+    "zod": "catalog:dev"
   }
 }

--- a/compat-test/package.json
+++ b/compat-test/package.json
@@ -7,16 +7,14 @@
     "test": "eslint --fix && vitest --run",
     "posttest": "rm sample.ts"
   },
-  "dependencies": {
-    "@express-zod-api/migration": "workspace:*",
-    "express-zod-api": "workspace:*",
-    "express": "npm:express@5.1.0",
-    "typescript": "npm:typescript@5.1.3",
-    "http-errors": "npm:http-errors@2.0.0",
-    "zod": "npm:zod@3.25.35"
-  },
   "devDependencies": {
+    "@express-zod-api/migration": "workspace:*",
     "eslint": "npm:eslint@9.0.0",
-    "typescript-eslint": "npm:typescript-eslint@8.0.0"
+    "express": "npm:express@5.1.0",
+    "express-zod-api": "workspace:*",
+    "http-errors": "npm:http-errors@2.0.0",
+    "typescript": "npm:typescript@5.1.3",
+    "typescript-eslint": "npm:typescript-eslint@8.0.0",
+    "zod": "npm:zod@3.25.35"
   }
 }

--- a/esm-test/package.json
+++ b/esm-test/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "express-zod-api": "workspace:*",
-    "zod": "catalog:peer"
+    "zod": "catalog:dev"
   }
 }

--- a/esm-test/package.json
+++ b/esm-test/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "vitest run --globals"
   },
-  "dependencies": {
+  "devDependencies": {
     "express-zod-api": "workspace:*",
     "zod": "catalog:dev"
   }

--- a/example/package.json
+++ b/example/package.json
@@ -11,16 +11,14 @@
     "pretest": "tsc --noEmit",
     "test": "vitest run --globals index.spec.ts"
   },
-  "dependencies": {
-    "express-zod-api": "workspace:*",
-    "http-errors": "catalog:dev",
-    "swagger-ui-express": "^5.0.0",
-    "zod": "catalog:dev"
-  },
   "devDependencies": {
     "@types/http-errors": "catalog:dev",
     "@types/swagger-ui-express": "^4.1.8",
+    "express-zod-api": "workspace:*",
+    "http-errors": "catalog:dev",
+    "swagger-ui-express": "^5.0.0",
     "typescript": "catalog:dev",
-    "undici": "catalog:dev"
+    "undici": "catalog:dev",
+    "zod": "catalog:dev"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "express-zod-api": "workspace:*",
-    "http-errors": "catalog:peer",
+    "http-errors": "catalog:dev",
     "swagger-ui-express": "^5.0.0",
-    "zod": "catalog:peer"
+    "zod": "catalog:dev"
   },
   "devDependencies": {
-    "@types/http-errors": "catalog:peer",
+    "@types/http-errors": "catalog:dev",
     "@types/swagger-ui-express": "^4.1.8",
-    "typescript": "catalog:peer",
+    "typescript": "catalog:dev",
     "undici": "catalog:dev"
   }
 }

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -89,16 +89,26 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/depd": "^1.1.37",
+    "@types/compression": "catalog:dev",
+    "@types/express": "catalog:dev",
+    "@types/express-fileupload": "catalog:dev",
+    "@types/http-errors": "catalog:dev",
     "@types/node-forge": "^1.3.11",
     "@types/ramda": "^0.30.0",
     "@types/semver": "^7.7.0",
     "camelize-ts": "^3.0.0",
+    "compression": "catalog:dev",
     "cors": "^2.8.5",
     "depd": "^2.0.0",
+    "express": "catalog:dev",
+    "express-fileupload": "catalog:dev",
+    "http-errors": "catalog:dev",
     "node-forge": "^1.3.1",
     "semver": "^7.7.2",
     "snakify-ts": "^2.3.0",
-    "undici": "catalog:dev"
+    "typescript": "catalog:dev",
+    "undici": "catalog:dev",
+    "zod": "catalog:dev"
   },
   "keywords": [
     "nodejs",

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -87,9 +87,9 @@
     }
   },
   "devDependencies": {
+    "@types/compression": "catalog:dev",
     "@types/cors": "^2.8.19",
     "@types/depd": "^1.1.37",
-    "@types/compression": "catalog:dev",
     "@types/express": "catalog:dev",
     "@types/express-fileupload": "catalog:dev",
     "@types/http-errors": "catalog:dev",

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -55,16 +55,16 @@
     "ramda": "^0.31.3"
   },
   "peerDependencies": {
-    "@types/compression": "catalog:peer",
-    "@types/express": "catalog:peer",
-    "@types/express-fileupload": "catalog:peer",
-    "@types/http-errors": "catalog:peer",
-    "compression": "catalog:peer",
-    "express": "catalog:peer",
-    "express-fileupload": "catalog:peer",
-    "http-errors": "catalog:peer",
-    "typescript": "catalog:peer",
-    "zod": "catalog:peer"
+    "@types/compression": "^1.7.5",
+    "@types/express": "^5.0.0",
+    "@types/express-fileupload": "^1.5.0",
+    "@types/http-errors": "^2.0.2",
+    "compression": "^1.8.0",
+    "express": "^5.1.0",
+    "express-fileupload": "^1.5.0",
+    "http-errors": "^2.0.0",
+    "typescript": "^5.1.3",
+    "zod": "^3.25.35"
   },
   "peerDependenciesMeta": {
     "@types/compression": {

--- a/issue952-test/package.json
+++ b/issue952-test/package.json
@@ -6,7 +6,7 @@
     "test": "tsc -p tsconfig.json",
     "posttest": "rm *.d.ts"
   },
-  "dependencies": {
+  "devDependencies": {
     "@types/express": "catalog:dev",
     "@types/express-fileupload": "catalog:dev",
     "express-zod-api": "workspace:*",

--- a/issue952-test/package.json
+++ b/issue952-test/package.json
@@ -6,7 +6,7 @@
     "test": "tsc -p tsconfig.json",
     "posttest": "rm *.d.ts"
   },
-  "devDependencies": {
+  "dependencies": {
     "@types/express": "catalog:dev",
     "@types/express-fileupload": "catalog:dev",
     "express-zod-api": "workspace:*",

--- a/issue952-test/package.json
+++ b/issue952-test/package.json
@@ -7,10 +7,10 @@
     "posttest": "rm *.d.ts"
   },
   "dependencies": {
-    "@types/express": "catalog:peer",
-    "@types/express-fileupload": "catalog:peer",
+    "@types/express": "catalog:dev",
+    "@types/express-fileupload": "catalog:dev",
     "express-zod-api": "workspace:*",
-    "typescript": "catalog:peer",
-    "zod": "catalog:peer"
+    "typescript": "catalog:dev",
+    "zod": "catalog:dev"
   }
 }

--- a/migration/package.json
+++ b/migration/package.json
@@ -42,8 +42,8 @@
     "*.md"
   ],
   "peerDependencies": {
-    "eslint": "catalog:peer",
-    "typescript-eslint": "catalog:peer"
+    "eslint": "^9.0.0",
+    "typescript-eslint": "^8.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/rule-tester": "catalog:dev"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "3.6.2",
     "tsup": "^8.5.0",
     "tsx": "^4.19.4",
-    "typescript-eslint": "^8.34.0",
+    "typescript-eslint": "catalog:dev",
     "vitest": "^3.2.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:esm": "pnpm -F esm-test test",
     "test:compat": "pnpm -F compat-test test",
     "test:952": "pnpm -F issue952-test test",
+    "test:migration": "pnpm -F migration test",
     "bench": "pnpm -F express-zod-api bench",
     "lint": "eslint && prettier *.md **/*.md --check",
     "mdfix": "prettier *.md **/*.md --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 3.2.4(@types/node@24.0.8)(tsx@4.20.3)(yaml@2.8.0)
 
   cjs-test:
-    dependencies:
+    devDependencies:
       express-zod-api:
         specifier: workspace:*
         version: link:../express-zod-api
@@ -106,10 +106,13 @@ importers:
         version: 3.25.67
 
   compat-test:
-    dependencies:
+    devDependencies:
       '@express-zod-api/migration':
         specifier: workspace:*
         version: link:../migration
+      eslint:
+        specifier: npm:eslint@9.0.0
+        version: 9.0.0
       express:
         specifier: npm:express@5.1.0
         version: 5.1.0
@@ -122,19 +125,15 @@ importers:
       typescript:
         specifier: npm:typescript@5.1.3
         version: 5.1.3
-      zod:
-        specifier: npm:zod@3.25.35
-        version: 3.25.35
-    devDependencies:
-      eslint:
-        specifier: npm:eslint@9.0.0
-        version: 9.0.0
       typescript-eslint:
         specifier: npm:typescript-eslint@8.0.0
         version: 8.0.0(eslint@9.0.0)(typescript@5.1.3)
+      zod:
+        specifier: npm:zod@3.25.35
+        version: 3.25.35
 
   esm-test:
-    dependencies:
+    devDependencies:
       express-zod-api:
         specifier: workspace:*
         version: link:../express-zod-api
@@ -143,7 +142,13 @@ importers:
         version: 3.25.67
 
   example:
-    dependencies:
+    devDependencies:
+      '@types/http-errors':
+        specifier: catalog:dev
+        version: 2.0.5
+      '@types/swagger-ui-express':
+        specifier: ^4.1.8
+        version: 4.1.8
       express-zod-api:
         specifier: workspace:*
         version: link:../express-zod-api
@@ -153,22 +158,15 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.0
         version: 5.0.1(express@5.1.0)
-      zod:
-        specifier: catalog:dev
-        version: 3.25.67
-    devDependencies:
-      '@types/http-errors':
-        specifier: catalog:dev
-        version: 2.0.5
-      '@types/swagger-ui-express':
-        specifier: ^4.1.8
-        version: 4.1.8
       typescript:
         specifier: catalog:dev
         version: 5.8.3
       undici:
         specifier: catalog:dev
         version: 6.21.3
+      zod:
+        specifier: catalog:dev
+        version: 3.25.67
 
   express-zod-api:
     dependencies:
@@ -253,7 +251,7 @@ importers:
         version: 3.25.67
 
   issue952-test:
-    dependencies:
+    devDependencies:
       '@types/express':
         specifier: catalog:dev
         version: 5.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,53 +1,49 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 catalogs:
   dev:
+    '@types/compression':
+      specifier: ^1.8.1
+      version: 1.8.1
+    '@types/express':
+      specifier: ^5.0.3
+      version: 5.0.3
+    '@types/express-fileupload':
+      specifier: ^1.5.1
+      version: 1.5.1
+    '@types/http-errors':
+      specifier: ^2.0.5
+      version: 2.0.5
     '@typescript-eslint/rule-tester':
       specifier: ^8.35.1
       version: 8.35.1
-    undici:
-      specifier: ^6.19.8
-      version: 6.21.3
-  peer:
-    '@types/compression':
-      specifier: ^1.7.5
-      version: 1.8.1
-    '@types/express':
-      specifier: ^5.0.0
-      version: 5.0.3
-    '@types/express-fileupload':
-      specifier: ^1.5.0
-      version: 1.5.1
-    '@types/http-errors':
-      specifier: ^2.0.2
-      version: 2.0.5
     compression:
       specifier: ^1.8.0
       version: 1.8.0
-    eslint:
-      specifier: ^9.0.0
-      version: 9.30.0
     express:
       specifier: ^5.1.0
       version: 5.1.0
     express-fileupload:
-      specifier: ^1.5.0
+      specifier: ^1.5.1
       version: 1.5.1
     http-errors:
       specifier: ^2.0.0
       version: 2.0.0
     typescript:
-      specifier: ^5.1.3
+      specifier: ^5.8.3
       version: 5.8.3
     typescript-eslint:
-      specifier: ^8.0.0
+      specifier: ^8.35.1
       version: 8.35.1
+    undici:
+      specifier: ^6.19.8
+      version: 6.21.3
     zod:
-      specifier: ^3.25.35
+      specifier: ^3.25.67
       version: 3.25.67
 
 overrides:
@@ -94,7 +90,7 @@ importers:
         specifier: ^4.19.4
         version: 4.20.3
       typescript-eslint:
-        specifier: ^8.34.0
+        specifier: catalog:dev
         version: 8.35.1(eslint@9.30.0)(typescript@5.8.3)
       vitest:
         specifier: ^3.2.3
@@ -106,7 +102,7 @@ importers:
         specifier: workspace:*
         version: link:../express-zod-api
       zod:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 3.25.67
 
   compat-test:
@@ -143,7 +139,7 @@ importers:
         specifier: workspace:*
         version: link:../express-zod-api
       zod:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 3.25.67
 
   example:
@@ -152,23 +148,23 @@ importers:
         specifier: workspace:*
         version: link:../express-zod-api
       http-errors:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 2.0.0
       swagger-ui-express:
         specifier: ^5.0.0
         version: 5.0.1(express@5.1.0)
       zod:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 3.25.67
     devDependencies:
       '@types/http-errors':
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 2.0.5
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
       typescript:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 5.8.3
       undici:
         specifier: catalog:dev
@@ -176,33 +172,9 @@ importers:
 
   express-zod-api:
     dependencies:
-      '@types/compression':
-        specifier: catalog:peer
-        version: 1.8.1
-      '@types/express':
-        specifier: catalog:peer
-        version: 5.0.3
-      '@types/express-fileupload':
-        specifier: catalog:peer
-        version: 1.5.1
-      '@types/http-errors':
-        specifier: catalog:peer
-        version: 2.0.5
       ansis:
         specifier: ^4.1.0
         version: 4.1.0
-      compression:
-        specifier: catalog:peer
-        version: 1.8.0
-      express:
-        specifier: catalog:peer
-        version: 5.1.0
-      express-fileupload:
-        specifier: catalog:peer
-        version: 1.5.1
-      http-errors:
-        specifier: catalog:peer
-        version: 2.0.0
       node-mocks-http:
         specifier: ^1.17.2
         version: 1.17.2(@types/express@5.0.3)(@types/node@24.0.8)
@@ -212,19 +184,25 @@ importers:
       ramda:
         specifier: ^0.31.3
         version: 0.31.3
-      typescript:
-        specifier: catalog:peer
-        version: 5.8.3
-      zod:
-        specifier: catalog:peer
-        version: 3.25.67
     devDependencies:
+      '@types/compression':
+        specifier: catalog:dev
+        version: 1.8.1
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
       '@types/depd':
         specifier: ^1.1.37
         version: 1.1.37
+      '@types/express':
+        specifier: catalog:dev
+        version: 5.0.3
+      '@types/express-fileupload':
+        specifier: catalog:dev
+        version: 1.5.1
+      '@types/http-errors':
+        specifier: catalog:dev
+        version: 2.0.5
       '@types/node-forge':
         specifier: ^1.3.11
         version: 1.3.11
@@ -237,11 +215,23 @@ importers:
       camelize-ts:
         specifier: ^3.0.0
         version: 3.0.0
+      compression:
+        specifier: catalog:dev
+        version: 1.8.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
       depd:
         specifier: ^2.0.0
+        version: 2.0.0
+      express:
+        specifier: catalog:dev
+        version: 5.1.0
+      express-fileupload:
+        specifier: catalog:dev
+        version: 1.5.1
+      http-errors:
+        specifier: catalog:dev
         version: 2.0.0
       node-forge:
         specifier: ^1.3.1
@@ -252,36 +242,35 @@ importers:
       snakify-ts:
         specifier: ^2.3.0
         version: 2.3.0
+      typescript:
+        specifier: catalog:dev
+        version: 5.8.3
       undici:
         specifier: catalog:dev
         version: 6.21.3
+      zod:
+        specifier: catalog:dev
+        version: 3.25.67
 
   issue952-test:
     dependencies:
       '@types/express':
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 5.0.3
       '@types/express-fileupload':
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 1.5.1
       express-zod-api:
         specifier: workspace:*
         version: link:../express-zod-api
       typescript:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 5.8.3
       zod:
-        specifier: catalog:peer
+        specifier: catalog:dev
         version: 3.25.67
 
   migration:
-    dependencies:
-      eslint:
-        specifier: catalog:peer
-        version: 9.30.0
-      typescript-eslint:
-        specifier: catalog:peer
-        version: 8.35.1(eslint@9.30.0)(typescript@5.8.3)
     devDependencies:
       '@typescript-eslint/rule-tester':
         specifier: catalog:dev

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
         version: 3.25.67
 
   issue952-test:
-    devDependencies:
+    dependencies:
       '@types/express':
         specifier: catalog:dev
         version: 5.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,16 +20,16 @@ publicHoistPattern:
   - "@types/express-serve-static-core" # used by index.ts, fixes TS2742 for attachRouting
 catalogs:
   dev:
-    "typescript-eslint": "^8.35.1"
-    "@typescript-eslint/rule-tester": "^8.35.1"
     "@types/compression": "^1.8.1"
     "@types/express": "^5.0.3"
     "@types/express-fileupload": "^1.5.1"
     "@types/http-errors": "^2.0.5"
+    "@typescript-eslint/rule-tester": "^8.35.1"
     "compression": "^1.8.0"
-    "http-errors": "^2.0.0"
     "express": "^5.1.0"
     "express-fileupload": "^1.5.1"
+    "http-errors": "^2.0.0"
     "typescript": "^5.8.3"
-    "zod": "^3.25.67"
+    "typescript-eslint": "^8.35.1"
     "undici": "^6.19.8"
+    "zod": "^3.25.67"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,19 +19,6 @@ publicHoistPattern:
   - "@types/qs" # used by index.ts, fixes TS2742 for attachRouting
   - "@types/express-serve-static-core" # used by index.ts, fixes TS2742 for attachRouting
 catalogs:
-  peer:
-    "@types/compression": "^1.7.5"
-    "@types/express": "^5.0.0"
-    "@types/express-fileupload": "^1.5.0"
-    "@types/http-errors": "^2.0.2"
-    "compression": "^1.8.0"
-    "express": "^5.1.0"
-    "express-fileupload": "^1.5.0"
-    "http-errors": "^2.0.0"
-    "typescript": "^5.1.3"
-    "zod": "^3.25.35"
-    "eslint": "^9.0.0"
-    "typescript-eslint": "^8.0.0"
   dev:
     "typescript-eslint": "^8.35.1"
     "@typescript-eslint/rule-tester": "^8.35.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ onlyBuiltDependencies:
   - esbuild
 gitChecks: false
 engineStrict: true
+autoInstallPeers: false
 publicHoistPattern:
   - "@typescript-eslint/*" # used as an assumed transitive in migration
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts
@@ -32,5 +33,16 @@ catalogs:
     "eslint": "^9.0.0"
     "typescript-eslint": "^8.0.0"
   dev:
-    "undici": "^6.19.8"
+    "typescript-eslint": "^8.35.1"
     "@typescript-eslint/rule-tester": "^8.35.1"
+    "@types/compression": "^1.8.1"
+    "@types/express": "^5.0.3"
+    "@types/express-fileupload": "^1.5.1"
+    "@types/http-errors": "^2.0.5"
+    "compression": "^1.8.0"
+    "http-errors": "^2.0.0"
+    "express": "^5.1.0"
+    "express-fileupload": "^1.5.1"
+    "typescript": "^5.8.3"
+    "zod": "^3.25.67"
+    "undici": "^6.19.8"


### PR DESCRIPTION
This should simplify upgrading dependencies, because even renovate struggles to do it correctly.

`catalog:peer` no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency types and versions across multiple packages, consolidating peer and development dependencies.
  * Upgraded several core and type-related dependencies to newer versions.
  * Adjusted workspace configuration to improve dependency management and prevent automatic peer installation.
  * Removed unnecessary dependencies from the catalog configuration.
  * Added a new migration test script and integrated it into the CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->