### PR TITLE
fix(documentation): Schema argument of `depictResponse()`

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -440,7 +440,7 @@ export const depictResponse = ({
     hasMultipleStatusCodes ? statusCode : ""
   }`.trim(),
 }: ReqResCommons & {
-  schema: z.core.$ZodType;
+  schema: z.ZodType;
   composition: "inline" | "components";
   description?: string;
   brandHandling?: BrandHandling;


### PR DESCRIPTION
The type should by `ZodType`, not the basic `core.$ZodType`, because it's typed (ensured) as a complete one by the `Result<S>` type all ResultHandlers are based on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions for better code consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->