### PR TITLE
fix(deps): Reducing Zod compatibility for v26

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master, v22, v23, v24, v25 ]
+    branches: [ master, v26 ]
   pull_request:
-    branches: [ master, v22, v23, v24, v25 ]
+    branches: [ master, v26 ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 26
 
+### v26.3.4
+
+- Limited Zod compatibility to `>=4.1.13 <4.4.0`:
+  - Zod 4.4.0 introduced a breaking change to how `brand` method works, making the current plugin approach incompatible;
+  - Supporting Zod 4.4+ requires a breaking change and will be addressed in v28.
+
 ### v26.3.3
 
 - Fixed performance regression since v24.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ catalogs:
       specifier: ^8.51.0
       version: 8.54.0
     zod:
-      specifier: ^4.3.4
+      specifier: ~4.3.4
       version: 4.3.6
   prod:
     ramda:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalogs:
   prod:
     "ramda": "^0.32.0"
   peer:
-    "zod": "^4.1.13"
+    "zod": ">=4.1.13 <4.4.0"
   dev:
     "@types/compression": "^1.8.1"
     "@types/express": "^5.0.6"
@@ -66,6 +66,6 @@ catalogs:
     "http-errors": "^2.0.1"
     "typescript": "^5.9.3"
     "typescript-eslint": "^8.51.0"
-    "zod": "^4.3.4"
+    "zod": "~4.3.4"
 overrides:
   "@scarf/scarf": "npm:empty-npm-package@1.0.0"

--- a/zod-plugin/CHANGELOG.md
+++ b/zod-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 3
 
+### v3.0.2
+
+- Limited compatibility to Zod versions `>=4.1.13 <4.4.0`:
+  - Zod 4.4.0 introduced a breaking change to how `brand` method works, making the current plugin approach incompatible;
+  - Support for Zod 4.4+ will be added in v5.
+
 ### v3.0.1
 
 - Improved readability of the types declaration in the bundle;

--- a/zod-plugin/README.md
+++ b/zod-plugin/README.md
@@ -18,7 +18,8 @@ This module extends Zod functionality when it's imported:
 
 ## Requirements
 
-- Zod `^4.1.13`
+- Compatible with Zod versions `>=4.1.13 <4.4.0`;
+- Zod 4.4+ support will be available in v5.
 
 ## Basic usage
 


### PR DESCRIPTION
cherry-picked 22d9b86184b01d871bbde0676ddb84c3390f9164, not supporting Zod 4.4, plugin 3.0.2, ez 26.3.4.
adapted copy of #3357 