### PR TITLE
chore(CI): Using pnpm 11.

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -45,9 +45,12 @@ jobs:
       - run: |
           pnpm install
           pnpm install_hooks
-      - name: Bump ${{inputs.workspace}}
+      - name: Bump ${{inputs.workspace}} ${{inputs.kind}}
+        working-directory: ${{inputs.workspace}}
         run: |
-          pnpm -F ${{inputs.workspace}} version ${{inputs.kind}} \
+          pnpm version ${{inputs.kind}} \
             ${{ startsWith(inputs.kind, 'pre') && '--preid beta' || '' }} \
             --tag-version-prefix=${{inputs.workspace}}-v \
             --message='${{inputs.workspace}} version %s'
+      - name: Push commit and tag
+        run: git push --follow-tags

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -34,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # for git describe --tags (used by bumpp internally)
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -45,9 +45,9 @@ jobs:
       - run: |
           pnpm install
           pnpm install_hooks
-      - name: Bumpp ${{inputs.workspace}}
+      - name: Bump ${{inputs.workspace}}
         run: |
-          pnpm -F ${{inputs.workspace}} exec \
-            pnpm dlx bumpp@10 ${{inputs.kind}} \
+          pnpm -F ${{inputs.workspace}} version ${{inputs.kind}} \
             ${{ startsWith(inputs.kind, 'pre') && '--preid beta' || '' }} \
-            --tag=${{inputs.workspace}}-v%s --commit='${{inputs.workspace}} version %s' -y
+            --tag-version-prefix=${{inputs.workspace}}-v \
+            --message='${{inputs.workspace}} version %s'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,5 +40,5 @@ jobs:
         run: pnpm install
       - name: Publish ${{inputs.workspace}} with ${{ inputs.tag }}
         run: |
-          pnpm -F ${{inputs.workspace}} exec \
-            pnpm publish --provenance --tag ${{ inputs.tag }}
+          pnpm -F ${{inputs.workspace}} \
+            publish --provenance --tag ${{ inputs.tag }}

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-zod-api",
-  "version": "28.0.0",
+  "version": "28.0.1-beta.0",
   "description": "A Typescript framework to help you get an API server up and running with I/O schema validation and custom middlewares in minutes.",
   "license": "MIT",
   "repository": {

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -69,7 +69,7 @@ const listen = <
     {},
   );
 
-const ruleName = `v${process.env.TSDOWN_VERSION?.split(".")[0] ?? "0"}`; // fail-safe for bumpp
+const ruleName = `v${process.env.TSDOWN_VERSION?.split(".")[0]}`;
 
 const theRule = ESLintUtils.RuleCreator.withoutDocs({
   name: ruleName,

--- a/migration/package.json
+++ b/migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@express-zod-api/migration",
-  "version": "28.0.0",
+  "version": "28.0.1-beta.0",
   "license": "MIT",
   "description": "Migration scripts for express-zod-api",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "typescript-eslint": "catalog:dev",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38"
 }


### PR DESCRIPTION
instead of #3375 

- Node.js 22+ required — support for Node 18, 19, 20, and 21 is dropped, pnpm itself is now pure ESM, and the standalone exe requires glibc 2.27.
- Supply-chain protection on by default — minimumReleaseAge defaults to 1 day (newly published packages are not resolved for 24h) and blockExoticSubdeps defaults to true.
- Native publish flow — [pnpm publish](https://pnpm.io/11.x/cli/publish), [login](https://pnpm.io/11.x/cli/login), [logout](https://pnpm.io/11.x/cli/logout), [view](https://pnpm.io/11.x/cli/view), [deprecate](https://pnpm.io/11.x/cli/deprecate), [unpublish](https://pnpm.io/11.x/cli/unpublish), [dist-tag](https://pnpm.io/11.x/cli/dist-tag), and [version](https://pnpm.io/11.x/cli/version) no longer delegate to the npm CLI, and the remaining npm passthrough commands now throw "not implemented".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository package manager declaration to pnpm v11 to align tooling with current releases and integrity metadata.
  * Switched CI release workflow to use pnpm-based versioning, adjusted tag and pre-release handling, and added an explicit push step to publish commits and tags.
  * Bumped express-zod-api package version to 28.0.1-beta.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RobinTail/express-zod-api/pull/3385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->