### PR TITLE
feat: The factory shorthand methods for cache and cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
     - `setExpires()` — sets the `Expires` response header;
     - `clearSiteData()` — sets the `Clear-Site-Data` header with `cache` directive;
     - `notModified()` — sends an HTTP 304 response and ends the stream;
-- Adjusted the Endpoint execution to skip output validation in case `response.writableEnded` (`notModified` called).
+- Adjusted the Endpoint execution to skip output validation in case `response.writableEnded` (`notModified` called);
+- Added two shorthand methods to `EndpointsFactory` class: `useCache()` and `useCookies()`.
 
 ### v28.1.1
 

--- a/README.md
+++ b/README.md
@@ -843,9 +843,7 @@ as well as `getCookie()` — alternative to the cookies as an input source:
 import { createCookieMiddleware, Middleware } from "express-zod-api";
 
 const cookieDrivenFactory = factory
-  .addMiddleware(
-    createCookieMiddleware({ httpOnly: true, sameSite: "lax", path: "/" }), // recommended base options
-  )
+  .useCookies({ httpOnly: true, sameSite: "lax", path: "/" }) // shorthand, recommended base options
   .addMiddleware(
     new Middleware({
       security: { type: "cookie", name: "session" }, // improves Documentation
@@ -872,7 +870,7 @@ It covers all standard `Cache-Control` directives, conditional request handling,
 import { createCacheMiddleware } from "express-zod-api";
 
 const avatarEndpoint = factory
-  .addMiddleware(createCacheMiddleware({ maxAge: 3600, scope: "public" })) // applies to every response
+  .useCache({ maxAge: 3600, scope: "public" }) // shorthand, the policy applies to every response
   .build({
     output: z.object({ avatar: z.string() }),
     handler: async ({

--- a/express-zod-api/src/cache-middleware.ts
+++ b/express-zod-api/src/cache-middleware.ts
@@ -39,7 +39,7 @@ interface CommonDirectives {
  * @desc Directives that clients send in requests to express their caching preferences.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#request_directives
  */
-interface CacheControl extends CommonDirectives {
+export interface CacheControl extends CommonDirectives {
   /**
    * @desc The client will accept a stored response that is stale for up to N seconds beyond its freshness lifetime.
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#max-stale
@@ -61,7 +61,7 @@ interface CacheControl extends CommonDirectives {
  * @desc Directives that servers send in responses to control how caches store and reuse the response.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#response_directives
  */
-interface CachePolicy extends CommonDirectives {
+export interface CachePolicy extends CommonDirectives {
   /**
    * @desc Restricts which caches may store the response.
    * @example "public" — any cache (browser, proxy, CDN); for static assets, responses without user-specific data.

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -26,6 +26,8 @@ import {
   arrayResultHandler,
   defaultResultHandler,
 } from "./result-handler";
+import { createCacheMiddleware } from "./cache-middleware.ts";
+import { createCookieMiddleware } from "./cookie-middleware.ts";
 
 interface BuildProps<
   IN extends IOSchema,
@@ -105,6 +107,16 @@ export class EndpointsFactory<
     return this.#extend(
       subject instanceof Middleware ? subject : new Middleware(subject),
     );
+  }
+
+  /** @desc Shorthand for .addMiddleware(createCookieMiddleware()) */
+  public useCookies(...args: Parameters<typeof createCookieMiddleware>) {
+    return this.#extend(createCookieMiddleware(...args));
+  }
+
+  /** @desc Shorthand for .addMiddleware(createCacheMiddleware()) */
+  public useCache(...args: Parameters<typeof createCacheMiddleware>) {
+    return this.#extend(createCacheMiddleware(...args));
   }
 
   public use = this.addExpressMiddleware;

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -26,8 +26,8 @@ import {
   arrayResultHandler,
   defaultResultHandler,
 } from "./result-handler";
-import { createCacheMiddleware } from "./cache-middleware.ts";
-import { createCookieMiddleware } from "./cookie-middleware.ts";
+import { createCacheMiddleware } from "./cache-middleware";
+import { createCookieMiddleware } from "./cookie-middleware";
 
 interface BuildProps<
   IN extends IOSchema,

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -41,6 +41,7 @@ export type { TagOverrides } from "./common-helpers";
 
 // Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
 import type {} from "qs"; // fixes TS2742 for attachRouting, makeRequestMock, testEndpoint, testMiddleware
+export type { CacheControl, CachePolicy } from "./cache-middleware";
 export type { Routing } from "./routing";
 export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -8,6 +8,8 @@ import {
   ResultHandler,
   testMiddleware,
 } from "../src";
+import * as cookieMw from "../src/cookie-middleware";
+import * as cacheMw from "../src/cache-middleware";
 import type { EmptyObject } from "../src/common-helpers";
 import { Endpoint } from "../src/endpoint";
 import { z } from "zod";
@@ -123,6 +125,24 @@ describe("EndpointsFactory", () => {
         option2: "other value",
       });
       expect(newFactory["resultHandler"]).toStrictEqual(resultHandlerMock);
+    });
+  });
+
+  describe(".useCookies", () => {
+    test("should add created cookie middleware", () => {
+      const spy = vi.spyOn(cookieMw, "createCookieMiddleware");
+      const factory = defaultEndpointsFactory.useCookies({ priority: "high" });
+      expect(spy).toHaveBeenCalledWith({ priority: "high" });
+      expect(factory["middlewares"]).toHaveLength(1);
+    });
+  });
+
+  describe(".useCache", () => {
+    test("should add created cache middleware", () => {
+      const spy = vi.spyOn(cacheMw, "createCacheMiddleware");
+      const factory = defaultEndpointsFactory.useCache({ maxAge: 100 });
+      expect(spy).toHaveBeenCalledWith({ maxAge: 100 });
+      expect(factory["middlewares"]).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
Following #3416 and #3406 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added useCookies() and useCache() convenience methods to simplify middleware setup.
  * Exported CacheControl and CachePolicy types for public consumption.

* **Documentation**
  * Updated README examples to demonstrate the new shorthand methods.
  * Clarified endpoint execution behavior to note when output validation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->