### PR TITLE
Fix the type of `examples` prop for `dateIn` and `dateOut` params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### v25.3.1
 
-- Small optimization for running diagnostics (non-production mode).
+- Small optimization for running diagnostics (non-production mode);
+- Fixed the type of the `examples` property for `ez.dateIn()` and `ez.dateOut()` arguments.
 
 ### v25.3.0
 

--- a/express-zod-api/src/date-in-schema.ts
+++ b/express-zod-api/src/date-in-schema.ts
@@ -4,7 +4,7 @@ export const ezDateInBrand = Symbol("DateIn");
 
 export interface DateInParams
   extends Omit<Parameters<z.ZodString["meta"]>[0], "examples"> {
-  examples?: Array<NonNullable<Parameters<z.ZodString["example"]>[0]>>;
+  examples?: string[];
 }
 
 export const dateIn = ({ examples, ...rest }: DateInParams = {}) => {

--- a/express-zod-api/src/date-in-schema.ts
+++ b/express-zod-api/src/date-in-schema.ts
@@ -2,10 +2,12 @@ import { z } from "zod";
 
 export const ezDateInBrand = Symbol("DateIn");
 
-export const dateIn = ({
-  examples,
-  ...rest
-}: Parameters<z.ZodString["meta"]>[0] = {}) => {
+export interface DateInParams
+  extends Omit<Parameters<z.ZodString["meta"]>[0], "examples"> {
+  examples?: Array<NonNullable<Parameters<z.ZodString["example"]>[0]>>;
+}
+
+export const dateIn = ({ examples, ...rest }: DateInParams = {}) => {
   const schema = z.union([
     z.iso.date(),
     z.iso.datetime(),

--- a/express-zod-api/src/date-out-schema.ts
+++ b/express-zod-api/src/date-out-schema.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 
 export const ezDateOutBrand = Symbol("DateOut");
 
-export const dateOut = (meta: Parameters<z.ZodString["meta"]>[0] = {}) =>
+export interface DateOutParams
+  extends Omit<Parameters<z.ZodString["meta"]>[0], "examples"> {
+  examples?: Array<NonNullable<Parameters<z.ZodString["example"]>[0]>>;
+}
+
+export const dateOut = (meta: DateOutParams = {}) =>
   z
     .date()
     .transform((date) => date.toISOString())

--- a/express-zod-api/src/date-out-schema.ts
+++ b/express-zod-api/src/date-out-schema.ts
@@ -4,7 +4,7 @@ export const ezDateOutBrand = Symbol("DateOut");
 
 export interface DateOutParams
   extends Omit<Parameters<z.ZodString["meta"]>[0], "examples"> {
-  examples?: Array<NonNullable<Parameters<z.ZodString["example"]>[0]>>;
+  examples?: string[];
 }
 
 export const dateOut = (meta: DateOutParams = {}) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected typing of the examples parameter for dateIn/dateOut, improving TypeScript accuracy and IDE hints.

- Refactor
  - Introduced dedicated parameter types for dateIn/dateOut to clarify API typings without changing runtime behavior.

- Documentation
  - Updated changelog punctuation.
  - Documented the corrected examples types for dateIn/dateOut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->