### PR TITLE
Fix negative response MIME type for `arrayResultHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 24
 
+### v24.7.2
+
+- Fixed the negative response MIME type for ~~`arrayResultHandler`~~ (deprecated entity):
+  - Should have been `text/plain`.
+
 ### v24.7.1
 
 - Compatibility fix for `zod@^3.25.68` and `^4.0.0`:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -441,7 +441,7 @@ paths:
         "400":
           description: GET /v1/user/list Negative response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
               examples:
@@ -457,7 +457,7 @@ paths:
         "400":
           description: HEAD /v1/user/list Negative response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
               examples:

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -169,7 +169,10 @@ export const arrayResultHandler = new ResultHandler({
     }
     return responseSchema;
   },
-  negative: z.string().example("Sample error message"),
+  negative: {
+    schema: z.string().example("Sample error message"),
+    mimeType: "text/plain",
+  },
   handler: ({ response, output, error, logger, request, input }) => {
     if (error) {
       const httpError = ensureHttpError(error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the negative response MIME type for deprecated error handling to use "text/plain" instead of "application/json" in both documentation and response handling.

* **Documentation**
  * Updated the changelog to reflect the fix for the negative response MIME type.
  * Adjusted API documentation to specify "text/plain" as the content type for certain error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->