### PR TITLE
ref(documentation): Changing signature of excludeParamsFromDepiction helper

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -402,12 +402,12 @@ const depict = (
 };
 
 export const excludeParamsFromDepiction = (
-  subject: SchemaObject | ReferenceObject,
+  subject: z.core.JSONSchema.BaseSchema,
   names: string[],
-): [SchemaObject | ReferenceObject, boolean] => {
+): [typeof subject, boolean] => {
   if (isReferenceObject(subject)) return [subject, false];
   let hasRequired = false;
-  const subTransformer = R.map((entry: SchemaObject | ReferenceObject) => {
+  const subTransformer = R.map((entry: typeof subject) => {
     const [sub, subRequired] = excludeParamsFromDepiction(entry, names);
     hasRequired = hasRequired || subRequired;
     return sub;
@@ -421,7 +421,7 @@ export const excludeParamsFromDepiction = (
     oneOf: subTransformer,
     anyOf: subTransformer,
   };
-  const result: SchemaObject = R.evolve(transformers, subject);
+  const result: typeof subject = R.evolve(transformers, subject);
   return [result, hasRequired || Boolean(result.required?.length)];
 };
 
@@ -596,20 +596,18 @@ export const depictBody = ({
   mimeType: string;
   paramNames: string[];
 }) => {
-  const [withoutParams, hasRequired] = excludeParamsFromDepiction(
-    asOAS(request),
-    paramNames,
-  );
+  const [_pure, hasRequired] = excludeParamsFromDepiction(request, paramNames);
+  const pure = asOAS(_pure);
   const examples = [];
-  if (isSchemaObject(withoutParams) && withoutParams.examples) {
-    examples.push(...withoutParams.examples);
-    delete withoutParams.examples; // pull up
+  if (isSchemaObject(pure) && pure.examples) {
+    examples.push(...pure.examples);
+    delete pure.examples; // pull up
   }
   const media: MediaTypeObject = {
     schema:
       composition === "components"
-        ? makeRef(schema, withoutParams, makeCleanId(description))
-        : withoutParams,
+        ? makeRef(schema, pure, makeCleanId(description))
+        : pure,
     examples: enumerateExamples(
       examples.length
         ? examples

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -47,7 +47,7 @@ describe("Documentation helpers", () => {
   });
 
   describe("excludeParamsFromDepiction()", () => {
-    test.each<SchemaObject>([
+    test.each<z.core.JSONSchema.BaseSchema>([
       {
         type: "object",
         properties: { a: { type: "string" }, b: { type: "string" } },


### PR DESCRIPTION
to operate Zod's JSON schema and assert OAS afterwards.

A type-only refactoring to simplify moving further into #3437 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened the documentation generation system with enhanced type safety mechanisms. Expanded schema type support to accommodate a broader range of definitions while ensuring validation accuracy. Optimized the internal schema processing workflow for improved system flexibility and maintainability.

* **Tests**
  * Updated the test suite to align with the new schema type specifications and enhanced documentation generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->