### PR TITLE
feat(zod-plugin): Add `x-brand` to the `GlobalMeta` augmentation

### DIFF
--- a/zod-plugin/CHANGELOG.md
+++ b/zod-plugin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 4
 
+### v4.1.0
+
+- Added `x-brand` type to the augmentation of Zod's `GlobalMeta` inteface:
+  - The property is used to store the brand of the schema when using the `ZodType::brand()` method.
+
 ### v4.0.1
 
 - Removed debug-level comments from the declaration files in the distribution.

--- a/zod-plugin/CHANGELOG.md
+++ b/zod-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.1.0
 
-- Added `x-brand` type to the augmentation of Zod's `GlobalMeta` inteface:
+- Added `x-brand` type to the augmentation of Zod's `GlobalMeta` interface:
   - The property is used to store the brand of the schema when using the `ZodType::brand()` method.
 
 ### v4.0.1

--- a/zod-plugin/src/augmentation.ts
+++ b/zod-plugin/src/augmentation.ts
@@ -1,10 +1,12 @@
 import type { z } from "zod";
 import type { Intact, Remap } from "./remap";
+import type { brandProperty } from "./brand";
 
 declare module "zod/v4/core" {
   interface GlobalMeta {
     default?: unknown; // can be an actual value or a label like "Today"
     examples?: unknown[]; // see zod commit ee5615d
+    [brandProperty]?: symbol | string | number;
   }
 }
 

--- a/zod-plugin/tests/index.spec.ts
+++ b/zod-plugin/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { globalRegistry, z } from "zod";
 import * as entrypoint from "../src";
 
 describe("Entrypoint", () => {
@@ -13,6 +13,18 @@ describe("Entrypoint", () => {
       .toHaveProperty("label")
       .toEqualTypeOf<(value: string) => z.ZodDefault<z.ZodString>>();
     expectTypeOf<z.ZodObject>().toHaveProperty("remap");
+    expectTypeOf<ReturnType<typeof globalRegistry.get>>()
+      .exclude(undefined)
+      .toHaveProperty("default")
+      .toEqualTypeOf<unknown | undefined>();
+    expectTypeOf<ReturnType<typeof globalRegistry.get>>()
+      .exclude(undefined)
+      .toHaveProperty("examples")
+      .toEqualTypeOf<unknown[] | undefined>();
+    expectTypeOf<ReturnType<typeof globalRegistry.get>>()
+      .exclude(undefined)
+      .toHaveProperty("x-brand")
+      .toEqualTypeOf<symbol | string | number | undefined>();
   });
 
   test("Exports", () => {


### PR DESCRIPTION
Found the lack of this feature while working on #3313 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema metadata now supports a brand property (symbol, string, or number) to record schema branding.

* **Tests**
  * Expanded type-level tests to validate the new brand metadata along with existing default and examples fields.

* **Documentation**
  * Changelog updated with a v4.1.0 entry describing the brand metadata support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->