### PR TITLE
exp: intake contract for ResultHandler

### DIFF
--- a/example/factories.ts
+++ b/example/factories.ts
@@ -32,13 +32,14 @@ export const cookieAssistedFactory = defaultEndpointsFactory.addMiddleware(
 /** @desc This factory sends the file as string located in the "data" property of the endpoint's output */
 export const fileSendingEndpointsFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: { schema: z.string(), mimeType: "image/svg+xml" },
+    positive: (output: z.ZodObject<{ data: z.ZodString }>) => ({
+      schema: output.shape.data,
+      mimeType: "image/svg+xml",
+    }),
     negative: { schema: z.string(), mimeType: "text/plain" },
     handler: ({ response, error, output }) => {
       if (error) return void response.status(400).send(error.message);
-      if ("data" in output && typeof output.data === "string")
-        response.type("svg").send(output.data);
-      else response.status(400).send("Data is missing");
+      response.type("svg").send(output.data);
     },
   }),
 );
@@ -46,20 +47,19 @@ export const fileSendingEndpointsFactory = new EndpointsFactory(
 /** @desc This one streams the file using the "filename" property of the endpoint's output */
 export const fileStreamingEndpointsFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: { schema: ez.buffer(), mimeType: "image/*" },
+    positive: ({}: z.ZodObject<{ filename: z.ZodString }>) => ({
+      schema: ez.buffer(),
+      mimeType: "image/*",
+    }),
     negative: { schema: z.string(), mimeType: "text/plain" },
     handler: async ({ response, error, output, request: { method } }) => {
       if (error) return void response.status(400).send(error.message);
-      if ("filename" in output && typeof output.filename === "string") {
-        const target = response.attachment(output.filename);
-        if (method === "HEAD") {
-          const { size } = await stat(output.filename);
-          return void target.set("Content-Length", `${size}`).end();
-        }
-        createReadStream(output.filename).pipe(target);
-      } else {
-        response.status(400).send("Filename is missing");
+      const target = response.attachment(output.filename);
+      if (method === "HEAD") {
+        const { size } = await stat(output.filename);
+        return void target.set("Content-Length", `${size}`).end();
       }
+      createReadStream(output.filename).pipe(target);
     },
   }),
 );

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -22,9 +22,10 @@ import {
   Middleware,
 } from "./middleware";
 import {
-  AbstractResultHandler,
+  type Result,
   arrayResultHandler,
   defaultResultHandler,
+  ResultHandler,
 } from "./result-handler";
 
 interface BuildProps<
@@ -73,10 +74,11 @@ export class EndpointsFactory<
   IN extends IOSchema | undefined = undefined,
   CTX extends FlatObject = EmptyObject,
   SCO extends string = string,
+  OUT extends IOSchema = IOSchema,
 > {
   protected schema = undefined as IN;
   protected middlewares: AbstractMiddleware[] = [];
-  constructor(protected resultHandler: AbstractResultHandler) {}
+  constructor(protected resultHandler: ResultHandler<Result, Result, OUT>) {}
 
   #extend<
     AIN extends IOSchema | undefined,
@@ -86,7 +88,8 @@ export class EndpointsFactory<
     const factory = new EndpointsFactory<
       Extension<IN, AIN>,
       (CTX extends EmptyObject ? RET : CTX) & RET,
-      SCO & ASCO
+      SCO & ASCO,
+      OUT
     >(this.resultHandler);
     factory.middlewares = this.middlewares.concat(middleware);
     factory.schema = ensureExtension(this.schema, middleware.schema);
@@ -121,7 +124,7 @@ export class EndpointsFactory<
     return this.#extend(new Middleware({ handler: getContext }));
   }
 
