### PR TITLE
SSE abort signal

### DIFF
--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -53,30 +53,30 @@ export const ensureStream = (response: Response) =>
     "cache-control": "no-cache",
   });
 
-  export const makeMiddleware = <E extends EventsMap>(events: E) =>
-    new Middleware({
-      handler: async ({ request, response }): Promise<Emitter<E>> => {
-        const controller = new AbortController();
-  
-        request.on("close", () => {
-          controller.abort();
-        });
-  
-       return setTimeout(() => ensureStream(response), headersTimeout) && {
-          isClosed: () => response.writableEnded || response.closed,
-          signal: controller.signal,
-          emit: (event, data) => {
-            ensureStream(response);
-            response.write(formatEvent(events, event, data), "utf-8");
-            /**
-             * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
-             * @link https://github.com/RobinTail/express-zod-api/issues/2347
-             * */
-            response.flush?.();
-          },
-        }
+export const makeMiddleware = <E extends EventsMap>(events: E) =>
+  new Middleware({
+    handler: async ({ request, response }): Promise<Emitter<E>> => {
+      const controller = new AbortController();
+
+      request.on("close", () => {
+        controller.abort();
+      });
+
+     return setTimeout(() => ensureStream(response), headersTimeout) && {
+        isClosed: () => response.writableEnded || response.closed,
+        signal: controller.signal,
+        emit: (event, data) => {
+          ensureStream(response);
+          response.write(formatEvent(events, event, data), "utf-8");
+          /**
+           * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
+           * @link https://github.com/RobinTail/express-zod-api/issues/2347
+           * */
+          response.flush?.();
+        },
       }
-    });
+    }
+  });
 
 export const makeResultHandler = <E extends EventsMap>(events: E) =>
   new ResultHandler({

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -16,6 +16,8 @@ type EventsMap = Record<string, z.ZodType>;
 export interface Emitter<E extends EventsMap> extends FlatObject {
   /** @desc Returns true when the connection was closed or terminated */
   isClosed: () => boolean;
+  /** @desc Abort signal bound to the client connection lifecycle */
+  signal: AbortSignal;
   /** @desc Sends an event to the stream according to the declared schema */
   emit: <K extends keyof E>(event: K, data: z.input<E[K]>) => void;
 }

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -64,7 +64,9 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
         controller.abort();
       });
 
-     return setTimeout(() => ensureStream(response), headersTimeout) && {
+     setTimeout(() => ensureStream(response), headersTimeout)
+
+     return {
         isClosed: () => response.writableEnded || response.closed,
         signal: controller.signal,
         emit: (event, data) => {

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -61,10 +61,7 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
       const controller = new AbortController();
 
       request.once("close", () => {
-        controller.abort();
-      });
-
-      response.once("close", () => {
+        console.log("here");
         controller.abort();
       });
 

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -64,9 +64,9 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
         controller.abort();
       });
 
-     setTimeout(() => ensureStream(response), headersTimeout)
+      setTimeout(() => ensureStream(response), headersTimeout);
 
-     return {
+      return {
         isClosed: () => response.writableEnded || response.closed,
         signal: controller.signal,
         emit: (event, data) => {
@@ -78,8 +78,8 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
            * */
           response.flush?.();
         },
-      }
-    }
+      };
+    },
   });
 
 export const makeResultHandler = <E extends EventsMap>(events: E) =>

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -61,7 +61,6 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
       const controller = new AbortController();
 
       request.once("close", () => {
-        console.log("here");
         controller.abort();
       });
 

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -64,6 +64,10 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
         controller.abort();
       });
 
+      response.once("close", () => {
+        controller.abort();
+      });
+
       setTimeout(() => ensureStream(response), headersTimeout);
 
       return {

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -53,22 +53,30 @@ export const ensureStream = (response: Response) =>
     "cache-control": "no-cache",
   });
 
