### PR TITLE
fix(mem): Destroy and remove failed sockets by graceful monitoring

### DIFF
--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -17,7 +17,8 @@ export const monitor = (
 ) => {
   let pending: Promise<PromiseSettledResult<void>[]> | undefined;
   const sockets = new Set<Socket>();
-  const destroy = (socket: Socket) => void sockets.delete(socket.destroy());
+  const cleanup = (socket: Socket) => void sockets.delete(socket);
+  const destroy = (socket: Socket) => cleanup(socket.destroy());
 
   const disconnect = (socket: Socket) =>
     void (hasResponse(socket)
@@ -28,7 +29,11 @@ export const monitor = (
   const watch = (socket: Socket) =>
     void (pending
       ? /* v8 ignore next -- unstable */ socket.destroy()
-      : sockets.add(socket.once("close", () => void sockets.delete(socket))));
+      : sockets.add(
+          socket
+            .once("close", () => cleanup(socket))
+            .once("error", () => destroy(socket)),
+        ));
 
   for (const server of servers) // eslint-disable-next-line curly
     for (const event of ["connection", "secureConnection"])

--- a/express-zod-api/tests/graceful-shutdown.spec.ts
+++ b/express-zod-api/tests/graceful-shutdown.spec.ts
@@ -172,6 +172,25 @@ describe("monitor()", () => {
     },
   );
 
+  test(
+    "removes socket from tracking on error event",
+    { timeout: 500 },
+    async ({ signal }) => {
+      const [httpServer, port] = await makeHttpServer(() => {});
+      const graceful = monitor([httpServer], { timeout: 150 });
+      void fetch(`http://localhost:${port}`, { signal }).catch(() => {});
+      await vi.waitFor(() => assert(graceful.sockets.size > 0), {
+        timeout: 200,
+        interval: 30,
+      });
+      const [socket] = graceful.sockets;
+      socket?.emit("error", new Error("forced"));
+      expect(graceful.sockets.size).toBe(0);
+      expect(socket?.destroyed).toBeTruthy();
+      await graceful.shutdown();
+    },
+  );
+
   describe("https", async () => {
     const [httpsServer, port] = await makeHttpsServer(({}, res) => {
       res.end("foo");


### PR DESCRIPTION
This is supposed to handle broken sockets that emit `error` but do not emit `close`, so that the `Set` won't grow.
This is an edge case.
Extracted from #3490 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket cleanup during graceful shutdown so tracked connections are removed correctly even when a socket errors.
  * Ensured errored sockets are destroyed and no longer linger in the active socket set.
* **Tests**
  * Added coverage for socket error handling during shutdown to verify cleanup and shutdown complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->