### PR TITLE
Add engine restrictions to migration package

### DIFF
--- a/migration/package.json
+++ b/migration/package.json
@@ -34,6 +34,9 @@
     "dist",
     "*.md"
   ],
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || ^24.0.0"
+  },
   "peerDependencies": {
     "eslint": "^9.0.0",
     "typescript-eslint": "^8.0.0"


### PR DESCRIPTION
Need this for consistency and proper `tsdown` build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version compatibility requirements for the migration package to support versions ^20.19.0, ^22.12.0, and ^24.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->