### PR TITLE
feat(deps): Sync `loadPeer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 28
 
+### v28.6.0
+
+- Changes to the `Integration` generator:
+  - The `typescript` option is no longer required for constructor;
+  - `Integration.create()` is now deprecated — use `new Integration()` instead;
+  - This is possible thanks to the `require(ESM)` feature, available on all supported Node.js versions;
+
 ### v28.5.0
 
 - Changes to the proprietary `Date` handling schemas:

--- a/README.md
+++ b/README.md
@@ -1190,11 +1190,9 @@ safety between your API and frontend. Make sure you have `typescript` installed.
 and using the async `printFormatted()` method.
 
 ```ts
-import typescript from "typescript";
 import { Integration } from "express-zod-api";
 
 const client = new Integration({
-  typescript, // or await Integration.create() to delegate importing
   routing,
   config,
   variant: "client", // <— optional, see also "types" for a DIY solution

--- a/compat-test/int.spec.ts
+++ b/compat-test/int.spec.ts
@@ -2,11 +2,9 @@ import { Integration } from "express-zod-api";
 import { describe, test, expect } from "vitest";
 
 describe("Integration", () => {
-  test("should work with minimum supported TypeScript", async () => {
+  test("should work with minimum supported TypeScript",  () => {
     expect(
-      (
-        await Integration.create({ config: { cors: false }, routing: {} })
-      ).print()
+      new Integration({ config: { cors: false }, routing: {} }).print()
     ).toContain("export class Client");
   });
 });

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -156,6 +156,7 @@ interface GracefulOptions {
   beforeExit?: () => void | Promise<void>;
 }
 
+/** @todo consider removing Promise to make createServer sync in next major */
 type ServerHook = (params: {
   app: IRouter;
   /** @desc Returns child logger for the given request (if configured) or the configured logger otherwise */

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -181,10 +181,11 @@ export class Integration extends IntegrationBase {
     );
   }
 
+  /** @todo remove async on next major — no longer needed */
   public static async create(params: Omit<IntegrationParams, "typescript">) {
     return new Integration({
       ...params,
-      typescript: await loadPeer<typeof ts>("typescript"),
+      typescript: loadPeer<typeof ts>("typescript"),
     });
   }
 
@@ -233,8 +234,7 @@ export class Integration extends IntegrationBase {
     let format = userDefined;
     if (!format) {
       try {
-        const prettierFormat = (await loadPeer<typeof Prettier>("prettier"))
-          .format;
+        const prettierFormat = loadPeer<typeof Prettier>("prettier").format;
         format = (text) => prettierFormat(text, { filepath: "client.ts" });
       } catch {}
     }

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -15,7 +15,8 @@ import type { ClientMethod } from "./method";
 import type { CommonConfig } from "./config-type";
 
 interface IntegrationParams {
-  typescript: typeof ts;
+  /** @default loadPeer("typescript") */
+  typescript?: typeof ts;
   routing: Routing;
   config: CommonConfig;
   /**
@@ -81,7 +82,7 @@ export class Integration extends IntegrationBase {
   }
 
   public constructor({
-    typescript,
+    typescript = loadPeer<typeof ts>("typescript"),
     routing,
     config,
     brandHandling,
@@ -181,7 +182,10 @@ export class Integration extends IntegrationBase {
     );
   }
 
-  /** @todo remove async on next major — no longer needed */
+  /**
+   * @deprecated use `new Integration()` without `typescript` option on its argument
+   * @todo remove in the next major — no longer needed
+   * */
   public static async create(params: Omit<IntegrationParams, "typescript">) {
     return new Integration({
       ...params,

--- a/express-zod-api/src/peer-helpers.ts
+++ b/express-zod-api/src/peer-helpers.ts
@@ -1,14 +1,14 @@
 import { createRequire } from "node:module";
 import { MissingPeerError } from "./errors";
 
-const require = createRequire(import.meta.url);
+let require: NodeJS.Require;
 
 export const loadPeer = <T>(
   moduleName: string,
   moduleExport: string = "default",
 ): T => {
   try {
-    const mod = require(moduleName);
+    const mod = (require ??= createRequire(import.meta.url))(moduleName);
     if (moduleExport !== "default") return mod[moduleExport] as T;
     return mod.default !== undefined ? mod.default : mod;
   } catch {

--- a/express-zod-api/src/peer-helpers.ts
+++ b/express-zod-api/src/peer-helpers.ts
@@ -1,11 +1,17 @@
+import { createRequire } from "node:module";
 import { MissingPeerError } from "./errors";
 
-export const loadPeer = async <T>(
+const require = createRequire(import.meta.url);
+
+export const loadPeer = <T>(
   moduleName: string,
   moduleExport: string = "default",
-): Promise<T> => {
+): T => {
   try {
-    return (await import(moduleName))[moduleExport];
-  } catch {}
-  throw new MissingPeerError(moduleName);
+    const mod = require(moduleName);
+    if (moduleExport !== "default") return mod[moduleExport] as T;
+    return mod.default !== undefined ? mod.default : mod;
+  } catch {
+    throw new MissingPeerError(moduleName);
+  }
 };

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -82,12 +82,12 @@ export const createUploadFailureHandler =
     next();
   };
 
-export const createCookieParser = async ({
+export const createCookieParser = ({
   config,
 }: {
   config: ServerConfig;
-}): Promise<RequestHandler> => {
-  const parser = await loadPeer<typeof cookieParser>("cookie-parser");
+}): RequestHandler => {
+  const parser = loadPeer<typeof cookieParser>("cookie-parser");
   const { secret, ...rest } = {
     ...(typeof config.cookies === "object" && config.cookies),
   };
@@ -98,14 +98,14 @@ export const createUploadLogger = (
   logger: ActualLogger,
 ): Pick<Console, "log"> => ({ log: logger.debug.bind(logger) });
 
-export const createUploadParsers = async ({
+export const createUploadParsers = ({
   getLogger,
   config,
 }: {
   getLogger: GetLogger;
   config: ServerConfig;
-}): Promise<RequestHandler[]> => {
-  const uploader = await loadPeer<typeof fileUpload>("express-fileupload");
+}): RequestHandler[] => {
+  const uploader = loadPeer<typeof fileUpload>("express-fileupload");
   const { limitError, beforeUpload, ...options } = {
     ...(typeof config.upload === "object" && config.upload),
   };

--- a/express-zod-api/src/server.ts
+++ b/express-zod-api/src/server.ts
@@ -72,23 +72,21 @@ export const createServer = async (config: ServerConfig, routing: Routing) => {
     .use(loggingMiddleware);
 
   if (config.compression) {
-    const compressor = await loadPeer<typeof compression>("compression");
+    const compressor = loadPeer<typeof compression>("compression");
     app.use(
       compressor(
         typeof config.compression === "object" ? config.compression : undefined,
       ),
     );
   }
-  if (config.cookies) app.use(await createCookieParser({ config }));
+  if (config.cookies) app.use(createCookieParser({ config }));
   await config.beforeRouting?.({ app, getLogger });
 
   const parsers: Parsers = {
     json: [config.jsonParser || express.json()],
     raw: [config.rawParser || express.raw(), moveRaw],
     form: [config.formParser || express.urlencoded()],
-    upload: config.upload
-      ? await createUploadParsers({ config, getLogger })
-      : [],
+    upload: config.upload ? createUploadParsers({ config, getLogger }) : [],
   };
   initRouting({ app, routing, getLogger, config, parsers });
 

--- a/express-zod-api/tests/express-mock.ts
+++ b/express-zod-api/tests/express-mock.ts
@@ -1,13 +1,6 @@
 const expressJsonMock = vi.fn();
 const expressRawMock = vi.fn();
 const expressUrlencodedMock = vi.fn();
-const compressionMock = vi.fn();
-const fileUploadMock = vi.fn();
-const cookieParserMock = vi.fn();
-
-vi.mock("compression", () => ({ default: compressionMock }));
-vi.mock("express-fileupload", () => ({ default: fileUploadMock }));
-vi.mock("cookie-parser", () => ({ default: cookieParserMock }));
 
 const staticHandler = vi.fn();
 const staticMock = vi.fn(() => staticHandler);
@@ -35,9 +28,6 @@ expressMock.static = staticMock;
 vi.mock("express", () => ({ default: expressMock }));
 
 export {
-  compressionMock,
-  fileUploadMock,
-  cookieParserMock,
   expressMock,
   appMock,
   expressJsonMock,

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -51,7 +51,7 @@ describe("Integration", () => {
   );
 
   test("Should treat optionals the same way as z.infer() by default", async () => {
-    const client = await Integration.create({
+    const client = new Integration({
       config: configMock,
       routing: {
         v1: {
@@ -74,7 +74,7 @@ describe("Integration", () => {
   test.each([undefined, false])(
     "Should support HEAD method by default %#",
     async (hasHeadMethod) => {
-      const client = await Integration.create({
+      const client = new Integration({
         config: configMock,
         hasHeadMethod,
         variant: "types",
@@ -111,7 +111,7 @@ describe("Integration", () => {
         handler: vi.fn(),
       }),
     );
-    const client = await Integration.create({
+    const client = new Integration({
       config: configMock,
       variant: "types",
       routing: {

--- a/express-zod-api/tests/peer-helpers.spec.ts
+++ b/express-zod-api/tests/peer-helpers.spec.ts
@@ -3,11 +3,11 @@ import { loadPeer } from "../src/peer-helpers";
 
 describe("Peer loading helpers", () => {
   describe("loadPeer()", () => {
-    test("should load the module", async () => {
-      expect(await loadPeer("compression")).toBeTruthy();
+    test("should load the module", () => {
+      expect(loadPeer("compression")).toBeTruthy();
     });
-    test("should throw when module not found", async () => {
-      await expect(async () => loadPeer("missing")).rejects.toThrow(
+    test("should throw when module not found", () => {
+      expect(() => loadPeer("missing")).toThrow(
         new MissingPeerError("missing"),
       );
     });

--- a/express-zod-api/tests/peers-mock.ts
+++ b/express-zod-api/tests/peers-mock.ts
@@ -1,0 +1,20 @@
+const compressionMock = vi.fn();
+const fileUploadMock = vi.fn();
+const cookieParserMock = vi.fn();
+
+vi.mock("../src/peer-helpers", () => ({
+  loadPeer: (moduleName: string) => {
+    switch (moduleName) {
+      case "compression":
+        return compressionMock;
+      case "cookie-parser":
+        return cookieParserMock;
+      case "express-fileupload":
+        return fileUploadMock;
+      default:
+        throw new Error(`Unhandled peer dependency mock: ${moduleName}`);
+    }
+  },
+}));
+
+export { compressionMock, fileUploadMock, cookieParserMock };

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -1,5 +1,5 @@
+import { fileUploadMock } from "./peers-mock";
 import { fail } from "node:assert/strict";
-import { fileUploadMock } from "./express-mock";
 import {
   createLoggingMiddleware,
   createNotFoundHandler,

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -162,10 +162,10 @@ describe("Server helpers", () => {
     });
   });
 
-  describe("createUploadParsers()", async () => {
+  describe("createUploadParsers()", () => {
     const loggerMock = makeLoggerMock();
     const beforeUploadMock = vi.fn();
-    const parsers = await createUploadParsers({
+    const parsers = createUploadParsers({
       config: {
         http: { listen: 1234 },
         upload: {

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -1,9 +1,8 @@
+import { compressionMock, cookieParserMock } from "./peers-mock";
 import { moveRaw } from "../src/server-helpers";
 import { givePort } from "../../tools/ports";
 import {
   appMock,
-  compressionMock,
-  cookieParserMock,
   expressJsonMock,
   expressUrlencodedMock,
   expressMock,


### PR DESCRIPTION
This is now possible because we dropped Node 20 in v28 ( #3242 ) and `require(ESM)` is available since 22.12 without flags. So we can do dynamic module import without async.

Could benefit in #3463 

A semi-breaking change to `Integration::create()` is postponed until next major.

⌛ Mocking peers in tests requires a rework (in progress)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Peer dependency loading is now synchronous, simplifying server startup flow.
  * Middleware setup for cookies and uploads now runs synchronously during initialization.
  * `Integration` TypeScript configuration is optional; prefer `new Integration(...)` over the deprecated `Integration.create()`.

* **Tests**
  * Updated integration and peer-helper tests to reflect synchronous initialization/loader behavior.
  * Adjusted and streamlined mocks for peers used in tests.

* **Documentation**
  * Updated the README “End-to-End Type Safety” example and added a `v28.6.0` changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->