### PR TITLE
Add `minimumReleaseAge` to `pnpm` config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,9 @@ onlyBuiltDependencies:
 gitChecks: false
 engineStrict: true
 autoInstallPeers: false
-minimumReleaseAge: 2880
+minimumReleaseAge: 2880 # 2 days
 minimumReleaseAgeExclude:
+  - "@types/node"
   - eslint
   - express
   - http-errors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update policy to require a 2-day minimum before adopting new releases, with an exclusions list for select tooling libraries (e.g., types, linters, test/run tooling). No functional or UI changes for end users; this improves build stability and reduces risk from immediate upstream updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->