### PR TITLE
chores: tsconfig `module: node20` and import extensions

### DIFF
--- a/compat-test/quick-start.spec.ts
+++ b/compat-test/quick-start.spec.ts
@@ -8,7 +8,7 @@ import {
   expect,
   test,
 } from "vitest";
-import { givePort } from "../tools/ports";
+import { givePort } from "../tools/ports.ts";
 
 describe("ESM Test", async () => {
   let out = "";

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,6 +68,10 @@ const performanceConcerns = [
     selector: "MemberExpression[object.name='R'] > Identifier[name='union']", // #2599
     message: "R.union() is 1.5x slower than [...Set().add()]",
   },
+  {
+    selector: "ImportDeclaration[source.value=/package.json$/]", // #2974
+    message: "it can not be tree shaken, use tsdown and process.env instead",
+  },
 ];
 
 const tsFactoryConcerns = [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,10 @@ const importConcerns = [
     selector: "ImportDeclaration[source.value=/^zod/] > ImportDefaultSpecifier",
     message: "do import { z } instead",
   },
+  {
+    selector: "ImportDeclaration[source.value=/^\\..+\\.js$/]",
+    message: "use .ts extension for relative imports",
+  },
   ...builtinModules.map((mod) => ({
     selector: `ImportDeclaration[source.value='${mod}']`,
     message: `use node:${mod} for the built-in module`,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ const importConcerns = [
     message: "do import { z } instead",
   },
   {
-    selector: "ImportDeclaration[source.value=/^\\..+\\.js$/]",
+    selector: "ImportDeclaration[source.value=/\\.js$/]",
     message: "use .ts extension for relative imports",
   },
   ...builtinModules.map((mod) => ({

--- a/esm-test/quick-start.spec.ts
+++ b/esm-test/quick-start.spec.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { givePort } from "../tools/ports";
+import { givePort } from "../tools/ports.ts";
 
 describe("ESM Test", async () => {
   let out = "";

--- a/esm-test/tsconfig.json
+++ b/esm-test/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../tsconfig.json"
-}

--- a/esm-test/tsconfig.json
+++ b/esm-test/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler"
-  }
+  "extends": "../tsconfig.json"
 }

--- a/example/config.ts
+++ b/example/config.ts
@@ -1,7 +1,7 @@
 import { BuiltinLogger, createConfig } from "express-zod-api";
 import ui from "swagger-ui-express";
 import createHttpError from "http-errors";
-import { givePort } from "../tools/ports";
+import { givePort } from "../tools/ports.ts";
 import qs from "qs";
 
 export const config = createConfig({

--- a/example/endpoints/create-user.ts
+++ b/example/endpoints/create-user.ts
@@ -1,7 +1,7 @@
 import createHttpError from "http-errors";
 import assert from "node:assert/strict";
 import { z } from "zod";
-import { statusDependingFactory } from "../factories";
+import { statusDependingFactory } from "../factories.ts";
 
 const namePart = z.string().regex(/^\w+$/);
 

--- a/example/endpoints/delete-user.ts
+++ b/example/endpoints/delete-user.ts
@@ -1,7 +1,7 @@
 import createHttpError from "http-errors";
 import assert from "node:assert/strict";
 import { z } from "zod";
-import { noContentFactory } from "../factories";
+import { noContentFactory } from "../factories.ts";
 
 /** @desc The endpoint demonstrates no content response established by its factory */
 export const deleteUserEndpoint = noContentFactory.buildVoid({

--- a/example/endpoints/list-users.ts
+++ b/example/endpoints/list-users.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { arrayRespondingFactory } from "../factories";
+import { arrayRespondingFactory } from "../factories.ts";
 
 const roleSchema = z.enum(["manager", "operator", "admin"]);
 

--- a/example/endpoints/retrieve-user.ts
+++ b/example/endpoints/retrieve-user.ts
@@ -2,7 +2,7 @@ import createHttpError from "http-errors";
 import assert from "node:assert/strict";
 import { z } from "zod";
 import { defaultEndpointsFactory } from "express-zod-api";
-import { methodProviderMiddleware } from "../middlewares";
+import { methodProviderMiddleware } from "../middlewares.ts";
 
 // Demonstrating circular schemas using z.object()
 const feature = z.object({

--- a/example/endpoints/send-avatar.ts
+++ b/example/endpoints/send-avatar.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { fileSendingEndpointsFactory } from "../factories";
+import { fileSendingEndpointsFactory } from "../factories.ts";
 import { readFile } from "node:fs/promises";
 
 export const sendAvatarEndpoint = fileSendingEndpointsFactory.build({

--- a/example/endpoints/stream-avatar.ts
+++ b/example/endpoints/stream-avatar.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { fileStreamingEndpointsFactory } from "../factories";
+import { fileStreamingEndpointsFactory } from "../factories.ts";
 
 export const streamAvatarEndpoint = fileStreamingEndpointsFactory.build({
   shortDescription: "Streams a file content.",

--- a/example/endpoints/time-subscription.ts
+++ b/example/endpoints/time-subscription.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { setTimeout } from "node:timers/promises";
-import { eventsFactory } from "../factories";
+import { eventsFactory } from "../factories.ts";
 
 /** @desc The endpoint demonstrates emitting server-sent events (SSE) */
 export const subscriptionEndpoint = eventsFactory.buildVoid({

--- a/example/endpoints/update-user.ts
+++ b/example/endpoints/update-user.ts
@@ -2,7 +2,7 @@ import createHttpError from "http-errors";
 import assert from "node:assert/strict";
 import { z } from "zod";
 import { ez } from "express-zod-api";
-import { keyAndTokenAuthenticatedEndpointsFactory } from "../factories";
+import { keyAndTokenAuthenticatedEndpointsFactory } from "../factories.ts";
 
 export const updateUserEndpoint =
   keyAndTokenAuthenticatedEndpointsFactory.build({

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -7,7 +7,7 @@ import {
   EventStreamFactory,
   defaultEndpointsFactory,
 } from "express-zod-api";
-import { authMiddleware } from "./middlewares";
+import { authMiddleware } from "./middlewares.ts";
 import { createReadStream } from "node:fs";
 import { z } from "zod";
 import { stat } from "node:fs/promises";

--- a/example/generate-client.ts
+++ b/example/generate-client.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { Integration } from "express-zod-api";
-import { routing } from "./routing";
-import { config } from "./config";
+import { routing } from "./routing.ts";
+import { config } from "./config.ts";
 
 await writeFile(
   "example.client.ts",

--- a/example/generate-documentation.ts
+++ b/example/generate-documentation.ts
@@ -1,8 +1,8 @@
 import { writeFile } from "node:fs/promises";
 import { Documentation } from "express-zod-api";
-import { config } from "./config";
-import { routing } from "./routing";
-import manifest from "./package.json";
+import { config } from "./config.ts";
+import { routing } from "./routing.ts";
+import manifest from "./package.json" with { type: "json" };
 
 await writeFile(
   "example.documentation.yaml",

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createReadStream, readFileSync } from "node:fs";
-import { Client, Subscription } from "./example.client";
-import { givePort } from "../tools/ports";
+import { Client, Subscription } from "./example.client.ts";
+import { givePort } from "../tools/ports.ts";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fail } from "node:assert";

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,6 +1,6 @@
 import { createServer } from "express-zod-api";
-import { config } from "./config";
-import { routing } from "./routing";
+import { config } from "./config.ts";
+import { routing } from "./routing.ts";
 
 /**
  * "await" is only needed for using entities returned from this method.

--- a/example/routing.ts
+++ b/example/routing.ts
@@ -1,15 +1,15 @@
 import { DependsOnMethod, Routing, ServeStatic } from "express-zod-api";
-import { rawAcceptingEndpoint } from "./endpoints/accept-raw";
-import { createUserEndpoint } from "./endpoints/create-user";
-import { deleteUserEndpoint } from "./endpoints/delete-user";
-import { listUsersEndpoint } from "./endpoints/list-users";
-import { submitFeedbackEndpoint } from "./endpoints/submit-feedback";
-import { subscriptionEndpoint } from "./endpoints/time-subscription";
-import { uploadAvatarEndpoint } from "./endpoints/upload-avatar";
-import { retrieveUserEndpoint } from "./endpoints/retrieve-user";
-import { sendAvatarEndpoint } from "./endpoints/send-avatar";
-import { updateUserEndpoint } from "./endpoints/update-user";
-import { streamAvatarEndpoint } from "./endpoints/stream-avatar";
+import { rawAcceptingEndpoint } from "./endpoints/accept-raw.ts";
+import { createUserEndpoint } from "./endpoints/create-user.ts";
+import { deleteUserEndpoint } from "./endpoints/delete-user.ts";
+import { listUsersEndpoint } from "./endpoints/list-users.ts";
+import { submitFeedbackEndpoint } from "./endpoints/submit-feedback.ts";
+import { subscriptionEndpoint } from "./endpoints/time-subscription.ts";
+import { uploadAvatarEndpoint } from "./endpoints/upload-avatar.ts";
+import { retrieveUserEndpoint } from "./endpoints/retrieve-user.ts";
+import { sendAvatarEndpoint } from "./endpoints/send-avatar.ts";
+import { updateUserEndpoint } from "./endpoints/update-user.ts";
+import { streamAvatarEndpoint } from "./endpoints/stream-avatar.ts";
 
 export const routing: Routing = {
   v1: {

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler"
-  }
+  "compilerOptions": {}
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {}
+  "extends": "../tsconfig.json"
 }

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -1,14 +1,14 @@
 import ansis from "ansis";
 import { inspect } from "node:util";
 import { performance } from "node:perf_hooks";
-import { FlatObject, isProduction } from "./common-helpers";
+import { FlatObject, isProduction } from "./common-helpers.ts";
 import {
   AbstractLogger,
   formatDuration,
   isHidden,
   Severity,
   styles,
-} from "./logger-helpers";
+} from "./logger-helpers.ts";
 
 interface Context extends FlatObject {
   requestId?: string;

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -1,16 +1,16 @@
 import { Request } from "express";
 import * as R from "ramda";
 import { z } from "zod";
-import { CommonConfig, InputSource, InputSources } from "./config-type";
-import { contentTypes } from "./content-type";
+import { CommonConfig, InputSource, InputSources } from "./config-type.ts";
+import { contentTypes } from "./content-type.ts";
 import {
   ClientMethod,
   SomeMethod,
   isMethod,
   Method,
   CORSMethod,
-} from "./method";
-import { NormalizedResponse } from "./api-response";
+} from "./method.ts";
+import { NormalizedResponse } from "./api-response.ts";
 
 /** @since zod 3.25.61 output type fixed */
 export const emptySchema = z.object({});

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -2,13 +2,13 @@ import type compression from "compression";
 import { IRouter, Request, RequestHandler } from "express";
 import type fileUpload from "express-fileupload";
 import { ServerOptions } from "node:https";
-import { BuiltinLoggerConfig } from "./builtin-logger";
-import { AbstractEndpoint } from "./endpoint";
-import { AbstractLogger, ActualLogger } from "./logger-helpers";
-import { Method } from "./method";
-import { AbstractResultHandler } from "./result-handler";
+import { BuiltinLoggerConfig } from "./builtin-logger.ts";
+import { AbstractEndpoint } from "./endpoint.ts";
+import { AbstractLogger, ActualLogger } from "./logger-helpers.ts";
+import { Method } from "./method.ts";
+import { AbstractResultHandler } from "./result-handler.ts";
 import { ListenOptions } from "node:net";
-import { GetLogger } from "./server-helpers";
+import { GetLogger } from "./server-helpers.ts";
 
 export type InputSource = keyof Pick<
   Request,

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -1,15 +1,15 @@
 import * as R from "ramda";
 import { z } from "zod";
-import { ezBufferBrand } from "./buffer-schema";
-import { ezDateInBrand } from "./date-in-schema";
-import { ezDateOutBrand } from "./date-out-schema";
-import { DeepCheckError } from "./errors";
-import { ezFormBrand } from "./form-schema";
-import { IOSchema } from "./io-schema";
+import { ezBufferBrand } from "./buffer-schema.ts";
+import { ezDateInBrand } from "./date-in-schema.ts";
+import { ezDateOutBrand } from "./date-out-schema.ts";
+import { DeepCheckError } from "./errors.ts";
+import { ezFormBrand } from "./form-schema.ts";
+import { IOSchema } from "./io-schema.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { FirstPartyKind } from "./schema-walker";
-import { ezUploadBrand } from "./upload-schema";
-import { ezRawBrand } from "./raw-schema";
+import { FirstPartyKind } from "./schema-walker.ts";
+import { ezUploadBrand } from "./upload-schema.ts";
+import { ezRawBrand } from "./raw-schema.ts";
 
 interface NestedSchemaLookupProps {
   io: "input" | "output";

--- a/express-zod-api/src/depends-on-method.ts
+++ b/express-zod-api/src/depends-on-method.ts
@@ -1,7 +1,7 @@
 import * as R from "ramda";
-import { AbstractEndpoint } from "./endpoint";
-import { Method } from "./method";
-import { Routable } from "./routable";
+import { AbstractEndpoint } from "./endpoint.ts";
+import { Method } from "./method.ts";
+import { Routable } from "./routable.ts";
 
 export class DependsOnMethod extends Routable {
   readonly #endpoints: ConstructorParameters<typeof DependsOnMethod>[0];

--- a/express-zod-api/src/diagnostics.ts
+++ b/express-zod-api/src/diagnostics.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import { responseVariants } from "./api-response";
-import { FlatObject, getRoutePathParams } from "./common-helpers";
-import { contentTypes } from "./content-type";
-import { findJsonIncompatible } from "./deep-checks";
-import { AbstractEndpoint } from "./endpoint";
-import { flattenIO } from "./json-schema-helpers";
-import { ActualLogger } from "./logger-helpers";
+import { responseVariants } from "./api-response.ts";
+import { FlatObject, getRoutePathParams } from "./common-helpers.ts";
+import { contentTypes } from "./content-type.ts";
+import { findJsonIncompatible } from "./deep-checks.ts";
+import { AbstractEndpoint } from "./endpoint.ts";
+import { flattenIO } from "./json-schema-helpers.ts";
+import { ActualLogger } from "./logger-helpers.ts";
 
 export class Diagnostics {
   #verifiedEndpoints = new WeakSet<AbstractEndpoint>();

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -16,8 +16,8 @@ import {
 } from "openapi3-ts/oas31";
 import * as R from "ramda";
 import { z } from "zod";
-import { NormalizedResponse, ResponseVariant } from "./api-response";
-import { ezBufferBrand } from "./buffer-schema";
+import { NormalizedResponse, ResponseVariant } from "./api-response.ts";
+import { ezBufferBrand } from "./buffer-schema.ts";
 import {
   shouldHaveContent,
   FlatObject,
@@ -29,23 +29,23 @@ import {
   routePathParamsRegex,
   Tag,
   ucFirst,
-} from "./common-helpers";
-import { InputSource } from "./config-type";
-import { contentTypes } from "./content-type";
-import { ezDateInBrand } from "./date-in-schema";
-import { ezDateOutBrand } from "./date-out-schema";
-import { DocumentationError } from "./errors";
-import { IOSchema } from "./io-schema";
-import { flattenIO } from "./json-schema-helpers";
-import { Alternatives } from "./logical-container";
+} from "./common-helpers.ts";
+import { InputSource } from "./config-type.ts";
+import { contentTypes } from "./content-type.ts";
+import { ezDateInBrand } from "./date-in-schema.ts";
+import { ezDateOutBrand } from "./date-out-schema.ts";
+import { DocumentationError } from "./errors.ts";
+import { IOSchema } from "./io-schema.ts";
+import { flattenIO } from "./json-schema-helpers.ts";
+import { Alternatives } from "./logical-container.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { ClientMethod } from "./method";
-import { ProprietaryBrand } from "./proprietary-schemas";
-import { ezRawBrand } from "./raw-schema";
-import { FirstPartyKind } from "./schema-walker";
-import { Security } from "./security";
-import { ezUploadBrand } from "./upload-schema";
-import wellKnownHeaders from "./well-known-headers.json";
+import { ClientMethod } from "./method.ts";
+import { ProprietaryBrand } from "./proprietary-schemas.ts";
+import { ezRawBrand } from "./raw-schema.ts";
+import { FirstPartyKind } from "./schema-walker.ts";
+import { Security } from "./security.ts";
+import { ezUploadBrand } from "./upload-schema.ts";
+import wellKnownHeaders from "./well-known-headers.json" with { type: "json" };
 
 interface ReqResCommons {
   makeRef: (

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -8,13 +8,13 @@ import {
   SecuritySchemeType,
 } from "openapi3-ts/oas31";
 import * as R from "ramda";
-import { responseVariants } from "./api-response";
-import { contentTypes } from "./content-type";
-import { DocumentationError } from "./errors";
-import { getInputSources, makeCleanId } from "./common-helpers";
-import { CommonConfig } from "./config-type";
-import { processContainers } from "./logical-container";
-import { ClientMethod } from "./method";
+import { responseVariants } from "./api-response.ts";
+import { contentTypes } from "./content-type.ts";
+import { DocumentationError } from "./errors.ts";
+import { getInputSources, makeCleanId } from "./common-helpers.ts";
+import { CommonConfig } from "./config-type.ts";
+import { processContainers } from "./logical-container.ts";
+import { ClientMethod } from "./method.ts";
 import {
   depictBody,
   depictRequestParams,
@@ -28,9 +28,9 @@ import {
   nonEmpty,
   BrandHandling,
   depictRequest,
-} from "./documentation-helpers";
-import { Routing } from "./routing";
-import { OnEndpoint, walkRouting, withHead } from "./routing-walker";
+} from "./documentation-helpers.ts";
+import { Routing } from "./routing.ts";
+import { OnEndpoint, walkRouting, withHead } from "./routing-walker.ts";
 
 type Component =
   | "positiveResponse"

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -1,36 +1,36 @@
 import { Request, Response } from "express";
 import * as R from "ramda";
 import { z, globalRegistry } from "zod";
-import { NormalizedResponse, ResponseVariant } from "./api-response";
-import { findRequestTypeDefiningSchema } from "./deep-checks";
+import { NormalizedResponse, ResponseVariant } from "./api-response.ts";
+import { findRequestTypeDefiningSchema } from "./deep-checks.ts";
 import {
   FlatObject,
   getActualMethod,
   getInput,
   ensureError,
   isSchema,
-} from "./common-helpers";
-import { CommonConfig } from "./config-type";
+} from "./common-helpers.ts";
+import { CommonConfig } from "./config-type.ts";
 import {
   InputValidationError,
   OutputValidationError,
   ResultHandlerError,
-} from "./errors";
-import { ezFormBrand } from "./form-schema";
-import { IOSchema } from "./io-schema";
-import { lastResortHandler } from "./last-resort";
-import { ActualLogger } from "./logger-helpers";
-import { LogicalContainer } from "./logical-container";
+} from "./errors.ts";
+import { ezFormBrand } from "./form-schema.ts";
+import { IOSchema } from "./io-schema.ts";
+import { lastResortHandler } from "./last-resort.ts";
+import { ActualLogger } from "./logger-helpers.ts";
+import { LogicalContainer } from "./logical-container.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { ClientMethod, CORSMethod, Method, SomeMethod } from "./method";
-import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
-import { ContentType } from "./content-type";
-import { ezRawBrand } from "./raw-schema";
-import { DiscriminatedResult, pullResponseExamples } from "./result-helpers";
-import { Routable } from "./routable";
-import { AbstractResultHandler } from "./result-handler";
-import { Security } from "./security";
-import { ezUploadBrand } from "./upload-schema";
+import { ClientMethod, CORSMethod, Method, SomeMethod } from "./method.ts";
+import { AbstractMiddleware, ExpressMiddleware } from "./middleware.ts";
+import { ContentType } from "./content-type.ts";
+import { ezRawBrand } from "./raw-schema.ts";
+import { DiscriminatedResult, pullResponseExamples } from "./result-helpers.ts";
+import { Routable } from "./routable.ts";
+import { AbstractResultHandler } from "./result-handler.ts";
+import { Security } from "./security.ts";
+import { ezUploadBrand } from "./upload-schema.ts";
 
 export type Handler<IN, OUT, OPT> = (params: {
   /** @desc The inputs from the enabled input sources validated against the final input schema (incl. Middlewares) */

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -6,26 +6,26 @@ import {
   EmptySchema,
   FlatObject,
   Tag,
-} from "./common-helpers";
-import { Endpoint, Handler } from "./endpoint";
+} from "./common-helpers.ts";
+import { Endpoint, Handler } from "./endpoint.ts";
 import {
   IOSchema,
   FinalInputSchema,
   Extension,
   ensureExtension,
   makeFinalInputSchema,
-} from "./io-schema";
-import { ClientMethod, Method } from "./method";
+} from "./io-schema.ts";
+import { ClientMethod, Method } from "./method.ts";
 import {
   AbstractMiddleware,
   ExpressMiddleware,
   Middleware,
-} from "./middleware";
+} from "./middleware.ts";
 import {
   AbstractResultHandler,
   arrayResultHandler,
   defaultResultHandler,
-} from "./result-handler";
+} from "./result-handler.ts";
 
 interface BuildProps<
   IN extends IOSchema,

--- a/express-zod-api/src/errors.ts
+++ b/express-zod-api/src/errors.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { getMessageFromError } from "./common-helpers";
-import { OpenAPIContext } from "./documentation-helpers";
-import type { Method } from "./method";
+import { getMessageFromError } from "./common-helpers.ts";
+import { OpenAPIContext } from "./documentation-helpers.ts";
+import type { Method } from "./method.ts";
 
 /** @desc An error related to the wrong Routing declaration */
 export class RoutingError extends Error {

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -2,14 +2,14 @@ import http from "node:http";
 import https from "node:https";
 import { setInterval } from "node:timers/promises";
 import type { Socket } from "node:net";
-import type { ActualLogger } from "./logger-helpers";
+import type { ActualLogger } from "./logger-helpers.ts";
 import {
   closeAsync,
   hasHttpServer,
   hasResponse,
   isEncrypted,
   weAreClosed,
-} from "./graceful-helpers";
+} from "./graceful-helpers.ts";
 
 export const monitor = (
   servers: Array<http.Server | https.Server>,

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -1,52 +1,52 @@
 import "@express-zod-api/zod-plugin"; // side effects here
-export { createConfig } from "./config-type";
+export { createConfig } from "./config-type.ts";
 export {
   EndpointsFactory,
   defaultEndpointsFactory,
   arrayEndpointsFactory,
-} from "./endpoints-factory";
-export { getMessageFromError } from "./common-helpers";
-export { ensureHttpError } from "./result-helpers";
-export { BuiltinLogger } from "./builtin-logger";
-export { Middleware } from "./middleware";
+} from "./endpoints-factory.ts";
+export { getMessageFromError } from "./common-helpers.ts";
+export { ensureHttpError } from "./result-helpers.ts";
+export { BuiltinLogger } from "./builtin-logger.ts";
+export { Middleware } from "./middleware.ts";
 export {
   ResultHandler,
   defaultResultHandler,
   arrayResultHandler,
-} from "./result-handler";
-export { DependsOnMethod } from "./depends-on-method";
-export { ServeStatic } from "./serve-static";
-export { createServer, attachRouting } from "./server";
-export { Documentation } from "./documentation";
+} from "./result-handler.ts";
+export { DependsOnMethod } from "./depends-on-method.ts";
+export { ServeStatic } from "./serve-static.ts";
+export { createServer, attachRouting } from "./server.ts";
+export { Documentation } from "./documentation.ts";
 export {
   DocumentationError,
   RoutingError,
   OutputValidationError,
   InputValidationError,
   MissingPeerError,
-} from "./errors";
-export { testEndpoint, testMiddleware } from "./testing";
-export { Integration } from "./integration";
-export { EventStreamFactory } from "./sse";
+} from "./errors.ts";
+export { testEndpoint, testMiddleware } from "./testing.ts";
+export { Integration } from "./integration.ts";
+export { EventStreamFactory } from "./sse.ts";
 
-export { ez } from "./proprietary-schemas";
+export { ez } from "./proprietary-schemas.ts";
 
 // Convenience types
-export type { Depicter } from "./documentation-helpers";
-export type { Producer } from "./zts-helpers";
+export type { Depicter } from "./documentation-helpers.ts";
+export type { Producer } from "./zts-helpers.ts";
 
 // Interfaces exposed for augmentation
-export type { LoggerOverrides } from "./logger-helpers";
-export type { TagOverrides } from "./common-helpers";
+export type { LoggerOverrides } from "./logger-helpers.ts";
+export type { TagOverrides } from "./common-helpers.ts";
 
 // Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
 import type {} from "qs"; // fixes TS2742 for attachRouting
-export type { Routing } from "./routing";
-export type { FlatObject } from "./common-helpers";
-export type { Method } from "./method";
-export type { IOSchema } from "./io-schema";
-export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
-export type { ApiResponse } from "./api-response";
+export type { Routing } from "./routing.ts";
+export type { FlatObject } from "./common-helpers.ts";
+export type { Method } from "./method.ts";
+export type { IOSchema } from "./io-schema.ts";
+export type { CommonConfig, AppConfig, ServerConfig } from "./config-type.ts";
+export type { ApiResponse } from "./api-response.ts";
 export type {
   BasicSecurity,
   BearerSecurity,
@@ -55,4 +55,4 @@ export type {
   InputSecurity,
   OAuth2Security,
   OpenIdSecurity,
-} from "./security";
+} from "./security.ts";

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -1,9 +1,9 @@
 import * as R from "ramda";
 import ts from "typescript";
-import { ResponseVariant } from "./api-response";
-import { contentTypes } from "./content-type";
-import { ClientMethod, clientMethods } from "./method";
-import type { makeEventSchema } from "./sse";
+import { ResponseVariant } from "./api-response.ts";
+import { contentTypes } from "./content-type.ts";
+import { ClientMethod, clientMethods } from "./method.ts";
+import type { makeEventSchema } from "./sse.ts";
 import {
   accessModifiers,
   ensureTypeNode,
@@ -39,7 +39,7 @@ import {
   makeFnType,
   makeLiteralType,
   literally,
-} from "./typescript-api";
+} from "./typescript-api.ts";
 
 type IOKind = "input" | "response" | ResponseVariant | "encoded";
 type SSEShape = ReturnType<typeof makeEventSchema>["shape"];

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -1,8 +1,8 @@
 import * as R from "ramda";
 import ts from "typescript";
 import { z } from "zod";
-import { ResponseVariant, responseVariants } from "./api-response";
-import { IntegrationBase } from "./integration-base";
+import { ResponseVariant, responseVariants } from "./api-response.ts";
+import { IntegrationBase } from "./integration-base.ts";
 import {
   f,
   makeInterfaceProp,
@@ -13,16 +13,16 @@ import {
   makeIndexed,
   makeLiteralType,
   makeUnion,
-} from "./typescript-api";
-import { shouldHaveContent, makeCleanId } from "./common-helpers";
-import { loadPeer } from "./peer-helpers";
-import { Routing } from "./routing";
-import { OnEndpoint, walkRouting, withHead } from "./routing-walker";
-import { HandlingRules } from "./schema-walker";
-import { zodToTs } from "./zts";
-import { ZTSContext } from "./zts-helpers";
+} from "./typescript-api.ts";
+import { shouldHaveContent, makeCleanId } from "./common-helpers.ts";
+import { loadPeer } from "./peer-helpers.ts";
+import { Routing } from "./routing.ts";
+import { OnEndpoint, walkRouting, withHead } from "./routing-walker.ts";
+import { HandlingRules } from "./schema-walker.ts";
+import { zodToTs } from "./zts.ts";
+import { ZTSContext } from "./zts-helpers.ts";
 import type Prettier from "prettier";
-import { ClientMethod } from "./method";
+import { ClientMethod } from "./method.ts";
 
 interface IntegrationParams {
   routing: Routing;

--- a/express-zod-api/src/json-schema-helpers.ts
+++ b/express-zod-api/src/json-schema-helpers.ts
@@ -1,5 +1,5 @@
 import * as R from "ramda";
-import { combinations, FlatObject, isObject } from "./common-helpers";
+import { combinations, FlatObject, isObject } from "./common-helpers.ts";
 import type { z } from "zod";
 
 const isJsonObjectSchema = (

--- a/express-zod-api/src/last-resort.ts
+++ b/express-zod-api/src/last-resort.ts
@@ -1,8 +1,8 @@
 import { Response } from "express";
 import createHttpError, { isHttpError } from "http-errors";
-import { ResultHandlerError } from "./errors";
-import { ActualLogger } from "./logger-helpers";
-import { getPublicErrorMessage } from "./result-helpers";
+import { ResultHandlerError } from "./errors.ts";
+import { ActualLogger } from "./logger-helpers.ts";
+import { getPublicErrorMessage } from "./result-helpers.ts";
 
 interface LastResortHandlerParams {
   error: ResultHandlerError;

--- a/express-zod-api/src/logger-helpers.ts
+++ b/express-zod-api/src/logger-helpers.ts
@@ -1,6 +1,6 @@
 import { Ansis, blue, green, hex, red, cyanBright } from "ansis";
 import * as R from "ramda";
-import { isObject } from "./common-helpers";
+import { isObject } from "./common-helpers.ts";
 
 export const styles = {
   debug: blue,

--- a/express-zod-api/src/logical-container.ts
+++ b/express-zod-api/src/logical-container.ts
@@ -1,5 +1,5 @@
 import * as R from "ramda";
-import { combinations, isObject } from "./common-helpers";
+import { combinations, isObject } from "./common-helpers.ts";
 
 type LogicalOr<T> = { or: T[] };
 type LogicalAnd<T> = { and: T[] };

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -1,11 +1,11 @@
 import { NextFunction, Request, Response } from "express";
 import { z } from "zod";
-import { emptySchema, FlatObject } from "./common-helpers";
-import { InputValidationError } from "./errors";
-import { IOSchema } from "./io-schema";
-import { LogicalContainer } from "./logical-container";
-import { Security } from "./security";
-import { ActualLogger } from "./logger-helpers";
+import { emptySchema, FlatObject } from "./common-helpers.ts";
+import { InputValidationError } from "./errors.ts";
+import { IOSchema } from "./io-schema.ts";
+import { LogicalContainer } from "./logical-container.ts";
+import { Security } from "./security.ts";
+import { ActualLogger } from "./logger-helpers.ts";
 
 type Handler<IN, OPT, OUT> = (params: {
   /** @desc The inputs from the enabled input sources validated against the input schema of the Middleware */

--- a/express-zod-api/src/peer-helpers.ts
+++ b/express-zod-api/src/peer-helpers.ts
@@ -1,4 +1,4 @@
-import { MissingPeerError } from "./errors";
+import { MissingPeerError } from "./errors.ts";
 
 export const loadPeer = async <T>(
   moduleName: string,

--- a/express-zod-api/src/proprietary-schemas.ts
+++ b/express-zod-api/src/proprietary-schemas.ts
@@ -1,9 +1,9 @@
-import { buffer, type ezBufferBrand } from "./buffer-schema";
-import { dateIn, type ezDateInBrand } from "./date-in-schema";
-import { dateOut, type ezDateOutBrand } from "./date-out-schema";
-import { form, type ezFormBrand } from "./form-schema";
-import { raw, type ezRawBrand } from "./raw-schema";
-import { upload, type ezUploadBrand } from "./upload-schema";
+import { buffer, type ezBufferBrand } from "./buffer-schema.ts";
+import { dateIn, type ezDateInBrand } from "./date-in-schema.ts";
+import { dateOut, type ezDateOutBrand } from "./date-out-schema.ts";
+import { form, type ezFormBrand } from "./form-schema.ts";
+import { raw, type ezRawBrand } from "./raw-schema.ts";
+import { upload, type ezUploadBrand } from "./upload-schema.ts";
 
 export const ez = { dateIn, dateOut, form, upload, raw, buffer };
 

--- a/express-zod-api/src/raw-schema.ts
+++ b/express-zod-api/src/raw-schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { buffer } from "./buffer-schema";
+import { buffer } from "./buffer-schema.ts";
 
 export const ezRawBrand = Symbol("Raw");
 

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -4,11 +4,11 @@ import {
   ApiResponse,
   defaultStatusCodes,
   NormalizedResponse,
-} from "./api-response";
-import { FlatObject, isObject } from "./common-helpers";
-import { contentTypes } from "./content-type";
-import { IOSchema } from "./io-schema";
-import { ActualLogger } from "./logger-helpers";
+} from "./api-response.ts";
+import { FlatObject, isObject } from "./common-helpers.ts";
+import { contentTypes } from "./content-type.ts";
+import { IOSchema } from "./io-schema.ts";
+import { ActualLogger } from "./logger-helpers.ts";
 import {
   DiscriminatedResult,
   ensureHttpError,
@@ -16,7 +16,7 @@ import {
   logServerError,
   normalize,
   ResultSchema,
-} from "./result-helpers";
+} from "./result-helpers.ts";
 
 type Handler<RES = unknown> = (
   params: DiscriminatedResult & {

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -2,16 +2,16 @@ import { Request } from "express";
 import createHttpError, { HttpError, isHttpError } from "http-errors";
 import * as R from "ramda";
 import { globalRegistry, z } from "zod";
-import { NormalizedResponse, ResponseVariant } from "./api-response";
+import { NormalizedResponse, ResponseVariant } from "./api-response.ts";
 import {
   combinations,
   FlatObject,
   getMessageFromError,
   isProduction,
-} from "./common-helpers";
-import { InputValidationError, ResultHandlerError } from "./errors";
-import { ActualLogger } from "./logger-helpers";
-import type { LazyResult, Result } from "./result-handler";
+} from "./common-helpers.ts";
+import { InputValidationError, ResultHandlerError } from "./errors.ts";
+import { ActualLogger } from "./logger-helpers.ts";
+import type { LazyResult, Result } from "./result-handler.ts";
 
 export type ResultSchema<R extends Result> =
   R extends Result<infer S> ? S : never;

--- a/express-zod-api/src/routable.ts
+++ b/express-zod-api/src/routable.ts
@@ -1,4 +1,4 @@
-import { Routing } from "./routing";
+import { Routing } from "./routing.ts";
 
 export abstract class Routable {
   /** @desc Marks the route as deprecated (makes a copy of the endpoint) */

--- a/express-zod-api/src/routing-walker.ts
+++ b/express-zod-api/src/routing-walker.ts
@@ -1,9 +1,9 @@
-import { DependsOnMethod } from "./depends-on-method";
-import { AbstractEndpoint } from "./endpoint";
-import { RoutingError } from "./errors";
-import { ClientMethod, isMethod, Method } from "./method";
-import { Routing } from "./routing";
-import { ServeStatic, StaticHandler } from "./serve-static";
+import { DependsOnMethod } from "./depends-on-method.ts";
+import { AbstractEndpoint } from "./endpoint.ts";
+import { RoutingError } from "./errors.ts";
+import { ClientMethod, isMethod, Method } from "./method.ts";
+import { Routing } from "./routing.ts";
+import { ServeStatic, StaticHandler } from "./serve-static.ts";
 
 export type OnEndpoint<M extends string = Method> = (
   method: M,

--- a/express-zod-api/src/routing.ts
+++ b/express-zod-api/src/routing.ts
@@ -1,15 +1,15 @@
 import { IRouter, RequestHandler } from "express";
 import createHttpError from "http-errors";
-import { isProduction } from "./common-helpers";
-import { CommonConfig } from "./config-type";
-import { ContentType } from "./content-type";
-import { DependsOnMethod } from "./depends-on-method";
-import { Diagnostics } from "./diagnostics";
-import { AbstractEndpoint } from "./endpoint";
-import { CORSMethod, isMethod } from "./method";
-import { OnEndpoint, walkRouting } from "./routing-walker";
-import { ServeStatic } from "./serve-static";
-import { GetLogger } from "./server-helpers";
+import { isProduction } from "./common-helpers.ts";
+import { CommonConfig } from "./config-type.ts";
+import { ContentType } from "./content-type.ts";
+import { DependsOnMethod } from "./depends-on-method.ts";
+import { Diagnostics } from "./diagnostics.ts";
+import { AbstractEndpoint } from "./endpoint.ts";
+import { CORSMethod, isMethod } from "./method.ts";
+import { OnEndpoint, walkRouting } from "./routing-walker.ts";
+import { ServeStatic } from "./serve-static.ts";
+import { GetLogger } from "./server-helpers.ts";
 import * as R from "ramda";
 
 /**

--- a/express-zod-api/src/schema-walker.ts
+++ b/express-zod-api/src/schema-walker.ts
@@ -1,4 +1,4 @@
-import type { EmptyObject, FlatObject } from "./common-helpers";
+import type { EmptyObject, FlatObject } from "./common-helpers.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
 import type { z } from "zod";
 

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -1,17 +1,17 @@
 import type fileUpload from "express-fileupload";
-import { loadPeer } from "./peer-helpers";
-import { AbstractResultHandler } from "./result-handler";
-import { ActualLogger } from "./logger-helpers";
-import { CommonConfig, ServerConfig } from "./config-type";
+import { loadPeer } from "./peer-helpers.ts";
+import { AbstractResultHandler } from "./result-handler.ts";
+import { ActualLogger } from "./logger-helpers.ts";
+import { CommonConfig, ServerConfig } from "./config-type.ts";
 import { ErrorRequestHandler, RequestHandler, Request } from "express";
 import createHttpError from "http-errors";
-import { lastResortHandler } from "./last-resort";
-import { ResultHandlerError } from "./errors";
-import { ensureError } from "./common-helpers";
-import { monitor } from "./graceful-shutdown";
-import { name as self } from "../package.json";
+import { lastResortHandler } from "./last-resort.ts";
+import { ResultHandlerError } from "./errors.ts";
+import { ensureError } from "./common-helpers.ts";
+import { monitor } from "./graceful-shutdown.ts";
+import manifest from "../package.json" with { type: "json" };
 
-export const localsID = Symbol.for(self);
+export const localsID = Symbol.for(manifest.name);
 
 type EquippedRequest = Request<
   unknown,

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -9,9 +9,9 @@ import { lastResortHandler } from "./last-resort.ts";
 import { ResultHandlerError } from "./errors.ts";
 import { ensureError } from "./common-helpers.ts";
 import { monitor } from "./graceful-shutdown.ts";
-import manifest from "../package.json" with { type: "json" };
 
-export const localsID = Symbol.for(manifest.name);
+// eslint-disable-next-line no-restricted-syntax -- substituted by TSDOWN
+export const localsID = Symbol.for(process.env.TSDOWN_SELF!);
 
 type EquippedRequest = Request<
   unknown,

--- a/express-zod-api/src/server.ts
+++ b/express-zod-api/src/server.ts
@@ -2,17 +2,17 @@ import express from "express";
 import type compression from "compression";
 import http from "node:http";
 import https from "node:https";
-import { BuiltinLogger } from "./builtin-logger";
+import { BuiltinLogger } from "./builtin-logger.ts";
 import {
   AppConfig,
   CommonConfig,
   HttpConfig,
   ServerConfig,
-} from "./config-type";
-import { isLoggerInstance } from "./logger-helpers";
-import { loadPeer } from "./peer-helpers";
-import { defaultResultHandler } from "./result-handler";
-import { Parsers, Routing, initRouting } from "./routing";
+} from "./config-type.ts";
+import { isLoggerInstance } from "./logger-helpers.ts";
+import { loadPeer } from "./peer-helpers.ts";
+import { defaultResultHandler } from "./result-handler.ts";
+import { Parsers, Routing, initRouting } from "./routing.ts";
 import {
   createLoggingMiddleware,
   createNotFoundHandler,
@@ -22,8 +22,8 @@ import {
   installDeprecationListener,
   moveRaw,
   installTerminationListener,
-} from "./server-helpers";
-import { printStartupLogo } from "./startup-logo";
+} from "./server-helpers.ts";
+import { printStartupLogo } from "./startup-logo.ts";
 
 const makeCommonEntities = (config: CommonConfig) => {
   if (config.startupLogo !== false) printStartupLogo(process.stdout);

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -1,15 +1,15 @@
 import { Response } from "express";
 import { z } from "zod";
-import { FlatObject } from "./common-helpers";
-import { contentTypes } from "./content-type";
-import { EndpointsFactory } from "./endpoints-factory";
-import { Middleware } from "./middleware";
-import { ResultHandler } from "./result-handler";
+import { FlatObject } from "./common-helpers.ts";
+import { contentTypes } from "./content-type.ts";
+import { EndpointsFactory } from "./endpoints-factory.ts";
+import { Middleware } from "./middleware.ts";
+import { ResultHandler } from "./result-handler.ts";
 import {
   ensureHttpError,
   getPublicErrorMessage,
   logServerError,
-} from "./result-helpers";
+} from "./result-helpers.ts";
 
 type EventsMap = Record<string, z.ZodType>;
 

--- a/express-zod-api/src/testing.ts
+++ b/express-zod-api/src/testing.ts
@@ -1,22 +1,22 @@
 import { Request, Response } from "express";
-import { ensureError, FlatObject, getInput } from "./common-helpers";
-import { CommonConfig } from "./config-type";
-import { AbstractEndpoint } from "./endpoint";
+import { ensureError, FlatObject, getInput } from "./common-helpers.ts";
+import { CommonConfig } from "./config-type.ts";
+import { AbstractEndpoint } from "./endpoint.ts";
 import {
   AbstractLogger,
   ActualLogger,
   isSeverity,
   Severity,
-} from "./logger-helpers";
-import { contentTypes } from "./content-type";
+} from "./logger-helpers.ts";
+import { contentTypes } from "./content-type.ts";
 import {
   createRequest,
   RequestOptions,
   createResponse,
   ResponseOptions,
 } from "node-mocks-http";
-import { AbstractMiddleware } from "./middleware";
-import { defaultResultHandler } from "./result-handler";
+import { AbstractMiddleware } from "./middleware.ts";
+import { defaultResultHandler } from "./result-handler.ts";
 
 export const makeRequestMock = <REQ extends RequestOptions>(props?: REQ) =>
   createRequest<Request & REQ>({

--- a/express-zod-api/src/zts-helpers.ts
+++ b/express-zod-api/src/zts-helpers.ts
@@ -1,6 +1,6 @@
 import type ts from "typescript";
-import { FlatObject } from "./common-helpers";
-import { SchemaHandler } from "./schema-walker";
+import { FlatObject } from "./common-helpers.ts";
+import { SchemaHandler } from "./schema-walker.ts";
 
 export interface ZTSContext extends FlatObject {
   isResponse: boolean;

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -1,21 +1,21 @@
 import * as R from "ramda";
 import ts from "typescript";
 import { globalRegistry, z } from "zod";
-import { ezBufferBrand } from "./buffer-schema";
-import { getTransformedType, isSchema } from "./common-helpers";
-import { ezDateInBrand } from "./date-in-schema";
-import { ezDateOutBrand } from "./date-out-schema";
-import { hasCycle } from "./deep-checks";
-import { ProprietaryBrand } from "./proprietary-schemas";
-import { ezRawBrand, RawSchema } from "./raw-schema";
-import { FirstPartyKind, HandlingRules, walkSchema } from "./schema-walker";
+import { ezBufferBrand } from "./buffer-schema.ts";
+import { getTransformedType, isSchema } from "./common-helpers.ts";
+import { ezDateInBrand } from "./date-in-schema.ts";
+import { ezDateOutBrand } from "./date-out-schema.ts";
+import { hasCycle } from "./deep-checks.ts";
+import { ProprietaryBrand } from "./proprietary-schemas.ts";
+import { ezRawBrand, RawSchema } from "./raw-schema.ts";
+import { FirstPartyKind, HandlingRules, walkSchema } from "./schema-walker.ts";
 import {
   ensureTypeNode,
   makeInterfaceProp,
   makeLiteralType,
   makeUnion,
-} from "./typescript-api";
-import { Producer, ZTSContext } from "./zts-helpers";
+} from "./typescript-api.ts";
+import { Producer, ZTSContext } from "./zts-helpers.ts";
 
 const { factory: f } = ts;
 

--- a/express-zod-api/tests/api-response.spec.ts
+++ b/express-zod-api/tests/api-response.spec.ts
@@ -1,4 +1,4 @@
-import { defaultStatusCodes, responseVariants } from "../src/api-response";
+import { defaultStatusCodes, responseVariants } from "../src/api-response.ts";
 
 describe("ApiResponse", () => {
   describe("defaultStatusCodes", () => {

--- a/express-zod-api/tests/buffer-schema.spec.ts
+++ b/express-zod-api/tests/buffer-schema.spec.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { z, $brand } from "zod";
-import { ez } from "../src";
+import { ez } from "../src/index.ts";
 
 describe("ez.buffer()", () => {
   describe("creation", () => {

--- a/express-zod-api/tests/builtin-logger.spec.ts
+++ b/express-zod-api/tests/builtin-logger.spec.ts
@@ -1,5 +1,5 @@
 import { performance } from "node:perf_hooks";
-import { BuiltinLogger, BuiltinLoggerConfig } from "../src/builtin-logger";
+import { BuiltinLogger, BuiltinLoggerConfig } from "../src/builtin-logger.ts";
 
 describe("BuiltinLogger", () => {
   beforeEach(() => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -12,11 +12,11 @@ import {
   emptySchema,
   EmptySchema,
   EmptyObject,
-} from "../src/common-helpers";
+} from "../src/common-helpers.ts";
 import { z } from "zod";
-import { makeRequestMock } from "../src/testing";
-import { methods } from "../src/method";
-import { CommonConfig, InputSources } from "../src/config-type";
+import { makeRequestMock } from "../src/testing.ts";
+import { methods } from "../src/method.ts";
+import { CommonConfig, InputSources } from "../src/config-type.ts";
 
 describe("Common Helpers", () => {
   describe("emptySchema", () => {

--- a/express-zod-api/tests/config-type.spec.ts
+++ b/express-zod-api/tests/config-type.spec.ts
@@ -1,5 +1,5 @@
 import { Express, IRouter } from "express";
-import { createConfig } from "../src";
+import { createConfig } from "../src/index.ts";
 
 describe("ConfigType", () => {
   describe("createConfig()", () => {

--- a/express-zod-api/tests/content-type.spec.ts
+++ b/express-zod-api/tests/content-type.spec.ts
@@ -1,4 +1,4 @@
-import { contentTypes } from "../src/content-type";
+import { contentTypes } from "../src/content-type.ts";
 
 describe("contentTypes", () => {
   test("should has predefined properties", () => {

--- a/express-zod-api/tests/date-in-schema.spec.ts
+++ b/express-zod-api/tests/date-in-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ezDateInBrand } from "../src/date-in-schema";
-import { ez } from "../src";
+import { ezDateInBrand } from "../src/date-in-schema.ts";
+import { ez } from "../src/index.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
 
 describe("ez.dateIn()", () => {

--- a/express-zod-api/tests/date-out-schema.spec.ts
+++ b/express-zod-api/tests/date-out-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ezDateOutBrand } from "../src/date-out-schema";
-import { ez } from "../src";
+import { ezDateOutBrand } from "../src/date-out-schema.ts";
+import { ez } from "../src/index.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
 
 describe("ez.dateOut()", () => {

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -1,9 +1,9 @@
 import { UploadedFile } from "express-fileupload";
 import { z } from "zod";
-import { ez } from "../src";
-import { findNestedSchema, hasCycle } from "../src/deep-checks";
+import { ez } from "../src/index.ts";
+import { findNestedSchema, hasCycle } from "../src/deep-checks.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { ezUploadBrand } from "../src/upload-schema";
+import { ezUploadBrand } from "../src/upload-schema.ts";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {

--- a/express-zod-api/tests/depends-on-method.spec.ts
+++ b/express-zod-api/tests/depends-on-method.spec.ts
@@ -3,8 +3,8 @@ import {
   DependsOnMethod,
   EndpointsFactory,
   defaultResultHandler,
-} from "../src";
-import { AbstractEndpoint } from "../src/endpoint";
+} from "../src/index.ts";
+import { AbstractEndpoint } from "../src/endpoint.ts";
 
 describe("DependsOnMethod", () => {
   test("should accept empty object", () => {

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,7 +1,7 @@
 import { SchemaObject } from "openapi3-ts/oas31";
 import * as R from "ramda";
 import { z } from "zod";
-import { ez } from "../src";
+import { ez } from "../src/index.ts";
 import {
   OpenAPIContext,
   depictRequestParams,
@@ -25,7 +25,7 @@ import {
   depictDateOut,
   depictBody,
   depictRequest,
-} from "../src/documentation-helpers";
+} from "../src/documentation-helpers.ts";
 
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -11,10 +11,10 @@ import {
   ResultHandler,
   Depicter,
   Method,
-} from "../src";
-import { contentTypes } from "../src/content-type";
+} from "../src/index.ts";
+import { contentTypes } from "../src/content-type.ts";
 import { z } from "zod";
-import { givePort } from "../../tools/ports";
+import { givePort } from "../../tools/ports.ts";
 import * as R from "ramda";
 
 describe("Documentation", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -7,8 +7,8 @@ import {
   ez,
   testEndpoint,
   ResultHandler,
-} from "../src";
-import { Endpoint } from "../src/endpoint";
+} from "../src/index.ts";
+import { Endpoint } from "../src/endpoint.ts";
 
 describe("Endpoint", () => {
   describe(".methods", () => {

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -7,9 +7,9 @@ import {
   defaultEndpointsFactory,
   ResultHandler,
   testMiddleware,
-} from "../src";
-import { EmptyObject } from "../src/common-helpers";
-import { Endpoint } from "../src/endpoint";
+} from "../src/index.ts";
+import { EmptyObject } from "../src/common-helpers.ts";
+import { Endpoint } from "../src/endpoint.ts";
 import { z } from "zod";
 
 describe("EndpointsFactory", () => {

--- a/express-zod-api/tests/errors.spec.ts
+++ b/express-zod-api/tests/errors.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DocumentationError, RoutingError } from "../src";
+import { DocumentationError, RoutingError } from "../src/index.ts";
 import {
   IOSchemaError,
   InputValidationError,
@@ -7,7 +7,7 @@ import {
   OutputValidationError,
   ResultHandlerError,
   DeepCheckError,
-} from "../src/errors";
+} from "../src/errors.ts";
 
 describe("Errors", () => {
   const zodError = new z.ZodError([

--- a/express-zod-api/tests/form-schema.spec.ts
+++ b/express-zod-api/tests/form-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ez } from "../src";
-import { ezFormBrand } from "../src/form-schema";
+import { ez } from "../src/index.ts";
+import { ezFormBrand } from "../src/form-schema.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
 
 describe("ez.form()", () => {

--- a/express-zod-api/tests/graceful-helpers.spec.ts
+++ b/express-zod-api/tests/graceful-helpers.spec.ts
@@ -4,9 +4,9 @@ import {
   closeAsync,
   weAreClosed,
   isEncrypted,
-} from "../src/graceful-helpers";
+} from "../src/graceful-helpers.ts";
 import http from "node:http";
-import { makeRequestMock } from "../src/testing";
+import { makeRequestMock } from "../src/testing.ts";
 import { Socket } from "node:net";
 
 describe("Graceful helpers", () => {

--- a/express-zod-api/tests/graceful-shutdown.spec.ts
+++ b/express-zod-api/tests/graceful-shutdown.spec.ts
@@ -3,9 +3,9 @@ import http from "node:http";
 import https from "node:https";
 import { Agent, fetch } from "undici";
 import { setTimeout } from "node:timers/promises";
-import { monitor } from "../src/graceful-shutdown";
-import { givePort } from "../../tools/ports";
-import { signCert } from "./ssl-helpers";
+import { monitor } from "../src/graceful-shutdown.ts";
+import { givePort } from "../../tools/ports.ts";
+import { signCert } from "./ssl-helpers.ts";
 
 describe("monitor()", () => {
   const makeHttpServer = (handler: http.RequestListener) =>

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -1,7 +1,7 @@
 import { IRouter } from "express";
 import ts from "typescript";
 import { z } from "zod";
-import * as entrypoint from "../src";
+import * as entrypoint from "../src/index.ts";
 import {
   ApiResponse,
   AppConfig,
@@ -21,7 +21,7 @@ import {
   Producer,
   Routing,
   ServerConfig,
-} from "../src";
+} from "../src/index.ts";
 
 describe("Index Entrypoint", () => {
   describe("exports", () => {

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -6,7 +6,7 @@ import {
   Producer,
   defaultEndpointsFactory,
   ResultHandler,
-} from "../src";
+} from "../src/index.ts";
 
 describe("Integration", () => {
   const recursive1: z.ZodType = z.lazy(() =>

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { IOSchema, ez } from "../src";
-import { makeFinalInputSchema, ensureExtension } from "../src/io-schema";
+import { IOSchema, ez } from "../src/index.ts";
+import { makeFinalInputSchema, ensureExtension } from "../src/io-schema.ts";
 
 describe("I/O Schema and related helpers", () => {
   describe("IOSchema", () => {

--- a/express-zod-api/tests/json-schema-helpers.spec.ts
+++ b/express-zod-api/tests/json-schema-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { flattenIO } from "../src/json-schema-helpers";
+import { flattenIO } from "../src/json-schema-helpers.ts";
 
 describe("JSON Schema helpers", () => {
   describe("flattenIO()", () => {

--- a/express-zod-api/tests/last-resort.spec.ts
+++ b/express-zod-api/tests/last-resort.spec.ts
@@ -1,7 +1,7 @@
 import createHttpError, { HttpError } from "http-errors";
-import { ResultHandlerError } from "../src/errors";
-import { lastResortHandler } from "../src/last-resort";
-import { makeLoggerMock, makeResponseMock } from "../src/testing";
+import { ResultHandlerError } from "../src/errors.ts";
+import { lastResortHandler } from "../src/last-resort.ts";
+import { makeLoggerMock, makeResponseMock } from "../src/testing.ts";
 
 describe("Last Resort Handler", () => {
   test("should be a function", () => {

--- a/express-zod-api/tests/logger-helpers.spec.ts
+++ b/express-zod-api/tests/logger-helpers.spec.ts
@@ -1,5 +1,5 @@
-import { BuiltinLogger } from "../src";
-import { BuiltinLoggerConfig } from "../src/builtin-logger";
+import { BuiltinLogger } from "../src/index.ts";
+import { BuiltinLoggerConfig } from "../src/builtin-logger.ts";
 import {
   AbstractLogger,
   isLoggerInstance,
@@ -7,7 +7,7 @@ import {
   isHidden,
   makeNumberFormat,
   formatDuration,
-} from "../src/logger-helpers";
+} from "../src/logger-helpers.ts";
 
 describe("Logger helpers", () => {
   describe("isSeverity()", () => {

--- a/express-zod-api/tests/logical-container.spec.ts
+++ b/express-zod-api/tests/logical-container.spec.ts
@@ -1,4 +1,4 @@
-import { processContainers } from "../src/logical-container";
+import { processContainers } from "../src/logical-container.ts";
 
 describe("LogicalContainer", () => {
   describe("processContainers()", () => {

--- a/express-zod-api/tests/method.spec.ts
+++ b/express-zod-api/tests/method.spec.ts
@@ -7,7 +7,7 @@ import {
   ClientMethod,
   SomeMethod,
   CORSMethod,
-} from "../src/method";
+} from "../src/method.ts";
 
 describe("Method", () => {
   describe("SomeMethod type", () => {

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import { InputValidationError, Middleware } from "../src";
-import { AbstractMiddleware, ExpressMiddleware } from "../src/middleware";
+import { InputValidationError, Middleware } from "../src/index.ts";
+import { AbstractMiddleware, ExpressMiddleware } from "../src/middleware.ts";
 import {
   makeLoggerMock,
   makeRequestMock,
   makeResponseMock,
-} from "../src/testing";
+} from "../src/testing.ts";
 
 describe("Middleware", () => {
   describe("constructor()", () => {

--- a/express-zod-api/tests/peer-helpers.spec.ts
+++ b/express-zod-api/tests/peer-helpers.spec.ts
@@ -1,5 +1,5 @@
-import { MissingPeerError } from "../src";
-import { loadPeer } from "../src/peer-helpers";
+import { MissingPeerError } from "../src/index.ts";
+import { loadPeer } from "../src/peer-helpers.ts";
 
 describe("Peer loading helpers", () => {
   describe("loadPeer()", () => {

--- a/express-zod-api/tests/raw-schema.spec.ts
+++ b/express-zod-api/tests/raw-schema.spec.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { ez } from "../src";
+import { ez } from "../src/index.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { ezRawBrand } from "../src/raw-schema";
+import { ezRawBrand } from "../src/raw-schema.ts";
 
 describe("ez.raw()", () => {
   describe("creation", () => {

--- a/express-zod-api/tests/result-handler.spec.ts
+++ b/express-zod-api/tests/result-handler.spec.ts
@@ -6,14 +6,14 @@ import {
   arrayResultHandler,
   defaultResultHandler,
   ResultHandler,
-} from "../src";
-import { ResultHandlerError } from "../src/errors";
-import { AbstractResultHandler, Result } from "../src/result-handler";
+} from "../src/index.ts";
+import { ResultHandlerError } from "../src/errors.ts";
+import { AbstractResultHandler, Result } from "../src/result-handler.ts";
 import {
   makeLoggerMock,
   makeRequestMock,
   makeResponseMock,
-} from "../src/testing";
+} from "../src/testing.ts";
 
 describe("ResultHandler", () => {
   describe("constructor()", () => {

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -1,14 +1,14 @@
 import createHttpError from "http-errors";
 import { z } from "zod";
-import { InputValidationError, OutputValidationError } from "../src";
+import { InputValidationError, OutputValidationError } from "../src/index.ts";
 import {
   ensureHttpError,
   getPublicErrorMessage,
   logServerError,
   normalize,
   pullResponseExamples,
-} from "../src/result-helpers";
-import { makeLoggerMock, makeRequestMock } from "../src/testing";
+} from "../src/result-helpers.ts";
+import { makeLoggerMock, makeRequestMock } from "../src/testing.ts";
 
 describe("Result helpers", () => {
   describe("normalize()", () => {

--- a/express-zod-api/tests/routable.spec.ts
+++ b/express-zod-api/tests/routable.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defaultEndpointsFactory, DependsOnMethod } from "../src";
+import { defaultEndpointsFactory, DependsOnMethod } from "../src/index.ts";
 
 const endpoint = defaultEndpointsFactory.build({
   output: z.object({}),

--- a/express-zod-api/tests/routing.spec.ts
+++ b/express-zod-api/tests/routing.spec.ts
@@ -3,7 +3,7 @@ import {
   expressMock,
   staticHandler,
   staticMock,
-} from "./express-mock";
+} from "./express-mock.ts";
 import { z } from "zod";
 import {
   DependsOnMethod,
@@ -12,13 +12,13 @@ import {
   ServeStatic,
   defaultResultHandler,
   ez,
-} from "../src";
+} from "../src/index.ts";
 import {
   makeLoggerMock,
   makeRequestMock,
   makeResponseMock,
-} from "../src/testing";
-import { createWrongMethodHandler, initRouting } from "../src/routing";
+} from "../src/testing.ts";
+import { createWrongMethodHandler, initRouting } from "../src/routing.ts";
 import type { IRouter, RequestHandler } from "express";
 import createHttpError from "http-errors";
 

--- a/express-zod-api/tests/serve-static.spec.ts
+++ b/express-zod-api/tests/serve-static.spec.ts
@@ -1,5 +1,5 @@
-import { staticMock, staticHandler } from "./express-mock";
-import { ServeStatic } from "../src";
+import { staticMock, staticHandler } from "./express-mock.ts";
+import { ServeStatic } from "../src/index.ts";
 
 describe("ServeStatic", () => {
   describe("constructor()", () => {

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { fail } from "node:assert/strict";
-import { fileUploadMock } from "./express-mock";
+import { fileUploadMock } from "./express-mock.ts";
 import {
   createLoggingMiddleware,
   createNotFoundHandler,
@@ -12,14 +12,18 @@ import {
   installDeprecationListener,
   installTerminationListener,
   localsID,
-} from "../src/server-helpers";
-import { CommonConfig, defaultResultHandler, ResultHandler } from "../src";
+} from "../src/server-helpers.ts";
+import {
+  CommonConfig,
+  defaultResultHandler,
+  ResultHandler,
+} from "../src/index.ts";
 import { Request } from "express";
 import {
   makeLoggerMock,
   makeRequestMock,
   makeResponseMock,
-} from "../src/testing";
+} from "../src/testing.ts";
 import createHttpError from "http-errors";
 
 describe("Server helpers", () => {

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -1,5 +1,5 @@
-import { moveRaw } from "../src/server-helpers";
-import { givePort } from "../../tools/ports";
+import { moveRaw } from "../src/server-helpers.ts";
+import { givePort } from "../../tools/ports.ts";
 import {
   appMock,
   compressionMock,
@@ -7,12 +7,12 @@ import {
   expressUrlencodedMock,
   expressMock,
   expressRawMock,
-} from "./express-mock";
+} from "./express-mock.ts";
 import {
   createHttpsServerSpy,
   httpListenSpy,
   httpsListenSpy,
-} from "./http-mock";
+} from "./http-mock.ts";
 import { z } from "zod";
 import {
   AppConfig,
@@ -23,7 +23,7 @@ import {
   createServer,
   defaultResultHandler,
   ez,
-} from "../src";
+} from "../src/index.ts";
 import express from "express";
 
 describe("Server", () => {

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -7,7 +7,7 @@ import {
   testMiddleware,
   EventStreamFactory,
   EndpointsFactory,
-} from "../src";
+} from "../src/index.ts";
 import {
   Emitter,
   ensureStream,
@@ -15,13 +15,13 @@ import {
   makeEventSchema,
   makeMiddleware,
   makeResultHandler,
-} from "../src/sse";
+} from "../src/sse.ts";
 import {
   makeLoggerMock,
   makeRequestMock,
   makeResponseMock,
-} from "../src/testing";
-import { AbstractEndpoint } from "../src/endpoint";
+} from "../src/testing.ts";
+import { AbstractEndpoint } from "../src/endpoint.ts";
 
 describe("SSE", () => {
   describe("makeEventSchema()", () => {

--- a/express-zod-api/tests/startup-logo.spec.ts
+++ b/express-zod-api/tests/startup-logo.spec.ts
@@ -1,5 +1,5 @@
 import { WriteStream } from "node:tty";
-import { printStartupLogo } from "../src/startup-logo";
+import { printStartupLogo } from "../src/startup-logo.ts";
 
 describe("Startup logo", () => {
   describe("printStartupLogo()", () => {

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -13,8 +13,8 @@ import {
   BuiltinLogger,
   Middleware,
   ez,
-} from "../src";
-import { givePort } from "../../tools/ports";
+} from "../src/index.ts";
+import { givePort } from "../../tools/ports.ts";
 import { setTimeout } from "node:timers/promises";
 
 describe("App in production mode", async () => {

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -6,7 +6,7 @@ import {
   ResultHandler,
   testEndpoint,
   testMiddleware,
-} from "../src";
+} from "../src/index.ts";
 import type { Mock } from "vitest";
 
 describe("Testing", () => {

--- a/express-zod-api/tests/upload-schema.spec.ts
+++ b/express-zod-api/tests/upload-schema.spec.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { ez } from "../src";
+import { ez } from "../src/index.ts";
 import { getBrand } from "@express-zod-api/zod-plugin";
-import { ezUploadBrand } from "../src/upload-schema";
+import { ezUploadBrand } from "../src/upload-schema.ts";
 
 describe("ez.upload()", () => {
   describe("creation", () => {

--- a/express-zod-api/tests/zts.spec.ts
+++ b/express-zod-api/tests/zts.spec.ts
@@ -1,9 +1,9 @@
 import ts from "typescript";
 import { z } from "zod";
-import { ez } from "../src";
-import { f, printNode } from "../src/typescript-api";
-import { zodToTs } from "../src/zts";
-import { ZTSContext } from "../src/zts-helpers";
+import { ez } from "../src/index.ts";
+import { f, printNode } from "../src/typescript-api.ts";
+import { zodToTs } from "../src/zts.ts";
+import { ZTSContext } from "../src/zts-helpers.ts";
 
 describe("zod-to-ts", () => {
   const printNodeTest = (node: ts.Node) =>

--- a/express-zod-api/tsconfig.json
+++ b/express-zod-api/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "stripInternal": true
   },

--- a/express-zod-api/tsconfig.json
+++ b/express-zod-api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "stripInternal": true
   },
   "include": [

--- a/express-zod-api/tsdown.config.ts
+++ b/express-zod-api/tsdown.config.ts
@@ -1,14 +1,12 @@
 import { defineConfig } from "tsdown";
-import { readFile } from "node:fs/promises";
-
-const { version } = JSON.parse(await readFile("./package.json", "utf8"));
+import manifest from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: "src/index.ts",
   minify: true,
   attw: { profile: "esmOnly", level: "error" },
   define: {
-    "process.env.TSDOWN_BUILD": `"v${version}"`, // @since v25.0.0 is pure ESM
+    "process.env.TSDOWN_BUILD": `"v${manifest.version}"`, // @since v25.0.0 is pure ESM
     "process.env.TSDOWN_STATIC": `"static"`, // used by isProduction()
   },
 });

--- a/express-zod-api/tsdown.config.ts
+++ b/express-zod-api/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   minify: true,
   attw: { profile: "esmOnly", level: "error" },
   define: {
+    "process.env.TSDOWN_SELF": `"${manifest.name}"`, // used by localsID
     "process.env.TSDOWN_BUILD": `"v${manifest.version}"`, // @since v25.0.0 is pure ESM
     "process.env.TSDOWN_STATIC": `"static"`, // used by isProduction()
   },

--- a/express-zod-api/vitest.setup.ts
+++ b/express-zod-api/vitest.setup.ts
@@ -1,7 +1,7 @@
 import { getBrand } from "@express-zod-api/zod-plugin";
 import type { NewPlugin } from "@vitest/pretty-format";
 import { z } from "zod";
-import { ResultHandlerError } from "./src/errors";
+import { ResultHandlerError } from "./src/errors.ts";
 
 /** Takes cause and certain props of custom errors into account */
 const errorSerializer: NewPlugin = {

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -1,7 +1,7 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import migration from "./index";
+import migration from "./index.ts";
 import parser from "@typescript-eslint/parser";
-import { version } from "./package.json";
+import manifest from "./package.json" with { type: "json" };
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
@@ -13,7 +13,9 @@ const tester = new RuleTester({
 
 describe("Migration", () => {
   test("should consist of one rule being the major version of the package", () => {
-    expect(migration.rules).toHaveProperty(`v${version.split(".")[0]}`);
+    expect(migration.rules).toHaveProperty(
+      `v${manifest.version.split(".")[0]}`,
+    );
     expect(migration).toMatchSnapshot();
   });
 

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -11,8 +11,8 @@ const tester = new RuleTester({
   languageOptions: { parser },
 });
 
-const ruleName =
-  `v${manifest.version.split(".")[0]}` as keyof typeof migration.rules;
+const ruleName = `v${manifest.version.split(".")[0]}`;
+const theRule = migration.rules[ruleName as keyof typeof migration.rules];
 
 describe("Migration", () => {
   test("should consist of one rule being the major version of the package", () => {
@@ -20,7 +20,7 @@ describe("Migration", () => {
     expect(migration).toMatchSnapshot();
   });
 
-  tester.run(ruleName, migration.rules[ruleName], {
+  tester.run(ruleName, theRule, {
     valid: [
       `import {} from "zod";`,
       `ez.dateIn({ examples: ["1963-04-21"] });`,

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -11,15 +11,16 @@ const tester = new RuleTester({
   languageOptions: { parser },
 });
 
+const ruleName =
+  `v${manifest.version.split(".")[0]}` as keyof typeof migration.rules;
+
 describe("Migration", () => {
   test("should consist of one rule being the major version of the package", () => {
-    expect(migration.rules).toHaveProperty(
-      `v${manifest.version.split(".")[0]}`,
-    );
+    expect(migration.rules).toHaveProperty(ruleName);
     expect(migration).toMatchSnapshot();
   });
 
-  tester.run("v25", migration.rules.v25, {
+  tester.run(ruleName, migration.rules[ruleName], {
     valid: [
       `import {} from "zod";`,
       `ez.dateIn({ examples: ["1963-04-21"] });`,

--- a/migration/tsconfig.json
+++ b/migration/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "resolveJsonModule": true
-  }
+  "extends": "../tsconfig.json"
 }

--- a/migration/tsconfig.json
+++ b/migration/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
     "resolveJsonModule": true
   }
 }

--- a/tools/license.ts
+++ b/tools/license.ts
@@ -1,5 +1,5 @@
 import { writeFile } from "node:fs/promises";
-import manifest from "../express-zod-api/package.json";
+import manifest from "../express-zod-api/package.json" with { type: "json" };
 
 const text = `
 MIT License

--- a/tools/make-tests.ts
+++ b/tools/make-tests.ts
@@ -16,7 +16,7 @@ const extractQuickStartFromReadme = async () => {
 
 const quickStart = await extractQuickStartFromReadme();
 const program = `
-import { givePort } from "../tools/ports";
+import { givePort } from "../tools/ports.ts";
 ${quickStart}
 `;
 

--- a/tools/make-tests.ts
+++ b/tools/make-tests.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile, writeFile } from "node:fs/promises";
-import { givePort } from "./ports";
+import { givePort } from "./ports.ts";
 
 const extractQuickStartFromReadme = async () => {
   const readme = await readFile("README.md", "utf-8");

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../tsconfig.json"
-}

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "resolveJsonModule": true
-  }
+  "extends": "../tsconfig.json"
 }

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
     "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
+    "module": "node20",
+    "target": "es2023",
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "noUncheckedSideEffectImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true,
     "types": ["vitest/globals"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "node20",
     "target": "es2023",
+    "allowImportingTsExtensions": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "noUncheckedSideEffectImports": true,

--- a/zod-plugin/src/augmentation.ts
+++ b/zod-plugin/src/augmentation.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { Intact, Remap } from "./remap";
+import type { Intact, Remap } from "./remap.ts";
 
 declare module "zod/v4/core" {
   interface GlobalMeta {

--- a/zod-plugin/src/brand.ts
+++ b/zod-plugin/src/brand.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { pack, unpack } from "./packer";
+import { pack, unpack } from "./packer.ts";
 
 /** The property within schema._zod.bag where we store the brand */
 export const brandProperty = "brand" as const;

--- a/zod-plugin/src/index.ts
+++ b/zod-plugin/src/index.ts
@@ -1,3 +1,3 @@
-import "./runtime"; // side effects here
-export { pack, unpack } from "./packer";
-export { getBrand } from "./brand";
+import "./runtime.ts"; // side effects here
+export { pack, unpack } from "./packer.ts";
+export { getBrand } from "./brand.ts";

--- a/zod-plugin/src/runtime.ts
+++ b/zod-plugin/src/runtime.ts
@@ -1,5 +1,4 @@
 import { globalRegistry, z } from "zod";
-import manifest from "../package.json" with { type: "json" };
 import { setBrand } from "./brand.ts";
 import { remap } from "./remap.ts";
 
@@ -17,7 +16,8 @@ const labelSetter = function (this: z.ZodDefault, defaultLabel: string) {
   return this.meta({ default: defaultLabel });
 };
 
-const pluginFlag = Symbol.for(manifest.name);
+// eslint-disable-next-line no-restricted-syntax -- substituted by TSDOWN
+const pluginFlag = Symbol.for(process.env.TSDOWN_SELF!);
 
 if (!(pluginFlag in globalThis)) {
   (globalThis as Record<symbol, unknown>)[pluginFlag] = true;

--- a/zod-plugin/src/runtime.ts
+++ b/zod-plugin/src/runtime.ts
@@ -1,7 +1,7 @@
 import { globalRegistry, z } from "zod";
-import { name } from "../package.json";
-import { setBrand } from "./brand";
-import { remap } from "./remap";
+import manifest from "../package.json" with { type: "json" };
+import { setBrand } from "./brand.ts";
+import { remap } from "./remap.ts";
 
 const exampleSetter = function (this: z.ZodType, value: z.output<typeof this>) {
   const examples = globalRegistry.get(this)?.examples?.slice() || [];
@@ -17,7 +17,7 @@ const labelSetter = function (this: z.ZodDefault, defaultLabel: string) {
   return this.meta({ default: defaultLabel });
 };
 
-const pluginFlag = Symbol.for(name);
+const pluginFlag = Symbol.for(manifest.name);
 
 if (!(pluginFlag in globalThis)) {
   (globalThis as Record<symbol, unknown>)[pluginFlag] = true;

--- a/zod-plugin/tests/brand.spec.ts
+++ b/zod-plugin/tests/brand.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { brandProperty, getBrand, setBrand } from "../src/brand";
-import * as packer from "../src/packer";
+import { brandProperty, getBrand, setBrand } from "../src/brand.ts";
+import * as packer from "../src/packer.ts";
 
 describe("Brand", () => {
   describe("brandProperty", () => {

--- a/zod-plugin/tests/index.spec.ts
+++ b/zod-plugin/tests/index.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import * as entrypoint from "../src";
+import * as entrypoint from "../src/index.ts";
 
 describe("Entrypoint", () => {
   test("Augmentation", () => {

--- a/zod-plugin/tests/packer.spec.ts
+++ b/zod-plugin/tests/packer.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { pack, unpack } from "../src";
+import { pack, unpack } from "../src/index.ts";
 
 describe("Packer", () => {
   describe("pack()", () => {

--- a/zod-plugin/tests/runtime.spec.ts
+++ b/zod-plugin/tests/runtime.spec.ts
@@ -1,6 +1,6 @@
 import camelize from "camelize-ts";
 import { z } from "zod";
-import { getBrand } from "../src";
+import { getBrand } from "../src/index.ts";
 
 describe("Zod Runtime Plugin", () => {
   describe(".example()", () => {

--- a/zod-plugin/tsconfig.json
+++ b/zod-plugin/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
     "resolveJsonModule": true
   },
   "exclude": ["dist"]

--- a/zod-plugin/tsconfig.json
+++ b/zod-plugin/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "resolveJsonModule": true
-  },
   "exclude": ["dist"]
 }

--- a/zod-plugin/tsdown.config.ts
+++ b/zod-plugin/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import manifest from "./package.json" with { type: "json" };
 
 export default defineConfig([
   {
@@ -7,6 +8,9 @@ export default defineConfig([
     attw: { profile: "esmOnly", level: "error" },
     banner: {
       dts: "import './augmentation.js';",
+    },
+    define: {
+      "process.env.TSDOWN_SELF": `"${manifest.name}"`, // used by pluginFlag
     },
   },
   {

--- a/zod-plugin/vitest.setup.ts
+++ b/zod-plugin/vitest.setup.ts
@@ -1,1 +1,1 @@
-import "./src/runtime";
+import "./src/runtime.ts";


### PR DESCRIPTION
`module: node20` introduced in Typescript 5.9 as a stable replacement for `nodenext`:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#support-for---module-node20

The recommended combination is with `moduleResolution: node16`:
https://github.com/microsoft/TypeScript/pull/61805

That change implies relative imports to have extensions, however, it's possible to change them directly to `.ts`, which will also reiterate and resolve #2289 . It will enable running typescript natively by Node.js without `tsx`. It may also come handy if I decide to publish to JSR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Project build and compiler settings standardized; JSON imports made explicit and some tooling switched to static JSON imports.
- Refactor
  - Internal module references normalized to explicit TypeScript entries; some runtime identifiers now derive from environment-provided build metadata.
- Tests
  - Test imports updated for explicit module resolution; migration tests expanded with additional valid cases.
- Style
  - New lint rules encourage .ts extensions for local imports and discourage direct package.json imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->