### PR TITLE
FIX(deps): Reducing compatibility with Zod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Limited Zod compatibility to `~4.3.4` (<4.4.0):
   - Zod 4.4.0 introduced a breaking change to how `brand` method works, making the current plugin approach incompatible;
   - `@express-zod-api/zod-plugin` version bumped to `^4.1.1` (limited Zod compatibility as well);
-  - Supporting Zod 4.4+ requires a breaking change and will be addressed in v28 (next major version);
+  - Supporting Zod 4.4+ requires a breaking change and will be addressed in v28 (next major version).
 
 ### v27.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 27
 
+### v27.2.6
+
+- Limited Zod compatibility to `~4.3.4` (<4.4.0):
+  - Zod 4.4.0 introduced a breaking change to how `brand` method works, making the current plugin approach incompatible;
+  - `@express-zod-api/zod-plugin` version bumped to `^4.1.1` (limited Zod compatibility as well);
+  - Supporting Zod 4.4+ requires a breaking change and will be addressed in v28 (next major version);
+
 ### v27.2.5
 
 - Reduced memory footprint at runtime: deferred population of well-known headers to Documentation;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ catalogs:
       specifier: ^8.51.0
       version: 8.55.0
     zod:
-      specifier: ^4.3.4
+      specifier: ~4.3.4
       version: 4.3.6
   prod:
     ramda:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalogs:
   prod:
     "ramda": "^0.32.0"
   peer:
-    "zod": "^4.3.4"
+    "zod": "~4.3.4"
   dev:
     "@types/compression": "^1.8.1"
     "@types/express": "^5.0.6"
@@ -66,7 +66,7 @@ catalogs:
     "http-errors": "^2.0.1"
     "typescript": "^6.0.2"
     "typescript-eslint": "^8.51.0"
-    "zod": "^4.3.4"
+    "zod": "~4.3.4"
 overrides:
   "@scarf/scarf": "-"
   "lightningcss": "-"

--- a/zod-plugin/CHANGELOG.md
+++ b/zod-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 4
 
+### v4.1.1
+
+- Limited compatibility to Zod versions `~4.3.4` (<4.4.0):
+  - Zod 4.4.0 introduced a breaking change to how `brand` method works, making the current plugin approach incompatible;
+  - Support for Zod 4.4+ will be added in v5 (the next major version).
+
 ### v4.1.0
 
 - Added `x-brand` type to the augmentation of Zod's `GlobalMeta` interface:

--- a/zod-plugin/README.md
+++ b/zod-plugin/README.md
@@ -18,7 +18,8 @@ This module extends Zod functionality when it's imported:
 
 ## Requirements
 
-- Zod `^4.3.4`
+- Compatible with Zod versions `~4.3.4` (<4.4.0);
+- Zod 4.4+ support will be available in v5 (the next major version).
 
 ## Basic usage
 


### PR DESCRIPTION
4.4 will be supported in #3208 
due to Zod's breaking changes revaled in #3355 
see https://github.com/RobinTail/express-zod-api/pull/3355#issuecomment-4350845092 for details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Zod compatibility: support limited to versions below 4.4.0 due to upstream behavior changes; note that broader Zod 4.4+ support will be delivered in a future major release.

* **Chores**
  * Tightened dependency version constraints across packages and updated release notes and README to enforce the stated Zod compatibility boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->