### PR TITLE
Pure ESM distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### v25.0.0
 
-- Supported Node.js versions: `^20.19.0 || ^22.12.0 || ^24.0.0`;
+- Supported Node.js versions: `^20.19.0 || ^22.12.0 || ^24.0.0`:
+  - The framework distribution is now ESM-only (finally);
+  - All the Node.js versions listed above support `require(ESM)` syntax;
 - Supported `zod` version: `^4.0.0`;
 - Changes to the `Middleware` class:
   - When the `input` schema is not defined, the `input` argument of the `handler` method is now `unknown`;

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -17,7 +17,7 @@
   "funding": "https://github.com/sponsors/RobinTail",
   "scripts": {
     "build": "tsup",
-    "postbuild": "attw --pack",
+    "postbuild": "attw --pack --profile esm-only",
     "pretest": "tsc --noEmit",
     "test": "vitest run --coverage",
     "bench": "vitest bench --run ./bench",
@@ -26,19 +26,13 @@
   },
   "type": "module",
   "sideEffects": true,
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/express-zod-api/tsup.config.ts
+++ b/express-zod-api/tsup.config.ts
@@ -9,9 +9,9 @@ export default defineConfig({
   ...commons,
   entry: ["src/index.ts"],
   target: `node${minNode.major}.${minNode.minor}.${minNode.patch}`,
-  esbuildOptions: (options, { format }) => {
+  esbuildOptions: (options) => {
     options.define = {
-      "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
+      "process.env.TSUP_BUILD": `"v${version}"`, // @since v25.0.0 is pure ESM
       "process.env.TSUP_STATIC": `"static"`, // used by isProduction()
     };
   },

--- a/express-zod-api/tsup.config.ts
+++ b/express-zod-api/tsup.config.ts
@@ -10,15 +10,6 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: `node${minNode.major}.${minNode.minor}.${minNode.patch}`,
   esbuildOptions: (options, { format }) => {
-    options.supported = options.supported || {};
-    if (format === "cjs") {
-      /**
-       * Downgrade dynamic imports for CJS even they are actually supported, but still are problematic for Jest
-       * @example jest with ts-jest
-       * @link https://github.com/evanw/esbuild/issues/2651
-       */
-      options.supported["dynamic-import"] = false;
-    }
     options.define = {
       "process.env.TSUP_BUILD": `"v${version} (${format.toUpperCase()})"`,
       "process.env.TSUP_STATIC": `"static"`, // used by isProduction()

--- a/migration/package.json
+++ b/migration/package.json
@@ -18,23 +18,17 @@
     "pretest": "tsc --noEmit",
     "test": "vitest run --globals",
     "build": "tsup",
-    "postbuild": "attw --pack",
+    "postbuild": "attw --pack --profile esm-only",
     "prepublishOnly": "eslint && pnpm test && pnpm build"
   },
   "type": "module",
-  "main": "dist/index.cjs",
-  "types": "dist/index.d.cts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/tsup.base.ts
+++ b/tsup.base.ts
@@ -1,7 +1,7 @@
 import type { Options } from "tsup";
 
 export const commons: Options = {
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: false,
   clean: true,


### PR DESCRIPTION
It turned out that all LTS versions of Node.js might already support `require(ESM)`.

https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require

Unflagged in: v23.0.0, v22.12.0, v20.19.0
And those are exactly the ones in v25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and packaging configuration to support only ES modules, removing CommonJS outputs and related type declarations.
  * Simplified package entry points and exports for a more streamlined ES module experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->