### PR TITLE
ref(documentation): Add constraints to `Component` type

### DIFF
--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -8,7 +8,7 @@ import {
   OpenApiBuilder,
 } from "openapi3-ts/oas31";
 import * as R from "ramda";
-import { responseVariants } from "./api-response";
+import { type ResponseVariant, responseVariants } from "./api-response";
 import { contentTypes } from "./content-type";
 import { DocumentationError } from "./errors";
 import { getInputSources, makeCleanId } from "./common-helpers";
@@ -34,8 +34,7 @@ import type { Routing } from "./routing";
 import { walkRouting, withHead, type OnEndpoint } from "./routing-walker";
 
 type Component =
-  | "positiveResponse"
-  | "negativeResponse"
+  | `${ResponseVariant}Response`
   | "requestParameter"
   | "requestBody";
 


### PR DESCRIPTION
depending on `ResponseVariant`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated response component name generation logic for improved consistency in response descriptor composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->