### PR TITLE
Enabling `noUncheckedSideEffectImports` globally

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "noImplicitOverride": true,
+    "noUncheckedSideEffectImports": true,
     "strictNullChecks": true,
     "types": ["vitest/globals"]
   }


### PR DESCRIPTION
This is one of the recommended settings of latest Typescript. It checks if side effect imports do exist and correct.
Since the framework does have side effects via `zod-plugin`, this setting makes sense to activate.

https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Maintenance-only update: internal TypeScript compiler configuration adjusted for development/build processes. No changes to functionality, interface, performance, or compatibility. No impact on data, settings, or user workflows. App behavior remains the same across all platforms. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->