### PR TITLE
fix: rm redundant `pullResponseExamples` call from `Endpoint::outputSchema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed performance regression since v24.0.0:
   - Removed unnecessary processing of output schema examples;
   - Those used to be processed when the first API request occurred on endpoint;
-  - Examples are only required for OpenAPI generators, not for runtime validation.
+  - Examples are only required for Documentation generator, not for runtime validation.
 
 ### v27.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 27
 
+### v27.2.4
+
+- Fixed performance regression since v24.4.0:
+  - Removed unnecessary `pullResponseExamples()` call in `outputSchema` getter;
+  - Examples are only required for OpenAPI generators, not for runtime validation.
+
 ### v27.2.3
 
 - Optimizing the performance of traverses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### v27.2.4
 
-- Fixed performance regression since v24.4.0:
-  - Removed unnecessary `pullResponseExamples()` call in `outputSchema` getter;
+- Fixed performance regression since v24.0.0:
+  - Removed unnecessary processing of output schema examples;
+  - Those used to be processed when the first API request occurred on endpoint;
   - Examples are only required for OpenAPI generators, not for runtime validation.
 
 ### v27.2.3

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -156,7 +156,6 @@ export class Endpoint<
 
   /** @internal */
   public override get outputSchema(): OUT {
-    this.#ensureOutputExamples();
     return this.#def.outputSchema;
   }
 


### PR DESCRIPTION
Performance regression since v24.0.0 - the `outputSchema` getter was calling the expensive `pullResponseExamples()` operation on first access (R.once protected), even though examples are only needed for OpenAPI documentation generation (getResponses).

This fixes the issue where simply accessing the output schema for runtime validation was unnecessarily triggering example generation.

first introduced by #2666 
merged by #2546 
found this during my work on #3344 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request performance by deferring output schema example processing; examples are now generated only when needed for documentation/OpenAPI workflows, not during initial request handling.

* **Documentation**
  * Added changelog entry v27.2.4 documenting the change in example processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->