### PR TITLE
Addressing changed type of Express a native middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Version 24
 
+### v24.6.1
+
+- Compatibility fix for recently changed type of Express native middleware:
+  - Fixes error `TS2345` when passing over an Express middleware to:
+    - `EndpointsFactory::use()`;
+    - `EndpointsFactory::addExpressMiddleware()`;
+  - The issue caused by `@types/express-serve-static-core` v5.0.7;
+  - The issue reported by [@zoton2](https://github.com/zoton2).
+
 ### v24.6.0
 
 - Supporting `zod` versions `^3.25.35 || ^4.0.0`:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Therefore, many basic tasks can be accomplished faster and easier, in particular
 
 These people contributed to the improvement of the framework by reporting bugs, making changes and suggesting ideas:
 
+[<img src="https://github.com/zoton2.png" alt="@zoton2" width="50px" />](https://github.com/zoton2)
 [<img src="https://github.com/ThomasKientz.png" alt="@ThomasKientz" width="50px" />](https://github.com/ThomasKientz)
 [<img src="https://github.com/james10424.png" alt="@james10424" width="50px" />](https://github.com/james10424)
 [<img src="https://github.com/HeikoOsigus.png" alt="@HeikoOsigus" width="50px" />](https://github.com/HeikoOsigus)

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -109,11 +109,8 @@ export class ExpressMiddleware<
   OUT extends FlatObject,
 > extends Middleware<FlatObject, OUT, string> {
   constructor(
-    nativeMw: (
-      request: R,
-      response: S,
-      next: NextFunction,
-    ) => void | Promise<void>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- issue #2824, assignment compatibility fix
+    nativeMw: (request: R, response: S, next: NextFunction) => any,
     {
       provider = () => ({}) as OUT,
       transformer = (err: Error) => err,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,8 +729,8 @@ packages:
   '@types/express-fileupload@1.5.1':
     resolution: {integrity: sha512-DllImBVI1lCyjl2klky/TEwk60mbNebgXv1669h66g9TfptWSrEFq5a/raHSutaFzjSm1tmn9ypdNfu4jPSixQ==}
 
-  '@types/express-serve-static-core@5.0.6':
-    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+  '@types/express-serve-static-core@5.0.7':
+    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
 
   '@types/express@5.0.3':
     resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
@@ -2733,7 +2733,7 @@ snapshots:
       '@types/busboy': 1.5.4
       '@types/express': 5.0.3
 
-  '@types/express-serve-static-core@5.0.6':
+  '@types/express-serve-static-core@5.0.7':
     dependencies:
       '@types/node': 24.0.14
       '@types/qs': 6.14.0
@@ -2743,7 +2743,7 @@ snapshots:
   '@types/express@5.0.3':
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 5.0.6
+      '@types/express-serve-static-core': 5.0.7
       '@types/serve-static': 1.15.7
 
   '@types/http-errors@2.0.5': {}


### PR DESCRIPTION
Fixes #2824 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the constructor of the ExpressMiddleware class to allow a broader range of return types for middleware functions.
* **Chores**
  * Added a patch version entry to the changelog addressing a compatibility issue with Express middleware types.
  * Included a new contributor in the README contributors section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->