### PR TITLE
feat: exposing `BuildProps` and `Endpoint` type

### DIFF
--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -27,7 +27,7 @@ import {
   defaultResultHandler,
 } from "./result-handler.ts";
 
-interface BuildProps<
+export interface BuildProps<
   IN extends IOSchema,
   OUT extends IOSchema | z.ZodVoid,
   MIN extends IOSchema | undefined,

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -1,7 +1,9 @@
 import "@express-zod-api/zod-plugin"; // side effects here
 export { createConfig } from "./config-type.ts";
+export { type Endpoint } from "./endpoint.ts";
 export {
   EndpointsFactory,
+  type BuildProps,
   defaultEndpointsFactory,
   arrayEndpointsFactory,
 } from "./endpoints-factory.ts";


### PR DESCRIPTION
We could use these to write custom wrappers around `build`.

Feel free to modify this PR before merging etc, thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported `BuildProps` type for public use, allowing developers to access endpoint builder configuration types.
  * Exported `Endpoint` type for public use, enabling developers to reference endpoint type definitions directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->