### PR TITLE
fix(mem): Remove SSE response timer if connection closed early

### DIFF
--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -60,12 +60,12 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
   new Middleware({
     handler: async ({ request, response }): Promise<Emitter<E>> => {
       const controller = new AbortController();
+      const timer = setTimeout(() => ensureStream(response), headersTimeout);
 
       request.once("close", () => {
+        clearTimeout(timer);
         controller.abort();
       });
-
-      setTimeout(() => ensureStream(response), headersTimeout);
 
       return {
         isClosed: () => response.writableEnded || response.closed,

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -113,17 +113,20 @@ describe("SSE", () => {
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
       vi.useFakeTimers();
-      const middleware = makeMiddleware({ test: z.string() });
-      const { requestMock, responseMock, output } = await testMiddleware({
-        middleware,
-      });
-      expect(output.signal?.aborted).toBeFalsy();
-      expect(responseMock.headersSent).toBeFalsy();
-      requestMock.emit("close");
-      expect(output.signal?.aborted).toBeTruthy();
-      vi.advanceTimersByTime(10000);
-      expect(responseMock.headersSent).toBeFalsy();
-      vi.useRealTimers();
+      try {
+        const middleware = makeMiddleware({ test: z.string() });
+        const { requestMock, responseMock, output } = await testMiddleware({
+          middleware,
+        });
+        expect(output.signal?.aborted).toBeFalsy();
+        expect(responseMock.headersSent).toBeFalsy();
+        requestMock.emit("close");
+        expect(output.signal?.aborted).toBeTruthy();
+        vi.advanceTimersByTime(10000);
+        expect(responseMock.headersSent).toBeFalsy();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -110,6 +110,21 @@ describe("SSE", () => {
       requestMock.emit("close");
       expect(signal?.aborted).toBeTruthy();
     });
+
+    test("should clear the stream timeout when request closes before timeout fires", async () => {
+      vi.useFakeTimers();
+      const middleware = makeMiddleware({ test: z.string() });
+      const { requestMock, responseMock, output } = await testMiddleware({
+        middleware,
+      });
+      expect(output.signal?.aborted).toBeFalsy();
+      expect(responseMock.headersSent).toBeFalsy();
+      requestMock.emit("close");
+      expect(output.signal?.aborted).toBeTruthy();
+      vi.advanceTimersByTime(10000);
+      expect(responseMock.headersSent).toBeFalsy();
+      vi.useRealTimers();
+    });
   });
 
   describe("makeResultHandler()", () => {


### PR DESCRIPTION
This should prevent keeping redundant timers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-sent events handling so pending connection setup is canceled when a client disconnects.
  * Prevented stream/header initialization from occurring after the request is closed.
  * Added automated coverage to verify timer cleanup on disconnect and that no headers are sent after closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->