-  public build<BOUT extends IOSchema, BIN extends IOSchema = EmptySchema>({
+  public build<BOUT extends OUT, BIN extends IOSchema = EmptySchema>({
     input = emptySchema as unknown as BIN,
     output: outputSchema,
     operationId,
@@ -153,18 +156,20 @@ export class EndpointsFactory<
   }
 
   /** @desc shorthand for returning {} while having output schema z.object({}) */
-  public buildVoid<BIN extends IOSchema = EmptySchema>({
-    handler,
-    ...rest
-  }: Omit<BuildProps<BIN, z.ZodVoid, IN, CTX, SCO>, "output">) {
+  public buildVoid<BIN extends IOSchema = EmptySchema>(
+    ...args: EmptySchema extends OUT
+      ? [params: Omit<BuildProps<BIN, z.ZodVoid, IN, CTX, SCO>, "output">]
+      : never
+  ): Endpoint<FinalInputSchema<IN, BIN>, EmptySchema, CTX> {
+    const [{ handler, ...rest }] = args;
     return this.build({
       ...rest,
-      output: emptySchema,
+      output: emptySchema as unknown as OUT,
       handler: async (props) => {
         await handler(props);
-        return {};
+        return {} as unknown as z.input<OUT>;
       },
-    });
+    }) as unknown as Endpoint<FinalInputSchema<IN, BIN>, EmptySchema, CTX>;
   }
 }
 

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -155,13 +155,8 @@ globalRegistry.add(arrayNegativeSchema, {
  * @desc This handler expects your endpoint to have the property 'items' in the output object schema
  * */
 export const arrayResultHandler = new ResultHandler({
-  positive: (output) => {
-    const responseSchema =
-      output instanceof z.ZodObject &&
-      "items" in output.shape &&
-      output.shape.items instanceof z.ZodArray
-        ? output.shape.items
-        : z.array(z.any());
+  positive: (output: z.ZodObject<{ items: z.ZodArray<z.ZodTypeAny> }>) => {
+    const responseSchema = output.shape.items;
     if (getExamples(responseSchema).length) return responseSchema; // has examples on the items, or pull down:
     const examples = getExamples(output)
       .filter(

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -158,7 +158,7 @@ globalRegistry.add(arrayNegativeSchema, {
  * @desc This handler expects your endpoint to have the property 'items' in the output object schema
  * */
 export const arrayResultHandler = new ResultHandler({
-  positive: (output: z.ZodObject<{ items: z.ZodArray<z.ZodTypeAny> }>) => {
+  positive: (output: z.ZodObject<{ items: z.ZodArray<z.ZodType> }>) => {
     const responseSchema = output.shape.items;
     if (getExamples(responseSchema).length) return responseSchema; // has examples on the items, or pull down:
     const examples = getExamples(output)

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -19,8 +19,8 @@ import {
 } from "./result-helpers";
 import { getExamples } from "./metadata";
 
-type Handler<RES = unknown> = (
-  params: DiscriminatedResult & {
+type Handler<RES = unknown, OUT extends FlatObject = FlatObject> = (
+  params: DiscriminatedResult<OUT> & {
     /** null in case of failure to parse or to find the matching endpoint (error: not found) */
     input: FlatObject | null;
     /** can be empty: check presence of the required property using "in" operator */
@@ -68,9 +68,12 @@ export class ResultHandler<
     /** @desc A description of the API response in case of error (schema, status code, MIME type) */
     negative: NEG | LazyResult<NEG>;
     /** @desc The actual implementation to transmit the response in any case */
-    handler: Handler<z.output<ResultSchema<POS> | ResultSchema<NEG>>>;
+    handler: Handler<
+      z.output<ResultSchema<POS> | ResultSchema<NEG>>,
+      z.input<OUT> & FlatObject
+    >;
   }) {
-    super(params.handler);
+    super(params.handler as Handler);
     this.#positive = params.positive;
     this.#negative = params.negative;
   }

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -57,13 +57,14 @@ export abstract class AbstractResultHandler {
 export class ResultHandler<
   POS extends Result,
   NEG extends Result,
+  OUT extends IOSchema = IOSchema,
 > extends AbstractResultHandler {
-  readonly #positive: POS | LazyResult<POS, [IOSchema]>;
+  readonly #positive: POS | LazyResult<POS, [OUT]>;
   readonly #negative: NEG | LazyResult<NEG>;
 
   constructor(params: {
     /** @desc A description of the API response in case of success (schema, status code, MIME type) */
-    positive: POS | LazyResult<POS, [IOSchema]>;
+    positive: POS | LazyResult<POS, [OUT]>;
     /** @desc A description of the API response in case of error (schema, status code, MIME type) */
     negative: NEG | LazyResult<NEG>;
     /** @desc The actual implementation to transmit the response in any case */
@@ -75,7 +76,7 @@ export class ResultHandler<
   }
 
   /** @internal */
-  public override getPositiveResponse(output: IOSchema) {
+  public override getPositiveResponse(output: OUT) {
     return normalize(this.#positive, {
       variant: "positive",
       args: [output],

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -17,9 +17,9 @@ import { getExamples } from "./metadata";
 export type ResultSchema<R extends Result> =
   R extends Result<infer S> ? S : never;
 
-export type DiscriminatedResult =
+export type DiscriminatedResult<OUT extends FlatObject = FlatObject> =
   | {
-      output: FlatObject;
+      output: OUT;
       error: null;
     }
   | {

--- a/express-zod-api/tests/result-handler.spec.ts
+++ b/express-zod-api/tests/result-handler.spec.ts
@@ -215,18 +215,6 @@ describe("ResultHandler", () => {
   test("arrayResultHandler should fail when there is no items prop in the output", () => {
     const responseMock = makeResponseMock();
     const loggerMock = makeLoggerMock();
-    const positiveSchema = arrayResultHandler
-      .getPositiveResponse(
-        z
-          .object({ anything: z.number() })
-          .meta({ examples: [{ anything: 118 }] }),
-      )
-      .pop()?.schema;
-    expect(positiveSchema).toHaveProperty(["_zod", "def", "type"], "array");
-    expect(positiveSchema).toHaveProperty(
-      ["_zod", "def", "element", "_zod", "def", "type"],
-      "any",
-    );
     expect(() =>
       arrayResultHandler.execute({
         error: null,

--- a/plans/improve-rh-intake-contract.md
+++ b/plans/improve-rh-intake-contract.md
@@ -1,0 +1,235 @@
+# Improve ResultHandler Intake Contract
+
+## Problem
+
+There is a type gap between what output schema a `ResultHandler` expects (its "intake contract") and what `EndpointsFactory.build()` accepts:
+
+1. `ResultHandler` accepts `LazyResult<POS, [IOSchema]>` — the `positive` callback's `output` parameter is typed as the broad `IOSchema`, losing any constraints about what shape the handler actually needs.
+2. `EndpointsFactory` stores `resultHandler: AbstractResultHandler` — all generic type info from the specific `ResultHandler<POS, NEG>` is erased.
+3. `build()` accepts `output: BOUT extends IOSchema` — no link to what the result handler expects.
+
+As a result, at compile time you can pass any `IOSchema` to `arrayEndpointsFactory.build({ output: ... })`, even though `arrayResultHandler` will throw at runtime if the output lacks `items: ZodArray`. Same issue applies to custom handlers like `fileSendingEndpointsFactory` (expects `data`) and `fileStreamingEndpointsFactory` (expects `filename`).
+
+---
+
+## Guiding constraints
+
+- **`AbstractResultHandler` stays unchanged** — it remains abstract with the broadest definition (`getPositiveResponse(output: IOSchema)`), no type parameters added.
+- The `OUT` type parameter lives only on `ResultHandler` and propagates through `EndpointsFactory`.
+- **Non-breaking** for all existing code: default type parameter values preserve current behavior.
+
+---
+
+## Proposed Changes
+
+### Step 1: Add `OUT` type parameter to `ResultHandler`
+
+**File:** `express-zod-api/src/result-handler.ts`
+
+```typescript
+export class ResultHandler<
+  POS extends Result,
+  NEG extends Result,
+  OUT extends IOSchema = IOSchema,   // NEW — at the end to preserve type param order
+> extends AbstractResultHandler {
+  readonly #positive: POS | LazyResult<POS, [OUT]>;   // narrowed from [IOSchema]
+  readonly #negative: NEG | LazyResult<NEG>;
+
+  constructor(params: {
+    positive: POS | LazyResult<POS, [OUT]>;  // narrowed
+    negative: NEG | LazyResult<NEG>;
+    handler: Handler<z.output<ResultSchema<POS> | ResultSchema<NEG>>>;
+  }) {
+    super(params.handler);
+    this.#positive = params.positive;
+    this.#negative = params.negative;
+  }
+
+  public override getPositiveResponse(output: OUT) {  // narrowed from IOSchema
+    return normalize(this.#positive, {
+      variant: "positive",
+      args: [output],
+      statusCodes: [defaultStatusCodes.positive],
+      mimeTypes: [contentTypes.json],
+    });
+  }
+
+  public override getNegativeResponse() {
+    return normalize(this.#negative, { ... });
+  }
+}
+```
+
+**Key insight:** The `positive` callback's parameter is now `OUT`. When a user annotates it (e.g., `(output: z.ZodObject<{ items: z.ZodArray<...> }>) => ...`), TypeScript infers `OUT` automatically from the constructor call.
+
+`OUT` sits at the end so existing explicit type annotations like `ResultHandler<SomePos, SomeNeg>` continue to work (defaults to `IOSchema`).
+
+`AbstractResultHandler` is not touched — it stays parameterless. The override `getPositiveResponse(output: OUT)` is valid because `OUT extends IOSchema` satisfies the base method signature.
+
+---
+
+### Step 2: Change `EndpointsFactory` constructor to accept `ResultHandler` and add `OUT` type param
+
+**File:** `express-zod-api/src/endpoints-factory.ts`
+
+```typescript
+export class EndpointsFactory<
+  IN extends IOSchema | undefined = undefined,
+  CTX extends FlatObject = EmptyObject,
+  SCO extends string = string,
+  OUT extends IOSchema = IOSchema,   // NEW — at the end, defaults to IOSchema
+> {
+  protected schema = undefined as IN;
+  protected middlewares: AbstractMiddleware[] = [];
+  // Accept the more specific ResultHandler instead of AbstractResultHandler
+  constructor(protected resultHandler: ResultHandler<Result, Result, OUT>) {}
+
+  #extend<
+    AIN extends IOSchema | undefined,
+    RET extends FlatObject,
+    ASCO extends string,
+  >(middleware: Middleware<CTX, RET, ASCO, AIN>) {
+    const factory = new EndpointsFactory<
+      Extension<IN, AIN>,
+      (CTX extends EmptyObject ? RET : CTX) & RET,
+      SCO & ASCO,
+      OUT       // propagate the constraint through the chain
+    >(this.resultHandler);
+    factory.middlewares = this.middlewares.concat(middleware);
+    factory.schema = ensureExtension(this.schema, middleware.schema);
+    return factory;
+  }
+
+  // addMiddleware, addExpressMiddleware, addContext, use — same propagation pattern
+
+  public build<BOUT extends OUT, BIN extends IOSchema = EmptySchema>({
+    input = emptySchema as unknown as BIN,
+    output: outputSchema,
+    ...
+  }: BuildProps<BIN, BOUT, IN, CTX, SCO>) {
+    // BOUT now constrained by OUT from the ResultHandler
+  }
+}
+```
+
+**This is the core payoff:** `BOUT extends OUT` in `build()` means the output schema must satisfy the constraint the result handler expects. For the default handler (`OUT = IOSchema`), no extra narrowing. For `arrayResultHandler` with a narrowed `OUT`, `build()` rejects output schemas missing `items`.
+
+The constructor accepts `ResultHandler<Result, Result, OUT>` and infers `OUT`. `POS` and `NEG` are not exposed as factory type params — only `OUT` matters for the build constraint.
+
+**Implementation detail:** Where `Endpoint` is constructed inside `build()`, `resultHandler` is passed as `ResultHandler<Result, Result, OUT>` which satisfies `Endpoint`'s constructor parameter type `AbstractResultHandler` (by inheritance).
+
+All `add*` and `#extend` methods propagate `OUT` unchanged. `buildVoid` delegates to `build`, inheriting the constraint automatically.
+
+---
+
+### Step 3: Update `arrayResultHandler` with narrowed type
+
+**File:** `express-zod-api/src/result-handler.ts`
+
+```typescript
+export const arrayResultHandler = new ResultHandler({
+  positive: (output: z.ZodObject<{ items: z.ZodArray<z.ZodTypeAny> }>) => {
+    const responseSchema = output.shape.items;
+    const examples = getExamples(responseSchema);
+    if (examples.length) return responseSchema;
+    const parentExamples = getExamples(output)
+      .filter(
+        (example): example is { items: unknown[] } =>
+          isObject(example) &&
+          "items" in example &&
+          Array.isArray(example.items),
+      )
+      .map((example) => example.items);
+    if (parentExamples?.length) {
+      const current = responseSchema.meta();
+      globalRegistry
+        .remove(responseSchema)
+        .add(responseSchema, { ...current, examples: parentExamples });
+    }
+    return responseSchema;
+  },
+  negative: { schema: arrayNegativeSchema, mimeType: "text/plain" },
+  handler: ({ response, output, error, logger, request, input }) => {
+    // runtime checks remain as defense-in-depth
+    if (error) { ... }
+    if ("items" in output && Array.isArray(output.items)) {
+      return void response.status(defaultStatusCodes.positive).json(output.items);
+    }
+    throw new Error("Property 'items' is missing in the endpoint output");
+  },
+});
+```
+
+The `positive` callback now has an explicit parameter type, so TypeScript infers `OUT = z.ZodObject<{ items: z.ZodArray<z.ZodTypeAny> }>`. The fallback `z.array(z.any())` is removed because the type now guarantees the schema shape.
+
+**Backwards compatibility:** Code using `arrayEndpointsFactory.build()` with an output schema lacking `items` will now get a compile-time error instead of a runtime crash. This is a positive breakage — it surfaces latent bugs.
+
+---
+
+### Step 4: Add `createResultHandler` helper (optional)
+
+**File:** `express-zod-api/src/result-handler.ts`
+
+```typescript
+export function createResultHandler<
+  POS extends Result,
+  NEG extends Result,
+  OUT extends IOSchema,
+>(params: {
+  positive: POS | LazyResult<POS, [OUT]>;
+  negative: NEG | LazyResult<NEG>;
+  handler: Handler<z.output<ResultSchema<POS> | ResultSchema<NEG>>>;
+}): ResultHandler<POS, NEG, OUT> {
+  return new ResultHandler(params);
+}
+```
+
+**Purpose:** Factory-function style. TypeScript infers `OUT` from the callback parameter annotation identically to the constructor approach. Not strictly required.
+
+---
+
+## What does NOT change
+
+| Module | Reason |
+|--------|--------|
+| `AbstractResultHandler` | Stays as-is: no type params, `getPositiveResponse(output: IOSchema)` |
+| `ResultSchema<R>`, `DiscriminatedResult`, `normalize()` | Pure runtime or unrelated |
+| `Endpoint` class | Constructor still accepts `AbstractResultHandler` |
+| `Endpoint.execute()` runtime logic | Unchanged |
+| Public API exports (`index.ts`) | No symbol removal |
+| Generators (`Integration`, `Documentation`) | Consume `NormalizedResponse[]` |
+| `example/` directory factories | Won't narrow unless/until annotated |
+
+---
+
+## Migration considerations
+
+### External code creating `ResultHandler` instances
+
+All existing `new ResultHandler({...})` calls continue to compile because `OUT` defaults to `IOSchema`. Users opt in by annotating the `positive` callback parameter.
+
+### External code passing custom `AbstractResultHandler` to `EndpointsFactory`
+
+This is the only real breaking change: `EndpointsFactory` constructor now requires `ResultHandler` instead of `AbstractResultHandler`. In practice, all usage passes `ResultHandler` instances (confirmed in codebase: zero direct `AbstractResultHandler` subclasses exist). Migration for hypothetical code:
+
+```typescript
+// Before (only if someone subclassed AbstractResultHandler directly):
+class MyHandler extends AbstractResultHandler { ... }
+new EndpointsFactory(new MyHandler());
+
+// After: wrap in ResultHandler or extend ResultHandler instead
+class MyHandler extends ResultHandler<...> { ... }
+```
+
+### External code referencing `EndpointsFactory` type params
+
+`EndpointsFactory<IN, CTX, SCO>` (3 params) continues to work. The 4th parameter `OUT` is optional and defaults to `IOSchema`.
+
+---
+
+## Verification
+
+1. All existing tests pass without modification (`OUT = IOSchema` preserves behavior).
+2. New compile-time test: `arrayEndpointsFactory.build({ output: z.object({ foo: z.string() }), handler: ... })` produces a type error.
+3. New compile-time test: `arrayEndpointsFactory.build({ output: z.object({ items: z.array(z.string()) }), handler: ... })` compiles.
+4. Runtime tests for `arrayResultHandler` continue to pass.

--- a/plans/improve-rh-intake-contract.md
+++ b/plans/improve-rh-intake-contract.md
@@ -190,15 +190,15 @@ export function createResultHandler<
 
 ## What does NOT change
 
-| Module | Reason |
-|--------|--------|
-| `AbstractResultHandler` | Stays as-is: no type params, `getPositiveResponse(output: IOSchema)` |
-| `ResultSchema<R>`, `DiscriminatedResult`, `normalize()` | Pure runtime or unrelated |
-| `Endpoint` class | Constructor still accepts `AbstractResultHandler` |
-| `Endpoint.execute()` runtime logic | Unchanged |
-| Public API exports (`index.ts`) | No symbol removal |
-| Generators (`Integration`, `Documentation`) | Consume `NormalizedResponse[]` |
-| `example/` directory factories | Won't narrow unless/until annotated |
+| Module                                                  | Reason                                                               |
+| ------------------------------------------------------- | -------------------------------------------------------------------- |
+| `AbstractResultHandler`                                 | Stays as-is: no type params, `getPositiveResponse(output: IOSchema)` |
+| `ResultSchema<R>`, `DiscriminatedResult`, `normalize()` | Pure runtime or unrelated                                            |
+| `Endpoint` class                                        | Constructor still accepts `AbstractResultHandler`                    |
+| `Endpoint.execute()` runtime logic                      | Unchanged                                                            |
+| Public API exports (`index.ts`)                         | No symbol removal                                                    |
+| Generators (`Integration`, `Documentation`)             | Consume `NormalizedResponse[]`                                       |
+| `example/` directory factories                          | Won't narrow unless/until annotated                                  |
 
 ---
 


### PR DESCRIPTION
Exploring the DX trade-off between the requirement for ResultHandler to handle any object-based `output` coming from Endpoints, or giving an ability to enforce type-only contract between ResultHandler and Endpoint through EndpointsFactory.

The POC looks promising except the `EndpointsFactory::buildVoid()` method that stands out of the concept.

The risk of possible temptation to abuse the type-only contract and remove runtime checks completely may compromise the stability of final products. Therefore, it's still under consideration.