### PR TITLE
Add `z.function()` to the list of JSON incompatible schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 25
 
+### v25.5.2
+
+- Added `z.function()` to the list of JSON-incompatible schemas:
+  - It will warn when using such schema in a JSON operating Endpoint;
+  - `z.function()` [became a schema again](https://github.com/colinhacks/zod/issues/4143) in Zod 4.1.0.
+
 ### v25.5.1
 
 - Aligned the requirements on Node.js versions between for `@express-zod-api/zod-plugin`;

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -73,6 +73,7 @@ const unsupported: FirstPartyKind[] = [
   "void",
   "promise",
   "never",
+  "function",
 ];
 
 export const findJsonIncompatible = (

--- a/express-zod-api/tests/routing.spec.ts
+++ b/express-zod-api/tests/routing.spec.ts
@@ -511,7 +511,7 @@ describe("Routing", () => {
       });
     });
 
-    const circular: z.ZodType = z.lazy(() => z.tuple([circular, z.nan()]));
+    const circular: z.ZodType = z.lazy(() => z.tuple([circular, z.function()]));
     test.each([
       [z.bigint(), z.set(z.string())],
       [z.nan(), z.map(z.string(), z.boolean())],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON compatibility checks now flag functions as unsupported, improving detection in deep and circular schemas.

* **Tests**
  * Updated tests to cover function handling in circular type scenarios.

* **Documentation**
  * Changelog updated (v25.5.2) noting that functions are now treated as JSON-incompatible and will warn when used in JSON-focused endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->