### PR TITLE
exp: OpenAPI component individual descriptions

### DIFF
--- a/example/endpoints/list-users.ts
+++ b/example/endpoints/list-users.ts
@@ -25,11 +25,14 @@ export const listUsersEndpoint = arrayRespondingFactory.build({
   }),
   output: z.object({
     // the arrayResultHandler will take the "items" prop as the response
-    items: z.array(z.object({ name: z.string(), role: roleSchema })).example([
-      { name: "Hunter Schafer", role: "manager" },
-      { name: "Laverne Cox", role: "operator" },
-      { name: "Patti Harrison", role: "admin" },
-    ]),
+    items: z
+      .array(z.object({ name: z.string(), role: roleSchema }))
+      .describe("The list of users")
+      .example([
+        { name: "Hunter Schafer", role: "manager" },
+        { name: "Laverne Cox", role: "operator" },
+        { name: "Patti Harrison", role: "admin" },
+      ]),
   }),
   handler: async ({ input: { roles } }) => ({
     items: users.filter(({ role }) => roles?.includes(role) ?? true),

--- a/example/endpoints/login.ts
+++ b/example/endpoints/login.ts
@@ -9,10 +9,12 @@ import { promisify } from "node:util";
 export const loginEndpoint = cookieAssistedFactory.build({
   method: "post",
   tag: "cookies",
-  input: z.object({
-    username: z.string().trim().nonempty(),
-    password: z.string().trim().nonempty(),
-  }),
+  input: z
+    .object({
+      username: z.string().trim().nonempty(),
+      password: z.string().trim().nonempty(),
+    })
+    .describe("Login credentials"),
   output: z.object({ message: z.string() }),
   handler: async ({ input: { username, password }, ctx: { setCookie } }) => {
     const key = await promisify<string, string, number, Buffer>(scrypt)(

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -195,7 +195,7 @@ paths:
           APIKEY_2: []
       responses:
         "200":
-          description: PATCH /v1/user/:id Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -229,6 +229,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -116,9 +116,9 @@ paths:
             pattern: \d+
       responses:
         "204":
-          description: Confirmation of successful action
+          description: Confirmation
         "404":
-          description: Rejection due to missing entity
+          description: Does not exist
   /v1/user/{id}:
     patch:
       operationId: PatchV1UserId
@@ -290,7 +290,7 @@ paths:
         required: true
       responses:
         "201":
-          description: Successful response
+          description: Confirmation on creation
           content:
             application/json:
               schema:
@@ -313,9 +313,9 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
+                description: Confirmation on creation
         "202":
-          description: Successful response
+          description: Confirmation on creation
           content:
             application/json:
               schema:
@@ -338,7 +338,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
+                description: Confirmation on creation
         "400":
           description: Generic error response
           content:
@@ -357,7 +357,7 @@ paths:
                 additionalProperties: false
                 description: Generic error response
         "409":
-          description: Error when entity already exists
+          description: Already exists
           content:
             application/json:
               schema:
@@ -374,7 +374,7 @@ paths:
                   - status
                   - id
                 additionalProperties: false
-                description: Error when entity already exists
+                description: Already exists
         "500":
           description: Generic error response
           content:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -74,7 +74,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -229,7 +228,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -259,7 +257,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -542,7 +539,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -747,7 +743,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -815,7 +810,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -961,7 +955,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1089,7 +1082,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -52,7 +52,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -314,7 +313,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Confirmation on creation
         "202":
           description: Confirmation on creation
           content:
@@ -339,7 +337,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Confirmation on creation
         "400":
           description: Generic error response
           content:
@@ -356,7 +353,6 @@ paths:
                   - status
                   - reason
                 additionalProperties: false
-                description: Generic error response
         "409":
           description: Already exists
           content:
@@ -375,7 +371,6 @@ paths:
                   - status
                   - id
                 additionalProperties: false
-                description: Already exists
         "500":
           description: Generic error response
           content:
@@ -392,7 +387,6 @@ paths:
                   - status
                   - reason
                 additionalProperties: false
-                description: Generic error response
   /v1/user/list:
     get:
       operationId: GetV1UserList
@@ -518,7 +512,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -570,14 +563,12 @@ paths:
             image/svg+xml:
               schema:
                 type: string
-                description: An image file
         "400":
           description: Error message
           content:
             text/plain:
               schema:
                 type: string
-                description: Error message
     head:
       operationId: HeadV1AvatarSend
       summary: Sends a file content.
@@ -619,7 +610,6 @@ paths:
           content:
             image/*:
               schema:
-                description: An image stream
                 externalDocs:
                   description: raw binary data
                   url: https://swagger.io/specification/#working-with-binary-data
@@ -629,7 +619,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                description: Error message
     head:
       operationId: HeadV1AvatarStream
       summary: Streams a file content.
@@ -723,7 +712,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -791,7 +779,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -937,7 +924,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1065,7 +1051,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -53,7 +53,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/user/retrieve Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -74,6 +74,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -116,9 +117,9 @@ paths:
             pattern: \d+
       responses:
         "204":
-          description: DELETE /v1/user/:id/remove Positive response
+          description: Confirmation of successful action
         "404":
-          description: DELETE /v1/user/:id/remove Negative response
+          description: Rejection due to missing entity
   /v1/user/{id}:
     patch:
       operationId: PatchV1UserId
@@ -236,7 +237,7 @@ paths:
                       name: John Doe
                       createdAt: 2021-12-31T00:00:00.000Z
         "400":
-          description: PATCH /v1/user/:id Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -257,6 +258,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -290,7 +292,7 @@ paths:
         required: true
       responses:
         "201":
-          description: POST /v1/user/create Positive response 201
+          description: Successful response
           content:
             application/json:
               schema:
@@ -313,8 +315,9 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "202":
-          description: POST /v1/user/create Positive response 202
+          description: Successful response
           content:
             application/json:
               schema:
@@ -337,8 +340,9 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
-          description: POST /v1/user/create Negative response 400
+          description: Generic error response
           content:
             application/json:
               schema:
@@ -353,8 +357,9 @@ paths:
                   - status
                   - reason
                 additionalProperties: false
+                description: Generic error response
         "409":
-          description: POST /v1/user/create Negative response 409
+          description: Error when entity already exists
           content:
             application/json:
               schema:
@@ -371,8 +376,9 @@ paths:
                   - status
                   - id
                 additionalProperties: false
+                description: Error when entity already exists
         "500":
-          description: POST /v1/user/create Negative response 500
+          description: Generic error response
           content:
             application/json:
               schema:
@@ -387,6 +393,7 @@ paths:
                   - status
                   - reason
                 additionalProperties: false
+                description: Generic error response
   /v1/user/list:
     get:
       operationId: GetV1UserList
@@ -513,7 +520,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/login Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -534,6 +541,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -558,17 +566,19 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: GET /v1/avatar/send Positive response
+          description: An image file
           content:
             image/svg+xml:
               schema:
                 type: string
+                description: An image file
         "400":
-          description: GET /v1/avatar/send Negative response
+          description: Error message
           content:
             text/plain:
               schema:
                 type: string
+                description: Error message
     head:
       operationId: HeadV1AvatarSend
       summary: Sends a file content.
@@ -606,19 +616,21 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: GET /v1/avatar/stream Positive response
+          description: An image stream
           content:
             image/*:
               schema:
+                description: An image stream
                 externalDocs:
                   description: raw binary data
                   url: https://swagger.io/specification/#working-with-binary-data
         "400":
-          description: GET /v1/avatar/stream Negative response
+          description: Error message
           content:
             text/plain:
               schema:
                 type: string
+                description: Error message
     head:
       operationId: HeadV1AvatarStream
       summary: Streams a file content.
@@ -713,7 +725,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/avatar/upload Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -734,6 +746,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -780,7 +793,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/avatar/raw Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -801,6 +814,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -925,7 +939,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/forms/feedback Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -946,6 +960,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1052,7 +1067,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v2/users/list Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1073,6 +1088,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -479,7 +479,7 @@ paths:
       tags:
         - cookies
       requestBody:
-        description: POST /v1/login Request body
+        description: Login credentials
         content:
           application/json:
             schema:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -21,7 +21,7 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: GET /v1/user/retrieve Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -52,6 +52,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -496,7 +497,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/login Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -517,6 +518,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -683,7 +685,7 @@ paths:
         - APIKEY_3: []
       responses:
         "200":
-          description: POST /v1/avatar/upload Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -721,6 +723,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -765,7 +768,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/avatar/raw Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -788,6 +791,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -910,7 +914,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/forms/feedback Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -933,6 +937,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1005,7 +1010,7 @@ paths:
                 - admin
       responses:
         "200":
-          description: GET /v2/users/list Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1060,6 +1065,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -407,7 +407,7 @@ paths:
                 - admin
       responses:
         "200":
-          description: GET /v1/user/list Positive response
+          description: The list of users
           content:
             application/json:
               schema:
@@ -464,7 +464,7 @@ paths:
                 - admin
       responses:
         "200":
-          description: HEAD /v1/user/list Positive response
+          description: The list of users
         "400":
           description: Error message
   /v1/login:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -443,7 +443,7 @@ paths:
                     - name: Patti Harrison
                       role: admin
         "400":
-          description: GET /v1/user/list Negative response
+          description: Error message
           content:
             text/plain:
               schema:

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -98,9 +98,9 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: HEAD /v1/user/retrieve Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/user/retrieve Negative response
+          description: Error response
   /v1/user/{id}/remove:
     delete:
       operationId: DeleteV1UserIdRemove
@@ -472,7 +472,7 @@ paths:
         "200":
           description: HEAD /v1/user/list Positive response
         "400":
-          description: HEAD /v1/user/list Negative response
+          description: Error message
   /v1/login:
     post:
       operationId: PostV1Login
@@ -595,9 +595,9 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: HEAD /v1/avatar/send Positive response
+          description: An image file
         "400":
-          description: HEAD /v1/avatar/send Negative response
+          description: Error message
   /v1/avatar/stream:
     get:
       operationId: GetV1AvatarStream
@@ -646,9 +646,9 @@ paths:
             pattern: \d+
       responses:
         "200":
-          description: HEAD /v1/avatar/stream Positive response
+          description: An image stream
         "400":
-          description: HEAD /v1/avatar/stream Negative response
+          description: Error message
   /v1/avatar/upload:
     post:
       operationId: PostV1AvatarUpload
@@ -1137,9 +1137,9 @@ paths:
                 - admin
       responses:
         "200":
-          description: HEAD /v2/users/list Positive response
+          description: Successful response
         "400":
-          description: HEAD /v2/users/list Negative response
+          description: Error response
 components:
   schemas:
     Feature:

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -90,14 +90,14 @@ export const statusDependingFactory = new EndpointsFactory(
       statusCode: [201, 202],
       schema: z
         .object({ status: z.literal("created"), data })
-        .describe("Successful response"),
+        .describe("Confirmation on creation"),
     }),
     negative: [
       {
         statusCode: 409,
         schema: z
           .object({ status: z.literal("exists"), id: z.int() })
-          .describe("Error when entity already exists"),
+          .describe("Already exists"),
       },
       {
         statusCode: [400, 500],
@@ -132,12 +132,12 @@ export const noContentFactory = new EndpointsFactory(
     positive: {
       statusCode: 204,
       mimeType: null,
-      schema: z.never().describe("Confirmation of successful action"),
+      schema: z.never().describe("Confirmation"),
     },
     negative: {
       statusCode: 404,
       mimeType: null,
-      schema: z.never().describe("Rejection due to missing entity"),
+      schema: z.never().describe("Does not exist"),
     },
     handler: ({ error, response }) => {
       response.status(error ? ensureHttpError(error).statusCode : 204).end(); // no content

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -32,8 +32,14 @@ export const cookieAssistedFactory = defaultEndpointsFactory.addMiddleware(
 /** @desc This factory sends the file as string located in the "data" property of the endpoint's output */
 export const fileSendingEndpointsFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: { schema: z.string(), mimeType: "image/svg+xml" },
-    negative: { schema: z.string(), mimeType: "text/plain" },
+    positive: {
+      schema: z.string().describe("An image file"),
+      mimeType: "image/svg+xml",
+    },
+    negative: {
+      schema: z.string().describe("Error message"),
+      mimeType: "text/plain",
+    },
     handler: ({ response, error, output }) => {
       if (error) return void response.status(400).send(error.message);
       if ("data" in output && typeof output.data === "string")
@@ -46,8 +52,14 @@ export const fileSendingEndpointsFactory = new EndpointsFactory(
 /** @desc This one streams the file using the "filename" property of the endpoint's output */
 export const fileStreamingEndpointsFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: { schema: ez.buffer(), mimeType: "image/*" },
-    negative: { schema: z.string(), mimeType: "text/plain" },
+    positive: {
+      schema: ez.buffer().describe("An image stream"),
+      mimeType: "image/*",
+    },
+    negative: {
+      schema: z.string().describe("Error message"),
+      mimeType: "text/plain",
+    },
     handler: async ({ response, error, output, request: { method } }) => {
       if (error) return void response.status(400).send(error.message);
       if ("filename" in output && typeof output.filename === "string") {
@@ -76,16 +88,22 @@ export const statusDependingFactory = new EndpointsFactory(
   new ResultHandler({
     positive: (data) => ({
       statusCode: [201, 202],
-      schema: z.object({ status: z.literal("created"), data }),
+      schema: z
+        .object({ status: z.literal("created"), data })
+        .describe("Successful response"),
     }),
     negative: [
       {
         statusCode: 409,
-        schema: z.object({ status: z.literal("exists"), id: z.int() }),
+        schema: z
+          .object({ status: z.literal("exists"), id: z.int() })
+          .describe("Error when entity already exists"),
       },
       {
         statusCode: [400, 500],
-        schema: z.object({ status: z.literal("error"), reason: z.string() }),
+        schema: z
+          .object({ status: z.literal("error"), reason: z.string() })
+          .describe("Generic error response"),
       },
     ],
     handler: ({ error, response, output }) => {
@@ -111,8 +129,16 @@ export const statusDependingFactory = new EndpointsFactory(
 /** @desc This factory demonstrates response without body, such as 204 No Content */
 export const noContentFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: { statusCode: 204, mimeType: null, schema: z.never() },
-    negative: { statusCode: 404, mimeType: null, schema: z.never() },
+    positive: {
+      statusCode: 204,
+      mimeType: null,
+      schema: z.never().describe("Confirmation of successful action"),
+    },
+    negative: {
+      statusCode: 404,
+      mimeType: null,
+      schema: z.never().describe("Rejection due to missing entity"),
+    },
     handler: ({ error, response }) => {
       response.status(error ? ensureHttpError(error).statusCode : 204).end(); // no content
     },

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -457,11 +457,11 @@ export const depictResponse = ({
       ctx: { isResponse: true, makeRef, path, method },
     }),
   );
+  delete response.description; // pulled up
   const examples = [];
   if (isSchemaObject(response) && response.examples) {
     examples.push(...response.examples);
     delete response.examples; // moving them up
-    delete response.description;
   }
   const media: MediaTypeObject = {
     schema:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -436,9 +436,10 @@ export const depictResponse = ({
   hasMultipleStatusCodes,
   statusCode,
   brandHandling,
-  description = `${method.toUpperCase()} ${path} ${ucFirst(variant)} response ${
-    hasMultipleStatusCodes ? statusCode : ""
-  }`.trim(),
+  description = schema.description ??
+    `${method.toUpperCase()} ${path} ${ucFirst(variant)} response ${
+      hasMultipleStatusCodes ? statusCode : ""
+    }`.trim(),
 }: ReqResCommons & {
   schema: z.ZodType;
   composition: "inline" | "components";

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -460,6 +460,7 @@ export const depictResponse = ({
   if (isSchemaObject(response) && response.examples) {
     examples.push(...response.examples);
     delete response.examples; // moving them up
+    delete response.description;
   }
   const media: MediaTypeObject = {
     schema:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -589,7 +589,8 @@ export const depictBody = ({
   makeRef,
   composition,
   paramNames,
-  description = `${method.toUpperCase()} ${path} Request body`,
+  description = request.description ||
+    `${method.toUpperCase()} ${path} Request body`,
 }: ReqResCommons & {
   schema: IOSchema;
   composition: "inline" | "components";
@@ -600,6 +601,7 @@ export const depictBody = ({
 }) => {
   const [_pure, hasRequired] = excludeParamsFromDepiction(request, paramNames);
   const pure = asOAS(_pure);
+  delete pure.description; // pulled up
   const examples = [];
   if (isSchemaObject(pure) && pure.examples) {
     examples.push(...pure.examples);

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -229,12 +229,14 @@ export class Documentation extends OpenApiBuilder {
               statusCode,
               hasMultipleStatusCodes:
                 apiResponses.length > 1 || statusCodes.length > 1,
-              description: descriptions?.[`${variant}Response`]?.({
-                method,
-                path,
-                operationId,
-                statusCode,
-              }),
+              description:
+                (method === "head" ? undefined : schema.description) ||
+                descriptions?.[`${variant}Response`]?.({
+                  method,
+                  path,
+                  operationId,
+                  statusCode,
+                }),
             });
           }
         }

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -229,14 +229,12 @@ export class Documentation extends OpenApiBuilder {
               statusCode,
               hasMultipleStatusCodes:
                 apiResponses.length > 1 || statusCodes.length > 1,
-              description:
-                (method === "head" ? undefined : schema.description) ||
-                descriptions?.[`${variant}Response`]?.({
-                  method,
-                  path,
-                  operationId,
-                  statusCode,
-                }),
+              description: descriptions?.[`${variant}Response`]?.({
+                method,
+                path,
+                operationId,
+                statusCode,
+              }),
             });
           }
         }

--- a/express-zod-api/src/io-schema.ts
+++ b/express-zod-api/src/io-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { globalRegistry, z } from "zod";
 
 type Base = object & { [Symbol.iterator]?: never };
 
@@ -41,7 +41,11 @@ export const makeFinalInputSchema = <
 >(
   factorySchema: FIN,
   buildSchema: BIN,
-) =>
-  (factorySchema
-    ? factorySchema.and(buildSchema)
-    : buildSchema) as FinalInputSchema<FIN, BIN>;
+) => {
+  const final = (
+    factorySchema ? factorySchema.and(buildSchema) : buildSchema
+  ) as FinalInputSchema<FIN, BIN>;
+  if (factorySchema)
+    globalRegistry.add(final, { description: buildSchema.description });
+  return final;
+};

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -131,7 +131,7 @@ export const defaultResultHandler = new ResultHandler({
     const examples = getExamples(output); // pulling down:
     if (examples.length) {
       globalRegistry.add(responseSchema, {
-        description: output.description,
+        description: "Successful response",
         examples: examples.map((data) => ({
           status: "success" as const,
           data,

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -110,6 +110,7 @@ const defaultNegativeSchema = z.object({
   error: z.object({ message: z.string() }),
 });
 globalRegistry.add(defaultNegativeSchema, {
+  description: "Error response",
   examples: [
     { status: "error", error: { message: "Sample error message" } },
   ] satisfies z.output<typeof defaultNegativeSchema>[],
@@ -130,6 +131,7 @@ export const defaultResultHandler = new ResultHandler({
     const examples = getExamples(output); // pulling down:
     if (examples.length) {
       globalRegistry.add(responseSchema, {
+        description: output.description,
         examples: examples.map((data) => ({
           status: "success" as const,
           data,

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -129,15 +129,15 @@ export const defaultResultHandler = new ResultHandler({
       data: output,
     });
     const examples = getExamples(output); // pulling down:
-    if (examples.length) {
-      globalRegistry.add(responseSchema, {
-        description: "Successful response",
+    globalRegistry.add(responseSchema, {
+      description: "Successful response",
+      ...(examples.length && {
         examples: examples.map((data) => ({
           status: "success" as const,
           data,
         })),
-      });
-    }
+      }),
+    });
     return responseSchema;
   },
   negative: defaultNegativeSchema,

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -161,6 +161,7 @@ export const defaultResultHandler = new ResultHandler({
 
 const arrayNegativeSchema = z.string();
 globalRegistry.add(arrayNegativeSchema, {
+  description: "Error message",
   examples: ["Sample error message"] satisfies z.output<
     typeof arrayNegativeSchema
   >[],

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -31,7 +31,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSome/thing Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -52,6 +52,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -114,7 +115,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSome/thing Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -135,6 +136,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -181,7 +183,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSome/thing Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -202,6 +204,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -255,7 +258,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSome/thing Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -276,6 +279,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -316,7 +320,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSome/:thing Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -337,6 +341,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -417,7 +422,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -438,6 +443,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -501,7 +507,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/setSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -522,6 +528,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -560,7 +567,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: PUT /v1/updateSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -581,6 +588,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -655,7 +663,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: DELETE /v1/deleteSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -676,6 +684,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -762,7 +771,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -783,6 +792,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -890,7 +900,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -911,6 +921,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -996,7 +1007,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1017,6 +1028,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1137,7 +1149,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1158,6 +1170,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1300,7 +1313,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1321,6 +1334,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1387,7 +1401,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1408,6 +1422,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1532,7 +1547,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1553,6 +1568,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1614,7 +1630,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1635,6 +1651,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1834,7 +1851,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -1855,6 +1872,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -1987,7 +2005,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2008,6 +2026,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2081,7 +2100,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2102,6 +2121,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2224,7 +2244,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2245,6 +2265,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2317,7 +2338,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2338,6 +2359,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2433,7 +2455,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2454,6 +2476,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2514,7 +2537,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2535,6 +2558,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2618,7 +2642,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2639,6 +2663,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2831,7 +2856,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/:name Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2852,6 +2877,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -2952,7 +2978,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/test Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -2973,6 +2999,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3061,7 +3088,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/test Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3082,6 +3109,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3160,7 +3188,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/test Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3181,6 +3209,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3273,7 +3302,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/test Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3294,6 +3323,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3364,7 +3394,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: PUT /v1/test Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3385,6 +3415,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3453,7 +3484,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3474,6 +3505,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3541,7 +3573,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3562,6 +3594,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3656,7 +3689,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3677,6 +3710,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3738,7 +3772,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3759,6 +3793,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3868,7 +3903,7 @@ paths:
                       a: second
                       b: prefix_second
         "400":
-          description: POST /v1/addSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -3889,6 +3924,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -3936,11 +3972,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/GetHrisEmployeesPositiveResponse"
         "400":
-          description: GET /hris/employees Negative response
+          description: Error response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetHrisEmployeesNegativeResponse"
+                $ref: "#/components/schemas/ErrorResponse"
               examples:
                 example1:
                   value:
@@ -3982,7 +4018,7 @@ components:
         - status
         - data
       additionalProperties: false
-    GetHrisEmployeesNegativeResponse:
+    ErrorResponse:
       type: object
       properties:
         status:
@@ -4000,6 +4036,7 @@ components:
         - status
         - error
       additionalProperties: false
+      description: Error response
   responses: {}
   parameters: {}
   examples: {}
@@ -4075,7 +4112,7 @@ paths:
                     data:
                       num: 123
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4096,6 +4133,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4185,7 +4223,7 @@ paths:
                     data:
                       num: 123
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4206,6 +4244,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4279,7 +4318,7 @@ paths:
                     data:
                       numericStr: "123"
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4300,6 +4339,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4396,7 +4436,7 @@ paths:
                     data:
                       numericStr: "123"
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4417,6 +4457,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4494,7 +4535,7 @@ paths:
                     data:
                       numericStr: "456"
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4515,6 +4556,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4617,7 +4659,7 @@ paths:
                     data:
                       numericStr: "456"
         "400":
-          description: POST /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4638,6 +4680,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4704,7 +4747,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/getSomething Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -4725,6 +4768,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4814,7 +4858,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: very negative response of PostV1Name
+          description: Error response
           content:
             application/json:
               schema:
@@ -4835,6 +4879,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -4888,11 +4933,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuperPositiveResponseOfV1Name"
         "400":
-          description: very negative response of PostV1Name
+          description: Error response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VeryNegativeResponseOfPostV1Name"
+                $ref: "#/components/schemas/ErrorResponse"
               examples:
                 example1:
                   value:
@@ -4921,7 +4966,7 @@ components:
         - status
         - data
       additionalProperties: false
-    VeryNegativeResponseOfPostV1Name:
+    ErrorResponse:
       type: object
       properties:
         status:
@@ -4939,6 +4984,7 @@ components:
         - status
         - error
       additionalProperties: false
+      description: Error response
     TheBodyOfRequest:
       type: object
       properties:
@@ -5006,7 +5052,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: GET /v1/:name Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -5027,6 +5073,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:
@@ -5121,7 +5168,7 @@ paths:
                   - data
                 additionalProperties: false
         "400":
-          description: POST /v1/:name Negative response
+          description: Error response
           content:
             application/json:
               schema:
@@ -5142,6 +5189,7 @@ paths:
                   - status
                   - error
                 additionalProperties: false
+                description: Error response
               examples:
                 example1:
                   value:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -3860,7 +3860,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/addSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3889,6 +3889,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4082,7 +4083,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4105,6 +4106,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4191,7 +4193,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4216,6 +4218,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4288,7 +4291,7 @@ paths:
               value: "123"
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4311,6 +4314,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4406,7 +4410,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4429,6 +4433,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4503,7 +4508,7 @@ paths:
               value: "123"
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4528,6 +4533,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:
@@ -4627,7 +4633,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4652,6 +4658,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
               examples:
                 example1:
                   value:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -52,7 +52,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -136,7 +135,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -204,7 +202,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -279,7 +276,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -341,7 +337,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -443,7 +438,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -528,7 +522,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -588,7 +581,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -684,7 +676,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -792,7 +783,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -921,7 +911,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1028,7 +1017,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1170,7 +1158,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1334,7 +1321,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1422,7 +1408,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1568,7 +1553,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1651,7 +1635,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -1872,7 +1855,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2026,7 +2008,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2121,7 +2102,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2265,7 +2245,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2359,7 +2338,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2476,7 +2454,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2558,7 +2535,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2663,7 +2639,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2877,7 +2852,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -2999,7 +2973,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3109,7 +3082,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3209,7 +3181,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3323,7 +3294,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3415,7 +3385,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3505,7 +3474,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3594,7 +3562,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3710,7 +3677,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3793,7 +3759,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -3889,7 +3854,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -3925,7 +3889,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4037,7 +4000,6 @@ components:
         - status
         - error
       additionalProperties: false
-      description: Error response
   responses: {}
   parameters: {}
   examples: {}
@@ -4106,7 +4068,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4135,7 +4096,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4218,7 +4178,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4247,7 +4206,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4314,7 +4272,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4343,7 +4300,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4433,7 +4389,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4462,7 +4417,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4533,7 +4487,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4562,7 +4515,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4658,7 +4610,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
               examples:
                 example1:
                   value:
@@ -4687,7 +4638,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4775,7 +4725,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4886,7 +4835,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -4991,7 +4939,6 @@ components:
         - status
         - error
       additionalProperties: false
-      description: Error response
     TheBodyOfRequest:
       type: object
       properties:
@@ -5080,7 +5027,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:
@@ -5196,7 +5142,6 @@ paths:
                   - status
                   - error
                 additionalProperties: false
-                description: Error response
               examples:
                 example1:
                   value:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -65,9 +65,9 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: HEAD /v1/getSome/thing Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSome/thing Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -149,9 +149,9 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: HEAD /v1/getSome/thing Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSome/thing Negative response
+          description: Error response
     post:
       operationId: postCoolOperationId
       summary: thing is the path segment
@@ -292,9 +292,9 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: HEAD /v1/getSome/thing Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSome/thing Negative response
+          description: Error response
   /v1/getSome/{thing}:
     get:
       operationId: GetV1GetSomeThing2
@@ -354,9 +354,9 @@ paths:
       description: thing is the path parameter
       responses:
         "200":
-          description: HEAD /v1/getSome/:thing Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSome/:thing Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -470,9 +470,9 @@ paths:
         - HTTP_1: []
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
   /v1/setSomething:
     post:
       operationId: PostV1SetSomething
@@ -1223,9 +1223,9 @@ paths:
             pattern: ^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -1448,9 +1448,9 @@ paths:
         - APIKEY_1: []
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -2575,9 +2575,9 @@ paths:
           schema: {}
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -2689,9 +2689,9 @@ paths:
             format: integer (preprocessed)
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -2907,9 +2907,9 @@ paths:
             type: boolean
       responses:
         "200":
-          description: HEAD /v1/:name Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/:name Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -3029,9 +3029,9 @@ paths:
                 pattern: ^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z||([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$
       responses:
         "200":
-          description: HEAD /v1/test Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/test Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -3127,9 +3127,9 @@ paths:
             type: string
       responses:
         "200":
-          description: HEAD /v1/test Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/test Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -3233,9 +3233,9 @@ paths:
             type: string
       responses:
         "200":
-          description: HEAD /v1/test Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/test Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -3526,9 +3526,9 @@ paths:
               type: string
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
     post:
       operationId: PostV1GetSomething
       requestBody:
@@ -3814,9 +3814,9 @@ paths:
             deprecated: true
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -3994,9 +3994,9 @@ paths:
             $ref: "#/components/schemas/GetHrisEmployeesParameterCursor"
       responses:
         "200":
-          description: HEAD /hris/employees Positive response
+          description: Successful response
         "400":
-          description: HEAD /hris/employees Negative response
+          description: Error response
 components:
   schemas:
     GetHrisEmployeesParameterCursor:
@@ -4356,9 +4356,9 @@ paths:
               value: "123"
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -4573,9 +4573,9 @@ paths:
               value: "123"
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -4780,9 +4780,9 @@ paths:
             description: here is the test
       responses:
         "200":
-          description: HEAD /v1/getSomething Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/getSomething Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}
@@ -4833,7 +4833,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Successful response
+          description: Super positive response of /v1/:name
           content:
             application/json:
               schema:
@@ -4852,7 +4852,7 @@ paths:
                 additionalProperties: false
                 description: Successful response
         "400":
-          description: Error response
+          description: very negative response of PostV1Name
           content:
             application/json:
               schema:
@@ -4920,17 +4920,17 @@ paths:
         required: true
       responses:
         "200":
-          description: Successful response
+          description: Super positive response of /v1/:name
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SuccessfulResponse"
+                $ref: "#/components/schemas/SuperPositiveResponseOfV1Name"
         "400":
-          description: Error response
+          description: very negative response of PostV1Name
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/VeryNegativeResponseOfPostV1Name"
               examples:
                 example1:
                   value:
@@ -4945,7 +4945,7 @@ components:
           const: John
         - type: string
           const: Jane
-    SuccessfulResponse:
+    SuperPositiveResponseOfV1Name:
       type: object
       properties:
         status:
@@ -4960,7 +4960,7 @@ components:
         - data
       additionalProperties: false
       description: Successful response
-    ErrorResponse:
+    VeryNegativeResponseOfPostV1Name:
       type: object
       properties:
         status:
@@ -5094,9 +5094,9 @@ paths:
             type: boolean
       responses:
         "200":
-          description: HEAD /v1/:name Positive response
+          description: Successful response
         "400":
-          description: HEAD /v1/:name Negative response
+          description: Error response
 components:
   schemas: {}
   responses: {}

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -30,7 +30,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -114,7 +113,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -182,7 +180,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -257,7 +254,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -319,7 +315,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -421,7 +416,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -506,7 +500,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -566,7 +559,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -662,7 +654,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -770,7 +761,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -899,7 +889,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1006,7 +995,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1148,7 +1136,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1312,7 +1299,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1400,7 +1386,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1546,7 +1531,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1629,7 +1613,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -1850,7 +1833,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2004,7 +1986,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2099,7 +2080,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2243,7 +2223,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2337,7 +2316,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2454,7 +2432,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2536,7 +2513,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2641,7 +2617,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2855,7 +2830,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -2977,7 +2951,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3087,7 +3060,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3187,7 +3159,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3301,7 +3272,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3393,7 +3363,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3483,7 +3452,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3572,7 +3540,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3688,7 +3655,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -3771,7 +3737,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -4017,7 +3982,6 @@ components:
         - status
         - data
       additionalProperties: false
-      description: Successful response
     ErrorResponse:
       type: object
       properties:
@@ -4739,7 +4703,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -4850,7 +4813,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: very negative response of PostV1Name
           content:
@@ -4959,7 +4921,6 @@ components:
         - status
         - data
       additionalProperties: false
-      description: Successful response
     VeryNegativeResponseOfPostV1Name:
       type: object
       properties:
@@ -5044,7 +5005,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:
@@ -5160,7 +5120,6 @@ paths:
                   - status
                   - data
                 additionalProperties: false
-                description: Successful response
         "400":
           description: Error response
           content:

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -13,7 +13,7 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: GET /v1/getSome/thing Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -30,6 +30,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -96,7 +97,7 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: GET /v1/getSome/thing Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -113,6 +114,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -163,7 +165,7 @@ paths:
               properties: {}
       responses:
         "200":
-          description: POST /v1/getSome/thing Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -180,6 +182,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -237,7 +240,7 @@ paths:
       description: thing is the path segment
       responses:
         "200":
-          description: GET /v1/getSome/thing Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -254,6 +257,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -298,7 +302,7 @@ paths:
       description: thing is the path parameter
       responses:
         "200":
-          description: GET /v1/getSome/:thing Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -315,6 +319,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -395,7 +400,7 @@ paths:
         - HTTP_1: []
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -416,6 +421,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -483,7 +489,7 @@ paths:
             - write
       responses:
         "200":
-          description: POST /v1/setSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -500,6 +506,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -542,7 +549,7 @@ paths:
         - HTTP_2: []
       responses:
         "200":
-          description: PUT /v1/updateSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -559,6 +566,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -633,7 +641,7 @@ paths:
       operationId: DeleteV1DeleteSomething
       responses:
         "200":
-          description: DELETE /v1/deleteSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -654,6 +662,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -736,7 +745,7 @@ paths:
             type: string
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -761,6 +770,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -845,7 +855,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -889,6 +899,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -964,7 +975,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -995,6 +1006,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1092,7 +1104,7 @@ paths:
             pattern: ^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1136,6 +1148,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1274,7 +1287,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1299,6 +1312,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1369,7 +1383,7 @@ paths:
         - APIKEY_1: []
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1386,6 +1400,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1494,7 +1509,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1531,6 +1546,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1592,7 +1608,7 @@ paths:
               $ref: "#/components/schemas/Schema1"
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1613,6 +1629,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1810,7 +1827,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1833,6 +1850,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -1964,7 +1982,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1986,6 +2004,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2056,7 +2075,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2080,6 +2099,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2142,7 +2162,7 @@ paths:
               properties: {}
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2223,6 +2243,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2295,7 +2316,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2316,6 +2337,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2408,7 +2430,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2432,6 +2454,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2493,7 +2516,7 @@ paths:
           schema: {}
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2513,6 +2536,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2596,7 +2620,7 @@ paths:
             format: integer (preprocessed)
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2617,6 +2641,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2809,7 +2834,7 @@ paths:
             type: boolean
       responses:
         "200":
-          description: GET /v1/:name Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2830,6 +2855,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -2930,7 +2956,7 @@ paths:
                 pattern: ^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z||([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$
       responses:
         "200":
-          description: GET /v1/test Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2951,6 +2977,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3039,7 +3066,7 @@ paths:
             type: string
       responses:
         "200":
-          description: GET /v1/test Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3060,6 +3087,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3142,7 +3170,7 @@ paths:
             type: string
       responses:
         "200":
-          description: GET /v1/test Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3159,6 +3187,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3255,7 +3284,7 @@ paths:
               required: []
       responses:
         "200":
-          description: POST /v1/test Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3272,6 +3301,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3346,7 +3376,7 @@ paths:
         required: true
       responses:
         "200":
-          description: PUT /v1/test Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3363,6 +3393,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3428,7 +3459,7 @@ paths:
               type: string
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3452,6 +3483,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3516,7 +3548,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3540,6 +3572,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3620,7 +3653,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3655,6 +3688,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3720,7 +3754,7 @@ paths:
             deprecated: true
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -3737,6 +3771,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -3930,11 +3965,11 @@ paths:
             $ref: "#/components/schemas/GetHrisEmployeesParameterCursor"
       responses:
         "200":
-          description: GET /hris/employees Positive response
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetHrisEmployeesPositiveResponse"
+                $ref: "#/components/schemas/SuccessfulResponse"
         "400":
           description: Error response
           content:
@@ -3968,7 +4003,7 @@ components:
       description: An optional cursor string used for pagination. This can be
         retrieved from the \`next\` property of the previous page response.
       type: string
-    GetHrisEmployeesPositiveResponse:
+    SuccessfulResponse:
       type: object
       properties:
         status:
@@ -3982,6 +4017,7 @@ components:
         - status
         - data
       additionalProperties: false
+      description: Successful response
     ErrorResponse:
       type: object
       properties:
@@ -4679,7 +4715,7 @@ paths:
             description: here is the test
       responses:
         "200":
-          description: GET /v1/getSomething Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4703,6 +4739,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -4796,7 +4833,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Super positive response of /v1/:name
+          description: Successful response
           content:
             application/json:
               schema:
@@ -4813,6 +4850,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -4882,11 +4920,11 @@ paths:
         required: true
       responses:
         "200":
-          description: Super positive response of /v1/:name
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SuperPositiveResponseOfV1Name"
+                $ref: "#/components/schemas/SuccessfulResponse"
         "400":
           description: Error response
           content:
@@ -4907,7 +4945,7 @@ components:
           const: John
         - type: string
           const: Jane
-    SuperPositiveResponseOfV1Name:
+    SuccessfulResponse:
       type: object
       properties:
         status:
@@ -4921,6 +4959,7 @@ components:
         - status
         - data
       additionalProperties: false
+      description: Successful response
     ErrorResponse:
       type: object
       properties:
@@ -4988,7 +5027,7 @@ paths:
             type: boolean
       responses:
         "200":
-          description: GET /v1/:name Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -5005,6 +5044,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:
@@ -5103,7 +5143,7 @@ paths:
         required: true
       responses:
         "200":
-          description: POST /v1/:name Positive response
+          description: Successful response
           content:
             application/json:
               schema:
@@ -5120,6 +5160,7 @@ paths:
                   - status
                   - data
                 additionalProperties: false
+                description: Successful response
         "400":
           description: Error response
           content:

--- a/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
@@ -81,6 +81,7 @@ exports[`Endpoint > .getResponses() > should return the positive responses (read
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
+      "description": "Successful response",
       "properties": {
         "data": {
           "additionalProperties": false,

--- a/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/endpoint.spec.ts.snap
@@ -32,6 +32,7 @@ exports[`Endpoint > .getResponses() > should return the negative responses (read
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
+      "description": "Error response",
       "examples": [
         {
           "error": {

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`]
 
 exports[`ResultHandler > 'defaultResultHandler' > should forward output schema examples 1`] = `
 {
-  "description": undefined,
+  "description": "Successful response",
   "examples": [
     {
       "data": {

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -48,6 +48,7 @@ exports[`ResultHandler > 'arrayResultHandler' > should forward output schema exa
 
 exports[`ResultHandler > 'arrayResultHandler' > should generate negative response example 1`] = `
 {
+  "description": "Error message",
   "examples": [
     "Sample error message",
   ],

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -117,6 +117,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`]
 
 exports[`ResultHandler > 'defaultResultHandler' > should forward output schema examples 1`] = `
 {
+  "description": undefined,
   "examples": [
     {
       "data": {
@@ -135,6 +136,7 @@ exports[`ResultHandler > 'defaultResultHandler' > should forward output schema e
 
 exports[`ResultHandler > 'defaultResultHandler' > should generate negative response example 1`] = `
 {
+  "description": "Error response",
   "examples": [
     {
       "error": {


### PR DESCRIPTION
Exploring better ways than `descriptions` (record of callbacks) of Documentation argument.

At least for responses I am aiming to provide a way to express the meaning of the payload instead of generic way to encode HTTP properties.