### PR TITLE
No codegen-reference to `givePort` in tests

### DIFF
--- a/tools/make-tests.ts
+++ b/tools/make-tests.ts
@@ -14,19 +14,15 @@ const extractQuickStartFromReadme = async () => {
     .trim();
 };
 
-const quickStart = await extractQuickStartFromReadme();
-const program = `
-import { givePort } from "../tools/ports";
-${quickStart}
-`;
+const program = await extractQuickStartFromReadme();
 
 const examplePort = String(givePort("example"));
 
 const testContent = {
-  cjs: program.replace(examplePort, "givePort('cjs')"),
-  esm: program.replace(examplePort, "givePort('esm')"),
-  compat: program.replace(examplePort, "givePort('compat')"),
-  issue952: quickStart.replace(/const/g, "export const"),
+  cjs: program.replace(examplePort, String(givePort("cjs"))),
+  esm: program.replace(examplePort, String(givePort("esm"))),
+  compat: program.replace(examplePort, String(givePort("compat"))),
+  issue952: program.replace(/const/g, "export const"),
 };
 
 for (const testName in testContent) {


### PR DESCRIPTION
This should simplify CJS test without `tsx` and overall it's redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal test generation tooling by streamlining program assembly logic and updating test content mappings for consistency. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->