### PR TITLE
v24: Replacing usage of `example()` method in framework sources

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,13 @@ const importConcerns = [
   })),
 ];
 
+const compatibilityConerns = [
+  {
+    selector: "CallExpression > MemberExpression[property.name='example']",
+    message: "avoid using example() method to operate without zod plugin",
+  },
+];
+
 const performanceConcerns = [
   {
     selector: "ImportDeclaration[source.value=/assert/]", // #2169
@@ -210,6 +217,7 @@ export default tsPlugin.config(
         "warn",
         ...importConcerns,
         ...performanceConcerns,
+        ...compatibilityConerns,
       ],
     },
   },

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -112,15 +112,17 @@ export const defaultResultHandler = new ResultHandler({
     }
     return responseSchema;
   },
-  negative: z
-    .object({
+  negative: () => {
+    const schema = z.object({
       status: z.literal("error"),
       error: z.object({ message: z.string() }),
-    })
-    .example({
-      status: "error",
-      error: { message: "Sample error message" },
-    }),
+    });
+    const examples: z.output<typeof schema>[] = [
+      { status: "error", error: { message: "Sample error message" } },
+    ];
+    globalRegistry.add(schema, { examples });
+    return schema;
+  },
   handler: ({ error, input, output, request, response, logger }) => {
     if (error) {
       const httpError = ensureHttpError(error);
@@ -169,9 +171,11 @@ export const arrayResultHandler = new ResultHandler({
     }
     return responseSchema;
   },
-  negative: {
-    schema: z.string().example("Sample error message"),
-    mimeType: "text/plain",
+  negative: () => {
+    const schema = z.string();
+    const examples: z.output<typeof schema>[] = ["Sample error message"];
+    globalRegistry.add(schema, { examples });
+    return { schema, mimeType: "text/plain" };
   },
   handler: ({ response, output, error, logger, request, input }) => {
     if (error) {


### PR DESCRIPTION
A user reported that they're having troubles with module augmentation in their environment, but they aren't even using the `example()` method. It's found to be used in the framework itself and this PR should fix it, so that the framework would be usable for them even without the plugin features.