### PR TITLE
Fix test concurrency limit

### DIFF
--- a/cjs-test/quick-start.spec.ts
+++ b/cjs-test/quick-start.spec.ts
@@ -9,7 +9,7 @@ describe("CJS Test", async () => {
   const quickStart = spawn("tsx", ["quick-start.ts"]);
   quickStart.stdout.on("data", listener);
   quickStart.stderr.on("data", listener);
-  const port = givePort("example");
+  const port = givePort("cjs");
   await vi.waitFor(() => assert(out.includes(`Listening`)), { timeout: 1e4 });
 
   afterAll(async () => {

--- a/compat-test/quick-start.spec.ts
+++ b/compat-test/quick-start.spec.ts
@@ -8,6 +8,7 @@ import {
   expect,
   test,
 } from "vitest";
+import { givePort } from "../tools/ports";
 
 describe("ESM Test", async () => {
   let out = "";
@@ -18,6 +19,7 @@ describe("ESM Test", async () => {
   quickStart.stdout.on("data", listener);
   quickStart.stderr.on("data", listener);
   await vi.waitFor(() => assert(out.includes(`Listening`)), { timeout: 1e4 });
+  const port = givePort("compat");
 
   afterAll(async () => {
     quickStart.stdout.removeListener("data", listener);
@@ -33,7 +35,9 @@ describe("ESM Test", async () => {
 
   describe("Quick Start from Readme", () => {
     test("Should handle valid GET request", async () => {
-      const response = await fetch(`http://localhost:8090/v1/hello?name=Rick`);
+      const response = await fetch(
+        `http://localhost:${port}/v1/hello?name=Rick`,
+      );
       expect(response.status).toBe(200);
       const json = await response.json();
       expect(json).toEqual({

--- a/esm-test/quick-start.spec.ts
+++ b/esm-test/quick-start.spec.ts
@@ -9,7 +9,7 @@ describe("ESM Test", async () => {
   const quickStart = spawn("tsx", ["quick-start.ts"]);
   quickStart.stdout.on("data", listener);
   quickStart.stderr.on("data", listener);
-  const port = givePort("example");
+  const port = givePort("esm");
   await vi.waitFor(() => assert(out.includes(`Listening`)), { timeout: 1e4 });
 
   afterAll(async () => {

--- a/example/config.ts
+++ b/example/config.ts
@@ -1,9 +1,10 @@
 import { BuiltinLogger, createConfig } from "express-zod-api";
 import ui from "swagger-ui-express";
 import createHttpError from "http-errors";
+import { givePort } from "../tools/ports";
 
 export const config = createConfig({
-  http: { listen: 8090 },
+  http: { listen: givePort("example") },
   upload: {
     limits: { fileSize: 51200 },
     limitError: createHttpError(413, "The file is too large"), // affects uploadAvatarEndpoint

--- a/express-zod-api/tests/__snapshots__/builtin-logger.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/builtin-logger.spec.ts.snap
@@ -126,7 +126,7 @@ exports[`BuiltinLogger > constructor() > Should handle empty object meta 1 1`] =
 exports[`BuiltinLogger > constructor() > Should handle non-object meta 0 1`] = `
 [
   [
-    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
+    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m1234[39m",
   ],
 ]
 `;
@@ -134,7 +134,7 @@ exports[`BuiltinLogger > constructor() > Should handle non-object meta 0 1`] = `
 exports[`BuiltinLogger > constructor() > Should handle non-object meta 1 1`] = `
 [
   [
-    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m8090[39m",
+    "2022-01-01T00:00:00.000Z [31merror[39m: Code [33m1234[39m",
   ],
 ]
 `;

--- a/express-zod-api/tests/builtin-logger.spec.ts
+++ b/express-zod-api/tests/builtin-logger.spec.ts
@@ -65,7 +65,7 @@ describe("BuiltinLogger", () => {
       "Should handle non-object meta %#",
       (level) => {
         const { logger, logSpy } = makeLogger({ level, color: true });
-        logger.error("Code", 8090);
+        logger.error("Code", 1234);
         expect(logSpy.mock.calls).toMatchSnapshot();
       },
     );

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -66,7 +66,7 @@ describe("Index Entrypoint", () => {
         logger: { level: "silent" };
       }>().toExtend<AppConfig>();
       expectTypeOf<{
-        http: { listen: 8090 };
+        http: { listen: 1234 };
         logger: { level: "silent" };
         cors: false;
       }>().toExtend<ServerConfig>();

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -176,7 +176,7 @@ describe("Server helpers", () => {
     const beforeUploadMock = vi.fn();
     const parsers = await createUploadParsers({
       config: {
-        http: { listen: 8090 },
+        http: { listen: 1234 },
         upload: {
           limits: { fileSize: 1024 },
           limitError: new Error("Too heavy"),

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ onlyBuiltDependencies:
 gitChecks: false
 engineStrict: true
 autoInstallPeers: false
-workspaceConcurrency: 1 # todo: find a way to have different ports in CJS, ESM, compat tests and remove it
 publicHoistPattern:
   - "@typescript-eslint/*" # used as an assumed transitive in migration
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts

--- a/tools/make-tests.ts
+++ b/tools/make-tests.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile, writeFile } from "node:fs/promises";
+import { givePort } from "./ports";
 
 const extractQuickStartFromReadme = async () => {
   const readme = await readFile("README.md", "utf-8");
@@ -14,11 +15,17 @@ const extractQuickStartFromReadme = async () => {
 };
 
 const quickStart = await extractQuickStartFromReadme();
+const program = `
+import { givePort } from "../tools/ports";
+${quickStart}
+`;
+
+const examplePort = String(givePort("example"));
 
 const testContent = {
-  cjs: quickStart,
-  esm: quickStart,
-  compat: quickStart,
+  cjs: program.replace(examplePort, "givePort('cjs')"),
+  esm: program.replace(examplePort, "givePort('esm')"),
+  compat: program.replace(examplePort, "givePort('compat')"),
   issue952: quickStart.replace(/const/g, "export const"),
 };
 

--- a/tools/ports.ts
+++ b/tools/ports.ts
@@ -3,9 +3,16 @@ const disposer = (function* () {
   while (true) yield port++;
 })();
 
-export const givePort = (test?: "example", reserved = 8090): number => {
-  if (test) return reserved;
+const reserved = {
+  example: 8090,
+  cjs: 8091,
+  esm: 8092,
+  compat: 8093,
+};
+
+export const givePort = (test?: keyof typeof reserved): number => {
+  if (test) return reserved[test];
   const { value } = disposer.next();
-  if (value === reserved) return givePort();
+  if (Object.values(reserved).includes(value)) return givePort();
   return value;
 };


### PR DESCRIPTION
Due to #2873 

Distributing test workspaces to different ports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test suites to use dynamic port assignment with distinct keys for each test variant, improving test reliability.
  * Centralized port management to prevent conflicts between CJS, ESM, and compatibility tests.
  * Removed workspace concurrency restriction from configuration to allow parallel test execution.
  * Adjusted default server port configurations in tests and examples for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->