-export const makeMiddleware = <E extends EventsMap>(events: E) =>
-  new Middleware({
-    handler: async ({ response }): Promise<Emitter<E>> =>
-      setTimeout(() => ensureStream(response), headersTimeout) && {
-        isClosed: () => response.writableEnded || response.closed,
-        emit: (event, data) => {
-          ensureStream(response);
-          response.write(formatEvent(events, event, data), "utf-8");
-          /**
-           * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
-           * @link https://github.com/RobinTail/express-zod-api/issues/2347
-           * */
-          response.flush?.();
-        },
-      },
-  });
+  export const makeMiddleware = <E extends EventsMap>(events: E) =>
+    new Middleware({
+      handler: async ({ request, response }): Promise<Emitter<E>> => {
+        const controller = new AbortController();
+  
+        request.on("close", () => {
+          controller.abort();
+        });
+  
+       return setTimeout(() => ensureStream(response), headersTimeout) && {
+          isClosed: () => response.writableEnded || response.closed,
+          signal: controller.signal,
+          emit: (event, data) => {
+            ensureStream(response);
+            response.write(formatEvent(events, event, data), "utf-8");
+            /**
+             * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
+             * @link https://github.com/RobinTail/express-zod-api/issues/2347
+             * */
+            response.flush?.();
+          },
+        }
+      }
+    });
 
 export const makeResultHandler = <E extends EventsMap>(events: E) =>
   new ResultHandler({

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -60,7 +60,7 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
     handler: async ({ request, response }): Promise<Emitter<E>> => {
       const controller = new AbortController();
 
-      request.on("close", () => {
+      request.once("close", () => {
         controller.abort();
       });
 

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -90,7 +90,9 @@ describe("SSE", () => {
           signal: expect.any(AbortSignal),
           emit: expect.any(Function),
         });
-        const { isClosed, emit, signal } = output as Emitter<{ test: z.ZodString }>;
+        const { isClosed, emit, signal } = output as Emitter<{
+          test: z.ZodString;
+        }>;
         expect(isClosed()).toBeFalsy();
         expect(signal.aborted).toBeFalsy();
         emit("test", "something");
@@ -109,9 +111,9 @@ describe("SSE", () => {
       const { requestMock, output } = await testMiddleware({ middleware });
       const { signal } = output as Emitter<{ test: z.ZodString }>;
       expect(signal.aborted).toBeFalsy();
-      requestMock.emit("close")
+      requestMock.emit("close");
       expect(signal.aborted).toBeTruthy();
-    })
+    });
   });
 
   describe("makeResultHandler()", () => {

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -90,11 +90,10 @@ describe("SSE", () => {
           signal: expect.any(AbortSignal),
           emit: expect.any(Function),
         });
-        const { isClosed, emit, signal } = output as Emitter<{
+        const { isClosed, emit } = output as Emitter<{
           test: z.ZodString;
         }>;
         expect(isClosed()).toBeFalsy();
-        expect(signal.aborted).toBeFalsy();
         emit("test", "something");
         expect(responseMock._getData()).toBe(
           `event: test\ndata: "something"\n\n`,
@@ -102,7 +101,6 @@ describe("SSE", () => {
         if (flushMock) expect(flushMock).toHaveBeenCalled();
         responseMock.end();
         expect(isClosed()).toBeTruthy();
-        expect(signal.aborted).toBeTruthy();
       },
     );
 

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -90,9 +90,7 @@ describe("SSE", () => {
           signal: expect.any(AbortSignal),
           emit: expect.any(Function),
         });
-        const { isClosed, emit } = output as Emitter<{
-          test: z.ZodString;
-        }>;
+        const { isClosed, emit } = output as Emitter<{ test: z.ZodString }>;
         expect(isClosed()).toBeFalsy();
         emit("test", "something");
         expect(responseMock._getData()).toBe(


### PR DESCRIPTION
I think this could be it but I haven't tested the change yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE emitters now include a cancellation signal tied to the client connection, and middleware handlers receive the full request context so they can observe that signal.

* **Bug Fixes**
  * Streams now reliably abort on client disconnects, preventing orphaned work and improving stability and test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->