### PR TITLE
fix(test): Making the OAS validation test optional

### DIFF
--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -557,8 +557,8 @@ describe("Example", async () => {
     }
 
     test.skipIf(!response)("should be valid", async () => {
-      const json = await response!.json();
       expect(response!.status).toBe(200);
+      const json = await response!.json();
       if (
         typeof json === "object" &&
         json !== null &&

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -540,19 +540,25 @@ describe("Example", async () => {
     });
   });
 
-  describe("OpenAPI Documentation", () => {
-    test("should be valid", { retry: 3 }, async () => {
-      const data = await readFile("example.documentation.yaml", "utf-8");
-      const response = await fetch(
-        "https://validator.swagger.io/validator/debug",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/yaml" },
-          body: data,
-        },
+  describe("OpenAPI Documentation", async () => {
+    const data = await readFile("example.documentation.yaml", "utf-8");
+    let response: Response | undefined;
+    try {
+      response = await fetch("https://validator.swagger.io/validator/debug", {
+        method: "POST",
+        headers: { "Content-Type": "application/yaml" },
+        body: data,
+        signal: AbortSignal.timeout(3000),
+      });
+    } catch {
+      console.warn(
+        "OpenAPI validation skipped: Swagger validator is unreachable",
       );
-      expect(response.status).toBe(200);
-      const json = await response.json();
+    }
+
+    test.skipIf(!response)("should be valid", async () => {
+      const json = await response!.json();
+      expect(response!.status).toBe(200);
       if (
         typeof json === "object" &&
         json !== null &&


### PR DESCRIPTION
It's the third day the Swagger validator is unstable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved robustness of the "OpenAPI Documentation" test by adding a 3-second timeout for external validator requests and handling unreachable validator endpoints gracefully.
  * Test now logs a warning instead of hard-failing when the external service is unavailable and conditionally performs schema validation only when a validator response is received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->