### PR TITLE
Changing the version of express in config references

### DIFF
--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -159,7 +159,7 @@ export interface ServerConfig extends CommonConfig {
   /**
    * @desc Custom JSON parser.
    * @default express.json()
-   * @link https://expressjs.com/en/4x/api.html#express.json
+   * @link https://expressjs.com/en/5x/api.html#express.json
    * */
   jsonParser?: RequestHandler;
   /**
@@ -175,13 +175,13 @@ export interface ServerConfig extends CommonConfig {
   /**
    * @desc Custom raw parser (assigns Buffer to request body)
    * @default express.raw()
-   * @link https://expressjs.com/en/4x/api.html#express.raw
+   * @link https://expressjs.com/en/5x/api.html#express.raw
    * */
   rawParser?: RequestHandler;
   /**
    * @desc Custom parser for URL Encoded requests used for submitting HTML forms
    * @default express.urlencoded()
-   * @link https://expressjs.com/en/4x/api.html#express.urlencoded
+   * @link https://expressjs.com/en/5x/api.html#express.urlencoded
    * */
   formParser?: RequestHandler;
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for default parsers to reference the latest Express 5.x API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->