### PR TITLE
feat: `AbortSignal` for SSE 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 25
 
+### v25.5.0
+
+- Feature: `AbortSignal` for subscription handlers:
+  - The `handler` of `EventStreamFactory::build()` is now equipped with `signal` option;
+  - That signal is aborted when the client disconnects;
+  - The feature was suggested and implemented by [@jakub-msqt](https://github.com/jakub-msqt).
+
 ### v25.4.1
 
 - This patch fixes the issue for users facing `TypeError: .example is not a function`, but not using that method:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Therefore, many basic tasks can be accomplished faster and easier, in particular
 
 These people contributed to the improvement of the framework by reporting bugs, making changes and suggesting ideas:
 
+[<img src="https://github.com/jakub-msqt.png" alt="@jakub-msqt" width="50px" />](https://github.com/jakub-msqt)
 [<img src="https://github.com/misha-z1nchuk.png" alt="@misha-z1nchuk" width="50px" />](https://github.com/misha-z1nchuk)
 [<img src="https://github.com/GreaterTamarack.png" alt="@GreaterTamarack" width="50px" />](https://github.com/GreaterTamarack)
 [<img src="https://github.com/pepegc.png" alt="@pepegc" width="50px" />](https://github.com/pepegc)

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-zod-api",
-  "version": "25.4.1",
+  "version": "25.5.0-beta.1",
   "description": "A Typescript framework to help you get an API server up and running with I/O schema validation and custom middlewares in minutes.",
   "license": "MIT",
   "repository": {

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -87,6 +87,7 @@ describe("SSE", () => {
         if (flushMock) responseMock.flush = flushMock;
         expect(output).toEqual({
           isClosed: expect.any(Function),
+          signal: expect.any(AbortSignal),
           emit: expect.any(Function),
         });
         const { isClosed, emit } = output as Emitter<{ test: z.ZodString }>;
@@ -100,6 +101,15 @@ describe("SSE", () => {
         expect(isClosed()).toBeTruthy();
       },
     );
+
+    test("should abort signal on connection close", async () => {
+      const middleware = makeMiddleware({ test: z.string() });
+      const { requestMock, output } = await testMiddleware({ middleware });
+      const { signal } = output as Emitter<{ test: z.ZodString }>;
+      expect(signal.aborted).toBeFalsy();
+      requestMock.emit("close");
+      expect(signal.aborted).toBeTruthy();
+    });
   });
 
   describe("makeResultHandler()", () => {


### PR DESCRIPTION
Copied from #2965 

Related discussion https://github.com/RobinTail/express-zod-api/discussions/991#discussioncomment-14507557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added AbortSignal support to event stream subscriptions; emitters now expose a signal that aborts when the client disconnects to enable proper cancellation and cleanup.

- Documentation
  - Updated changelog for version 25.5.0 to note AbortSignal support.
  - Added contributor acknowledgements to the README.

- Tests
  - Added tests ensuring the signal is present on emitters and aborts on connection close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->