### PR TITLE
Accessing core types via `z.core`

### DIFF
--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -1,7 +1,6 @@
 import { Request } from "express";
 import * as R from "ramda";
 import { z } from "zod";
-import type { $ZodTransform, $ZodType } from "zod/v4/core";
 import { CommonConfig, InputSource, InputSources } from "./config-type";
 import { contentTypes } from "./content-type";
 import {
@@ -102,7 +101,7 @@ export const getMessageFromError = (error: Error): string => {
 };
 
 /** Faster replacement to instanceof for code operating core types (traversing schemas) */
-export const isSchema = <T extends $ZodType = $ZodType>(
+export const isSchema = <T extends z.core.$ZodType = z.core.$ZodType>(
   subject: unknown,
   type?: T["_zod"]["def"]["type"],
 ): subject is T =>
@@ -130,7 +129,7 @@ export const makeCleanId = (...args: string[]) => {
 };
 
 export const getTransformedType = R.tryCatch(
-  <T>(schema: $ZodTransform<unknown, T>, sample: T) =>
+  <T>(schema: z.core.$ZodTransform<unknown, T>, sample: T) =>
     typeof z.parse(schema, sample),
   R.always(undefined),
 );

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -1,4 +1,3 @@
-import type { $ZodType, JSONSchema } from "zod/v4/core";
 import * as R from "ramda";
 import { z } from "zod";
 import { ezBufferBrand } from "./buffer-schema";
@@ -14,11 +13,11 @@ import { ezRawBrand } from "./raw-schema";
 
 interface NestedSchemaLookupProps {
   io: "input" | "output";
-  condition: (zodSchema: $ZodType) => boolean;
+  condition: (zodSchema: z.core.$ZodType) => boolean;
 }
 
 export const findNestedSchema = (
-  subject: $ZodType,
+  subject: z.core.$ZodType,
   { io, condition }: NestedSchemaLookupProps,
 ) =>
   R.tryCatch(
@@ -37,7 +36,7 @@ export const findNestedSchema = (
 
 /** not using cycle:"throw" because it also affects parenting objects */
 export const hasCycle = (
-  subject: $ZodType,
+  subject: z.core.$ZodType,
   { io }: Pick<NestedSchemaLookupProps, "io">,
 ) => {
   const json = z.toJSONSchema(subject, { io, unrepresentable: "any" });
@@ -45,7 +44,7 @@ export const hasCycle = (
   while (stack.length) {
     const entry = stack.shift()!;
     if (R.is(Object, entry)) {
-      if ((entry as JSONSchema.BaseSchema).$ref === "#") return true;
+      if ((entry as z.core.JSONSchema.BaseSchema).$ref === "#") return true;
       stack.push(...R.values(entry));
     }
     if (R.is(Array, entry)) stack.push(...R.values(entry));
@@ -77,7 +76,7 @@ const unsupported: FirstPartyKind[] = [
 ];
 
 export const findJsonIncompatible = (
-  subject: $ZodType,
+  subject: z.core.$ZodType,
   io: "input" | "output",
 ) =>
   findNestedSchema(subject, {

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import * as R from "ramda";
 import { z, globalRegistry } from "zod";
-import type { $ZodObject } from "zod/v4/core";
 import { NormalizedResponse, ResponseVariant } from "./api-response";
 import { findRequestTypeDefiningSchema } from "./deep-checks";
 import {
@@ -87,13 +86,13 @@ export class Endpoint<
   /** considered expensive operation, only required for generators */
   #ensureOutputExamples = R.once(() => {
     if (globalRegistry.get(this.#def.outputSchema)?.examples?.length) return; // examples on output schema, or pull up:
-    if (!isSchema<$ZodObject>(this.#def.outputSchema, "object")) return;
-    const examples = pullResponseExamples(this.#def.outputSchema as $ZodObject);
+    if (!isSchema<z.core.$ZodObject>(this.#def.outputSchema, "object")) return;
+    const examples = pullResponseExamples(this.#def.outputSchema);
     if (!examples.length) return;
     const current = this.#def.outputSchema.meta();
     globalRegistry
       .remove(this.#def.outputSchema) // reassign to avoid cloning
-      .add(this.#def.outputSchema as $ZodObject, { ...current, examples });
+      .add(this.#def.outputSchema, { ...current, examples });
   });
 
   constructor(def: {

--- a/express-zod-api/src/errors.ts
+++ b/express-zod-api/src/errors.ts
@@ -1,4 +1,3 @@
-import type { $ZodType } from "zod/v4/core";
 import { z } from "zod";
 import { getMessageFromError } from "./common-helpers";
 import { OpenAPIContext } from "./documentation-helpers";
@@ -45,7 +44,7 @@ export class IOSchemaError extends Error {
 export class DeepCheckError extends IOSchemaError {
   public override name = "DeepCheckError";
 
-  constructor(public override readonly cause: $ZodType) {
+  constructor(public override readonly cause: z.core.$ZodType) {
     super("Found", { cause });
   }
 }

--- a/express-zod-api/src/form-schema.ts
+++ b/express-zod-api/src/form-schema.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
-import type { $ZodShape } from "zod/v4/core";
 
 export const ezFormBrand = Symbol("Form");
 
 /** @desc Accepts an object shape or a custom object schema */
-export const form = <S extends $ZodShape>(base: S | z.ZodObject<S>) =>
+export const form = <S extends z.core.$ZodShape>(base: S | z.ZodObject<S>) =>
   (base instanceof z.ZodObject ? base : z.object(base)).brand(
     ezFormBrand as symbol,
   );

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -1,10 +1,10 @@
-import type { JSONSchema } from "zod/v4/core";
 import * as R from "ramda";
 import { combinations, FlatObject, isObject } from "./common-helpers";
+import type { z } from "zod";
 
 const isJsonObjectSchema = (
-  subject: JSONSchema.BaseSchema,
-): subject is JSONSchema.ObjectSchema => subject.type === "object";
+  subject: z.core.JSONSchema.BaseSchema,
+): subject is z.core.JSONSchema.ObjectSchema => subject.type === "object";
 
 const propsMerger = R.mergeDeepWith((a: unknown, b: unknown) => {
   if (Array.isArray(a) && Array.isArray(b)) return R.concat(a, b);
@@ -21,19 +21,19 @@ const canMerge = R.pipe(
     "examples",
     "description",
     "additionalProperties",
-  ] satisfies Array<keyof JSONSchema.ObjectSchema>),
+  ] satisfies Array<keyof z.core.JSONSchema.ObjectSchema>),
   R.isEmpty,
 );
 
 const nestOptional = R.pair(true);
 
 export const flattenIO = (
-  jsonSchema: JSONSchema.BaseSchema,
+  jsonSchema: z.core.JSONSchema.BaseSchema,
   mode: "coerce" | "throw" = "coerce",
 ) => {
   const stack = [R.pair(false, jsonSchema)]; // [isOptional, JSON Schema]
-  const flat: JSONSchema.ObjectSchema &
-    Required<Pick<JSONSchema.ObjectSchema, "properties">> = {
+  const flat: z.core.JSONSchema.ObjectSchema &
+    Required<Pick<z.core.JSONSchema.ObjectSchema, "properties">> = {
     type: "object",
     properties: {},
   };
@@ -91,7 +91,7 @@ export const flattenIO = (
 };
 
 /** @see pullResponseExamples */
-export const pullRequestExamples = (subject: JSONSchema.ObjectSchema) =>
+export const pullRequestExamples = (subject: z.core.JSONSchema.ObjectSchema) =>
   Object.entries(subject.properties || {}).reduce<FlatObject[]>(
     (acc, [key, prop]) => {
       const { examples = [] } = isObject(prop) ? prop : {};

--- a/express-zod-api/src/metadata.ts
+++ b/express-zod-api/src/metadata.ts
@@ -1,8 +1,8 @@
-import type { $ZodType } from "zod/v4/core";
+import type { z } from "zod";
 
 export const metaSymbol = Symbol.for("express-zod-api");
 
-export const getBrand = (subject: $ZodType) => {
+export const getBrand = (subject: z.core.$ZodType) => {
   const { brand } = subject._zod.bag || {};
   if (
     typeof brand === "symbol" ||

--- a/express-zod-api/src/raw-schema.ts
+++ b/express-zod-api/src/raw-schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { $ZodShape } from "zod/v4/core";
 import { buffer } from "./buffer-schema";
 
 export const ezRawBrand = Symbol("Raw");
@@ -7,14 +6,14 @@ export const ezRawBrand = Symbol("Raw");
 const base = z.object({ raw: buffer() });
 type Base = ReturnType<typeof base.brand<symbol>>;
 
-const extended = <S extends $ZodShape>(extra: S) =>
+const extended = <S extends z.core.$ZodShape>(extra: S) =>
   base.extend(extra).brand(ezRawBrand as symbol);
 
 export function raw(): Base;
-export function raw<S extends $ZodShape>(
+export function raw<S extends z.core.$ZodShape>(
   extra: S,
 ): ReturnType<typeof extended<S>>;
-export function raw(extra?: $ZodShape) {
+export function raw(extra?: z.core.$ZodShape) {
   return extra ? extended(extra) : base.brand(ezRawBrand as symbol);
 }
 

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -2,7 +2,6 @@ import { Request } from "express";
 import createHttpError, { HttpError, isHttpError } from "http-errors";
 import * as R from "ramda";
 import { globalRegistry, z } from "zod";
-import type { $ZodObject } from "zod/v4/core";
 import { NormalizedResponse, ResponseVariant } from "./api-response";
 import {
   combinations,
@@ -89,7 +88,7 @@ export const getPublicErrorMessage = (error: HttpError): string =>
     : error.message;
 
 /** @see pullRequestExamples */
-export const pullResponseExamples = <T extends $ZodObject>(subject: T) =>
+export const pullResponseExamples = <T extends z.core.$ZodObject>(subject: T) =>
   Object.entries(subject._zod.def.shape).reduce<FlatObject[]>(
     (acc, [key, schema]) => {
       const { examples = [] } = globalRegistry.get(schema) || {};

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -1,11 +1,11 @@
-import type { $ZodType, $ZodTypeDef } from "zod/v4/core";
 import type { EmptyObject, FlatObject } from "./common-helpers";
 import { getBrand } from "./metadata";
+import type { z } from "zod";
 
-export type FirstPartyKind = $ZodTypeDef["type"];
+export type FirstPartyKind = z.core.$ZodTypeDef["type"];
 
 export interface NextHandlerInc<U> {
-  next: (schema: $ZodType) => U;
+  next: (schema: z.core.$ZodType) => U;
 }
 
 interface PrevInc<U> {
@@ -37,7 +37,7 @@ export const walkSchema = <
   U extends object,
   Context extends FlatObject = EmptyObject,
 >(
-  schema: $ZodType,
+  schema: z.core.$ZodType,
   {
     onEach,
     rules,
@@ -55,7 +55,7 @@ export const walkSchema = <
     brand && brand in rules
       ? rules[brand as keyof typeof rules]
       : rules[schema._zod.def.type];
-  const next = (subject: $ZodType) =>
+  const next = (subject: z.core.$ZodType) =>
     walkSchema(subject, { ctx, onEach, rules, onMissing });
   const result = handler
     ? handler(schema, { ...ctx, next })

--- a/express-zod-api/src/zod-plugin.ts
+++ b/express-zod-api/src/zod-plugin.ts
@@ -11,22 +11,6 @@ import * as R from "ramda";
 import { globalRegistry, z } from "zod";
 import { metaSymbol } from "./metadata";
 import { Intact, Remap } from "./mapping-helpers";
-import type {
-  $ZodType,
-  $ZodShape,
-  $ZodLooseShape,
-  $ZodObjectConfig,
-  $ZodCheck,
-  $ZodCheckInternals,
-  $ZodCheckDef,
-  SomeType,
-  $ZodDefaultInternals,
-  $ZodDefault,
-  $ZodObjectInternals,
-  $ZodObject,
-  $ZodTypeInternals,
-  $strip,
-} from "zod/v4/core";
 
 /** @todo remove when typed, https://github.com/ramda/types/pull/140 */
 declare module "ramda" {
@@ -48,49 +32,49 @@ declare module "zod" {
   interface ZodType<
     out Output = unknown,
     out Input = unknown,
-    out Internals extends $ZodTypeInternals<Output, Input> = $ZodTypeInternals<
+    out Internals extends z.core.$ZodTypeInternals<
       Output,
       Input
-    >,
-  > extends $ZodType<Output, Input, Internals> {
+    > = z.core.$ZodTypeInternals<Output, Input>,
+  > extends z.core.$ZodType<Output, Input, Internals> {
     /** @desc Alias for .meta({examples}), but argument is typed to ensure the correct placement for transformations */
     example(example: z.output<this>): this;
     deprecated(): this;
   }
-  interface ZodDefault<T extends SomeType = $ZodType>
-    extends z._ZodType<$ZodDefaultInternals<T>>,
-      $ZodDefault<T> {
+  interface ZodDefault<T extends z.core.SomeType = z.core.$ZodType>
+    extends z._ZodType<z.core.$ZodDefaultInternals<T>>,
+      z.core.$ZodDefault<T> {
     /** @desc Change the default value in the generated Documentation to a label, alias for .meta({ default }) */
     label(label: string): this;
   }
   interface ZodObject<
     // @ts-expect-error -- external issue
-    out Shape extends $ZodShape = $ZodLooseShape,
-    out Config extends $ZodObjectConfig = $strip,
-  > extends z._ZodType<$ZodObjectInternals<Shape, Config>>,
-      $ZodObject<Shape, Config> {
+    out Shape extends z.core.$ZodShape = z.core.$ZodLooseShape,
+    out Config extends z.core.$ZodObjectConfig = z.core.$strip,
+  > extends z._ZodType<z.core.$ZodObjectInternals<Shape, Config>>,
+      z.core.$ZodObject<Shape, Config> {
     remap<V extends string, U extends { [P in keyof Shape]?: V }>(
       mapping: U,
     ): z.ZodPipe<
       z.ZodPipe<this, z.ZodTransform>, // internal type simplified
       z.ZodObject<Remap<Shape, U, V> & Intact<Shape, U>, Config>
     >;
-    remap<U extends $ZodShape>(
+    remap<U extends z.core.$ZodShape>(
       mapper: (subject: Shape) => U,
     ): z.ZodPipe<z.ZodPipe<this, z.ZodTransform>, z.ZodObject<U>>; // internal type simplified
   }
 }
 
-interface $EZBrandCheckDef extends $ZodCheckDef {
+interface $EZBrandCheckDef extends z.core.$ZodCheckDef {
   check: "$EZBrandCheck";
   brand?: string | number | symbol;
 }
 
-interface $EZBrandCheckInternals extends $ZodCheckInternals<unknown> {
+interface $EZBrandCheckInternals extends z.core.$ZodCheckInternals<unknown> {
   def: $EZBrandCheckDef;
 }
 
-interface $EZBrandCheck extends $ZodCheck {
+interface $EZBrandCheck extends z.core.$ZodCheck {
   _zod: $EZBrandCheckInternals;
 }
 

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -1,6 +1,5 @@
 import { UploadedFile } from "express-fileupload";
 import { z } from "zod";
-import type { $brand, $ZodType } from "zod/v4/core";
 import { ez } from "../src";
 import { findNestedSchema, hasCycle } from "../src/deep-checks";
 import { getBrand } from "../src/metadata";
@@ -8,7 +7,7 @@ import { ezUploadBrand } from "../src/upload-schema";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {
-    const condition = (subject: $ZodType) =>
+    const condition = (subject: z.core.$ZodType) =>
       getBrand(subject) === ezUploadBrand;
 
     test("should return true for given argument satisfying condition", () => {
@@ -23,7 +22,7 @@ describe("Checks", () => {
       z.object({ test: z.boolean() }).and(z.object({ test2: ez.upload() })),
       z.optional(ez.upload()),
       ez.upload().nullable(),
-      ez.upload().default({} as UploadedFile & $brand<symbol>),
+      ez.upload().default({} as UploadedFile & z.core.$brand<symbol>),
       z.record(z.string(), ez.upload()),
       ez.upload().refine(() => true),
       z.array(ez.upload()),

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,4 +1,3 @@
-import type { JSONSchema } from "zod/v4/core";
 import { SchemaObject } from "openapi3-ts/oas31";
 import * as R from "ramda";
 import { z } from "zod";
@@ -118,7 +117,7 @@ describe("Documentation helpers", () => {
 
   describe("depictRaw()", () => {
     test("should extract the raw property", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         type: "object",
         properties: { raw: { format: "binary", type: "string" } },
       };
@@ -166,7 +165,7 @@ describe("Documentation helpers", () => {
 
   describe("depictIntersection()", () => {
     test("should flatten two object schemas", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         allOf: [
           {
             type: "object",
@@ -182,7 +181,7 @@ describe("Documentation helpers", () => {
     });
 
     test("should flatten objects with same prop of same type", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         allOf: [
           { type: "object", properties: { one: { type: "number" } } },
           { type: "object", properties: { one: { type: "number" } } },
@@ -194,7 +193,7 @@ describe("Documentation helpers", () => {
     });
 
     test("should NOT flatten object schemas having conflicting props", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         allOf: [
           { type: "object", properties: { one: { type: "number" } } },
           { type: "object", properties: { one: { type: "string" } } },
@@ -206,7 +205,7 @@ describe("Documentation helpers", () => {
     });
 
     test("should merge examples deeply", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         allOf: [
           {
             type: "object",
@@ -226,7 +225,7 @@ describe("Documentation helpers", () => {
     });
 
     test("should maintain uniqueness in the array of required props", () => {
-      const jsonSchema: JSONSchema.BaseSchema = {
+      const jsonSchema: z.core.JSONSchema.BaseSchema = {
         allOf: [
           {
             type: "object",
@@ -245,7 +244,7 @@ describe("Documentation helpers", () => {
       ).toMatchSnapshot();
     });
 
-    test.each<JSONSchema.BaseSchema>([
+    test.each<z.core.JSONSchema.BaseSchema>([
       {
         allOf: [
           {
@@ -274,7 +273,7 @@ describe("Documentation helpers", () => {
     test.each([requestCtx, responseCtx])(
       "should add null type to the first of anyOf %#",
       (ctx) => {
-        const jsonSchema: JSONSchema.BaseSchema = {
+        const jsonSchema: z.core.JSONSchema.BaseSchema = {
           anyOf: [{ type: "string" }, { type: "null" }],
         };
         expect(
@@ -299,7 +298,7 @@ describe("Documentation helpers", () => {
         depictNullable(
           {
             zodSchema: z.never(),
-            jsonSchema: jsonSchema as JSONSchema.BaseSchema,
+            jsonSchema: jsonSchema as z.core.JSONSchema.BaseSchema,
           },
           requestCtx,
         ),

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -1,4 +1,3 @@
-import type { $ZodType, JSONSchema } from "zod/v4/core";
 import { IRouter } from "express";
 import ts from "typescript";
 import { z } from "zod";
@@ -42,8 +41,8 @@ describe("Index Entrypoint", () => {
         ({
           jsonSchema,
         }: {
-          zodSchema: $ZodType;
-          jsonSchema: JSONSchema.BaseSchema;
+          zodSchema: z.core.$ZodType;
+          jsonSchema: z.core.JSONSchema.BaseSchema;
         }) => jsonSchema,
       ).toExtend<Depicter>();
       expectTypeOf(() =>

--- a/express-zod-api/tests/metadata.spec.ts
+++ b/express-zod-api/tests/metadata.spec.ts
@@ -1,5 +1,5 @@
-import type { $ZodType } from "zod/v4/core";
 import { getBrand } from "../src/metadata";
+import type { z } from "zod";
 
 describe("Metadata", () => {
   describe("getBrand", () => {
@@ -7,7 +7,7 @@ describe("Metadata", () => {
       "should take it from bag",
       (bag) => {
         const mock = { _zod: { bag } };
-        expect(getBrand(mock as unknown as $ZodType)).toBe(bag?.brand);
+        expect(getBrand(mock as unknown as z.core.$ZodType)).toBe(bag?.brand);
       },
     );
   });


### PR DESCRIPTION
Previously, I separated core types imports because they were intended to be published in a separate package `@zod/core`.
However, since stable v4 rolled out, that idea was abandoned, so that it's now safe to refer to it using the `z.core` without additional imports.
This was suggested by @coderabbitai 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type references to use the public `z.core` namespace instead of direct imports from internal Zod paths. This affects type annotations and function signatures throughout the codebase, including helpers, schemas, documentation utilities, and tests.

* **Tests**
  * Adjusted test files to use the new `z.core` type references, ensuring consistency with the updated type import approach. 

No changes to application logic or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->