### PR TITLE
docs: add Scalar example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,36 @@ const exampleEndpoint = defaultEndpointsFactory.build({
 _See the example of the generated documentation
 [here](https://github.com/RobinTail/express-zod-api/blob/master/example/example.documentation.yaml)_
 
+## Serving documentation with Scalar
+
+Once you have generated your OpenAPI documentation, you can serve it with a beautiful UI using [Scalar](https://github.com/scalar/scalar). Scalar provides a modern, customizable interface for your API documentation. Install it like this:
+
+```bash
+npm install @scalar/express-api-reference
+```
+
+And then pass the URL to your OpenAPI document to the `apiReference` middleware:
+
+```typescript
+import { createConfig } from "express-zod-api";
+import { apiReference } from "@scalar/express-api-reference";
+
+const config = createConfig({
+  beforeRouting: ({ app, getLogger }) => {
+    const logger = getLogger();
+    logger.info("Serving the API reference at https://example.com/docs");
+
+    app.use(
+      "/docs",
+      apiReference({
+        // Pass your generated OpenAPI document
+        content: documentation.getSpecAsJson(),
+      }),
+    );
+  },
+});
+```
+
 ## Tagging the endpoints
 
 When generating documentation, you may find it necessary to classify endpoints into groups. The possibility of tagging


### PR DESCRIPTION
Hey @RobinTail! Just discovered your awesome project and thought it would be cool to add an example how you can easily generate a [Scalar API Reference](https://github.com/scalar/scalar) for the generated OpenAPI document.

I wondered if I could add it where the Swagger UI example is, but the section is actually about the middleware, so I thought a new section could be better.

What do you think? Helpful? Excited to hear your thoughts!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining how to serve OpenAPI documentation using Scalar, including installation steps and integration instructions for Express apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->