### PR TITLE
fix(test): rm duplicated test.

### DIFF
--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -156,26 +156,6 @@ describe("Endpoint", () => {
       expect(responseMock._getStatusCode()).toBe(500);
       expect(responseMock._getJSONData()).toMatchSnapshot();
     });
-
-    test("Should throw on output parsing non-Zod error", async () => {
-      const factory = new EndpointsFactory(defaultResultHandler);
-      const endpoint = factory.build({
-        method: "post",
-        output: z.object({
-          test: z.number().transform(() => assert.fail("Something unexpected")),
-        }),
-        handler: async () => ({
-          test: 123,
-        }),
-      });
-      const { responseMock, loggerMock } = await testEndpoint({ endpoint });
-      expect(loggerMock._getLogs().error).toHaveLength(1);
-      expect(responseMock._getStatusCode()).toBe(500);
-      expect(responseMock._getJSONData()).toEqual({
-        status: "error",
-        error: { message: "Something unexpected" },
-      });
-    });
   });
 
   describe("#runMiddlewares", () => {


### PR DESCRIPTION
it's exactly the same as the one on the line 434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined the output parsing test suite by removing a test case, improving maintainability while preserving focus on core validation failure detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RobinTail/express-zod-api/pull/3423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->