### PR TITLE
feat: Add `current` ctx to `EndpointsFactory::addContext()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 28
 
+### v28.3.0
+
+- `EndpointsFactory::addContext()` now passes the previously accumulated context to its callback:
+  - The argument function receives the current context as the first argument.
+
 ### v28.2.0
 
 - Added `createCacheMiddleware()` function for solving most of the caching problems:

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ connection, consider shorthand method `addContext`. For static values consider r
 import { readFile } from "node:fs/promises";
 import { defaultEndpointsFactory } from "express-zod-api";
 
-const endpointsFactory = defaultEndpointsFactory.addContext(async () => {
+const endpointsFactory = defaultEndpointsFactory.addContext(async (ctx) => {
   // caution: new connection on every request:
   const db = mongoose.connect("mongodb://connection.string");
   const privateKey = await readFile("private-key.pem", "utf-8");

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -129,8 +129,12 @@ export class EndpointsFactory<
     return this.#extend(new ExpressMiddleware(...params));
   }
 
-  public addContext<RET extends FlatObject>(getContext: () => Promise<RET>) {
-    return this.#extend(new Middleware({ handler: getContext }));
+  public addContext<RET extends FlatObject>(
+    provider: (current: CTX) => Promise<RET>,
+  ) {
+    return this.#extend(
+      new Middleware({ handler: ({ ctx }) => provider(ctx) }),
+    );
   }
 
   public build<BOUT extends IOSchema, BIN extends IOSchema = EmptySchema>({

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -129,6 +129,12 @@ export class EndpointsFactory<
     return this.#extend(new ExpressMiddleware(...params));
   }
 
+  /**
+   * @desc Extends the context available to Endpoints built on this factory by resolving additional properties
+   *       from an asynchronous callback. The callback receives the current accumulated context, allowing further
+   *       context values to depend on previously provided ones. This is a shorthand for addMiddleware() with no schema.
+   * @see addMiddleware
+   * */
   public addContext<RET extends FlatObject>(
     provider: (current: CTX) => Promise<RET>,
   ) {

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -106,25 +106,29 @@ describe("EndpointsFactory", () => {
   describe(".addContext()", () => {
     test("Should create a new factory with an empty-input middleware and the same result handler", async () => {
       const factory = new EndpointsFactory(resultHandlerMock);
-      const newFactory = factory.addContext(async () => ({
-        option1: "some value",
-        option2: "other value",
-      }));
+      const newFactory = factory
+        .addContext(async () => ({ option1: "some value" }))
+        .addContext(async (ctx) => ({
+          option2: `not ${ctx.option1}`,
+        }));
       expectTypeOf(newFactory).toEqualTypeOf<
-        EndpointsFactory<undefined, { option1: string; option2: string }>
+        EndpointsFactory<undefined, { option1: string } & { option2: string }>
       >();
       expect(factory["middlewares"]).toStrictEqual([]);
       expect(factory["resultHandler"]).toStrictEqual(resultHandlerMock);
-      expect(newFactory["middlewares"].length).toBe(1);
+      expect(newFactory["middlewares"].length).toBe(2);
       expect(newFactory["middlewares"][0]!.schema).toBeUndefined();
-      const { output: options } = await testMiddleware({
+      expect(newFactory["middlewares"][1]!.schema).toBeUndefined();
+      const { output: first } = await testMiddleware({
         middleware: newFactory["middlewares"][0]!,
       });
-      expect(options).toEqual({
-        option1: "some value",
-        option2: "other value",
-      });
+      expect(first).toEqual({ option1: "some value" });
       expect(newFactory["resultHandler"]).toStrictEqual(resultHandlerMock);
+      const { output: second } = await testMiddleware({
+        middleware: newFactory["middlewares"][1]!,
+        ctx: { option1: "some value" },
+      });
+      expect(second).toEqual({ option2: "not some value" });
     });
   });
 


### PR DESCRIPTION
should be non-breaking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `addContext()` now receives the currently accumulated context as an argument, so callbacks can build on prior context values.

* **Documentation**
  * README example and changelog updated to show the new callback signature.

* **Tests**
  * Test coverage updated to reflect chained context additions and the resulting middleware chain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->