### PR TITLE
fix(mem): Ensure single graceful shutdown monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 28
 
+### v28.7.3
+
+- Several minor improvements to the `gracefulShutdown` feature:
+  - Ensured a single graceful shutdown event listener per signal on the process;
+  - Handling potential errors thrown from syncronous `beforeExit` hooks and ensured the hooks run only once.
+
 ### v28.7.2
 
 - Several minor memory optimizations:

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -1,7 +1,5 @@
-import http from "node:http";
-import https from "node:https";
 import { setInterval } from "node:timers/promises";
-import type { Socket } from "node:net";
+import type { Socket, Server } from "node:net";
 import type { ActualLogger } from "./logger-helpers";
 import {
   closeAsync,
@@ -11,11 +9,12 @@ import {
   weAreClosed,
 } from "./graceful-helpers";
 
-export const monitor = (
-  servers: Array<http.Server | https.Server>,
-  { timeout = 1e3, logger }: { timeout?: number; logger?: ActualLogger } = {},
-) => {
+export const monitor = ({
+  timeout = 1e3,
+  logger,
+}: { timeout?: number; logger?: ActualLogger } = {}) => {
   let pending: Promise<PromiseSettledResult<void>[]> | undefined;
+  const servers: Array<Server> = [];
   const sockets = new Set<Socket>();
   const cleanup = (socket: Socket) => void sockets.delete(socket);
   const destroy = (socket: Socket) => cleanup(socket.destroy());
@@ -35,9 +34,12 @@ export const monitor = (
             .once("error", () => destroy(socket)),
         ));
 
-  for (const server of servers) // eslint-disable-next-line curly
-    for (const event of ["connection", "secureConnection"])
-      server.on(event, watch);
+  const add = (...subjects: Server[]) => {
+    servers.push(...subjects);
+    for (const server of subjects) // eslint-disable-next-line curly
+      for (const event of ["connection", "secureConnection"])
+        server.on(event, watch);
+  };
 
   const workflow = async () => {
     for (const server of servers) server.on("request", weAreClosed);
@@ -50,5 +52,5 @@ export const monitor = (
     return Promise.allSettled(servers.map(closeAsync));
   };
 
-  return { sockets, shutdown: () => (pending ??= workflow()) };
+  return { sockets, add, shutdown: () => (pending ??= workflow()) };
 };

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -52,5 +52,10 @@ export const monitor = ({
     return Promise.allSettled(servers.map(closeAsync));
   };
 
-  return { sockets, add, shutdown: () => (pending ??= workflow()) };
+  return {
+    sockets,
+    add,
+    shutdown: () => (pending ??= workflow()),
+    get isShuttingDown() { return !!pending; }, // eslint-disable-line prettier/prettier
+  };
 };

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -34,13 +34,6 @@ export const monitor = ({
             .once("error", () => destroy(socket)),
         ));
 
-  const add = (...subjects: Server[]) => {
-    servers.push(...subjects);
-    for (const server of subjects) // eslint-disable-next-line curly
-      for (const event of ["connection", "secureConnection"])
-        server.on(event, watch);
-  };
-
   const workflow = async () => {
     for (const server of servers) server.on("request", weAreClosed);
     logger?.info("Graceful shutdown", { sockets: sockets.size, timeout });
@@ -52,10 +45,17 @@ export const monitor = ({
     return Promise.allSettled(servers.map(closeAsync));
   };
 
-  return {
+  const instance = {
     sockets,
-    add,
+    add: (...subjects: Server[]) => {
+      servers.push(...subjects);
+      for (const server of subjects) // eslint-disable-next-line curly
+        for (const event of ["connection", "secureConnection"])
+          server.on(event, watch);
+      return instance;
+    },
     shutdown: () => (pending ??= workflow()),
     get isShuttingDown() { return !!pending; }, // eslint-disable-line prettier/prettier
   };
+  return instance;
 };

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -14,7 +14,7 @@ export const monitor = ({
   logger,
 }: { timeout?: number; logger?: ActualLogger } = {}) => {
   let pending: Promise<PromiseSettledResult<void>[]> | undefined;
-  const servers: Array<Server> = [];
+  const servers = new Set<Server>();
   const sockets = new Set<Socket>();
   const cleanup = (socket: Socket) => void sockets.delete(socket);
   const destroy = (socket: Socket) => cleanup(socket.destroy());
@@ -42,16 +42,18 @@ export const monitor = ({
     for await (const started of setInterval(10, Date.now()))
       if (sockets.size === 0 || Date.now() - started >= timeout) break;
     for (const socket of sockets) destroy(socket);
-    return Promise.allSettled(servers.map(closeAsync));
+    return Promise.allSettled([...servers].map(closeAsync));
   };
 
   const instance = {
     sockets,
     add: (...subjects: Server[]) => {
-      servers.push(...subjects);
-      for (const server of subjects) // eslint-disable-next-line curly
+      for (const server of subjects) {
+        if (servers.has(server)) continue;
+        servers.add(server);
         for (const event of ["connection", "secureConnection"])
           server.on(event, watch);
+      }
       return instance;
     },
     shutdown: () => (pending ??= workflow()),

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -186,8 +186,9 @@ export const installTerminationListener = ({
   graceful.add(...servers);
   if (beforeExit) exitHooks.push(() => Promise.resolve().then(beforeExit));
   onTerm ??= async () => {
+    if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    await Promise.allSettled(exitHooks.splice(0).map((hook) => hook()));
+    await Promise.allSettled(exitHooks.map((hook) => hook()));
     logger.info("Done.");
     process.exit();
   };

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -188,11 +188,8 @@ export const installTerminationListener = ({
   onTerm ??= async () => {
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    if (exitHooks.size) {
-      await Promise.allSettled(
-        [...exitHooks].map((hook) => Promise.resolve().then(hook)),
-      );
-    }
+    if (exitHooks.size)
+      await Promise.allSettled([...exitHooks].map(async (hook) => hook()));
     process.exit();
   };
   for (const trigger of events) {

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -10,6 +10,7 @@ import { lastResortHandler } from "./last-resort";
 import { ResultHandlerError } from "./errors";
 import { ensureError } from "./common-helpers";
 import { monitor } from "./graceful-shutdown";
+import type { Server } from "node:net";
 
 // eslint-disable-next-line no-restricted-syntax -- substituted by TSDOWN
 export const localsID = Symbol.for(process.env.TSDOWN_SELF!);
@@ -169,20 +170,29 @@ export const installDeprecationListener = (logger: ActualLogger) => {
   );
 };
 
+let graceful: ReturnType<typeof monitor> | undefined;
+let onTerm: () => Promise<void> | undefined;
+const exitHooks: Array<() => Promise<void>> = [];
 export const installTerminationListener = ({
   servers,
   logger,
   options: { timeout, beforeExit, events = ["SIGINT", "SIGTERM"] },
 }: {
-  servers: Parameters<typeof monitor>[0];
+  servers: Server[];
   options: Extract<ServerConfig["gracefulShutdown"], object>;
   logger: ActualLogger;
 }) => {
-  const graceful = monitor(servers, { logger, timeout });
-  const onTerm = async () => {
-    await graceful.shutdown();
-    await beforeExit?.();
+  graceful ??= monitor({ logger, timeout });
+  graceful.add(...servers);
+  if (beforeExit) exitHooks.push(() => Promise.resolve().then(beforeExit));
+  onTerm ??= async () => {
+    await graceful?.shutdown();
+    await Promise.allSettled(exitHooks.splice(0).map((hook) => hook()));
+    logger.info("Done.");
     process.exit();
   };
-  for (const trigger of events) process.on(trigger, onTerm);
+  for (const trigger of events) {
+    if (!process.listeners(trigger).includes(onTerm))
+      process.on(trigger, onTerm);
+  }
 };

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -172,7 +172,7 @@ export const installDeprecationListener = (logger: ActualLogger) => {
 
 let graceful: ReturnType<typeof monitor> | undefined;
 let onTerm: (() => Promise<void>) | undefined;
-const beforeExitHooks = new Set<() => Promise<void>>();
+const exitHooks = new Set<() => void | Promise<void>>();
 export const installTerminationListener = ({
   servers,
   logger,
@@ -184,12 +184,15 @@ export const installTerminationListener = ({
 }) => {
   graceful ??= monitor({ logger, timeout });
   graceful.add(...servers);
-  if (beforeExit) beforeExitHooks.add(() => Promise.resolve().then(beforeExit));
+  if (beforeExit) exitHooks.add(beforeExit);
   onTerm ??= async () => {
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    if (beforeExitHooks.size)
-      await Promise.allSettled([...beforeExitHooks].map((hook) => hook()));
+    if (exitHooks.size) {
+      await Promise.allSettled(
+        [...exitHooks].map((hook) => Promise.resolve().then(hook)),
+      );
+    }
     process.exit();
   };
   for (const trigger of events) {

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -189,7 +189,6 @@ export const installTerminationListener = ({
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
     await Promise.allSettled(exitHooks.map((hook) => hook()));
-    logger.info("Done.");
     process.exit();
   };
   for (const trigger of events) {

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -188,7 +188,8 @@ export const installTerminationListener = ({
   onTerm ??= async () => {
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    await Promise.allSettled(exitHooks.map((hook) => hook()));
+    if (exitHooks.length)
+      await Promise.allSettled(exitHooks.map((hook) => hook()));
     process.exit();
   };
   for (const trigger of events) {

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -171,7 +171,7 @@ export const installDeprecationListener = (logger: ActualLogger) => {
 };
 
 let graceful: ReturnType<typeof monitor> | undefined;
-let onTerm: () => Promise<void> | undefined;
+let onTerm: (() => Promise<void>) | undefined;
 const exitHooks: Array<() => Promise<void>> = [];
 export const installTerminationListener = ({
   servers,

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -172,7 +172,7 @@ export const installDeprecationListener = (logger: ActualLogger) => {
 
 let graceful: ReturnType<typeof monitor> | undefined;
 let onTerm: (() => Promise<void>) | undefined;
-const exitHooks: Array<() => Promise<void>> = [];
+const beforeExitHooks = new Set<() => Promise<void>>();
 export const installTerminationListener = ({
   servers,
   logger,
@@ -184,12 +184,12 @@ export const installTerminationListener = ({
 }) => {
   graceful ??= monitor({ logger, timeout });
   graceful.add(...servers);
-  if (beforeExit) exitHooks.push(() => Promise.resolve().then(beforeExit));
+  if (beforeExit) beforeExitHooks.add(() => Promise.resolve().then(beforeExit));
   onTerm ??= async () => {
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    if (exitHooks.length)
-      await Promise.allSettled(exitHooks.map((hook) => hook()));
+    if (beforeExitHooks.size)
+      await Promise.allSettled([...beforeExitHooks].map((hook) => hook()));
     process.exit();
   };
   for (const trigger of events) {

--- a/express-zod-api/tests/graceful-shutdown.spec.ts
+++ b/express-zod-api/tests/graceful-shutdown.spec.ts
@@ -37,7 +37,8 @@ describe("monitor()", () => {
     async () => {
       const [httpServer] = await makeHttpServer(vi.fn());
       expect(httpServer.listening).toBeTruthy();
-      const graceful = monitor([httpServer]);
+      const graceful = monitor();
+      graceful.add(httpServer);
       await graceful.shutdown();
       expect(httpServer.listening).toBeFalsy();
     },
@@ -49,7 +50,8 @@ describe("monitor()", () => {
     async ({ signal }) => {
       const handler = vi.fn();
       const [httpServer, port] = await makeHttpServer(handler);
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       void fetch(`http://localhost:${port}`, {
         signal,
         headers: { connection: "close" },
@@ -75,7 +77,8 @@ describe("monitor()", () => {
         await setTimeout(100);
         res.end("foo");
       });
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       const request0 = fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,
@@ -102,7 +105,8 @@ describe("monitor()", () => {
         await setTimeout(100);
         res.end("foo");
       });
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       const request = fetch(`http://localhost:${port}`, {
         keepalive: true,
         signal,
@@ -131,7 +135,8 @@ describe("monitor()", () => {
           res.end("baz");
         });
       const [httpServer, port] = await makeHttpServer(handler);
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       const dispatcher = new Agent({ pipelining: 5, keepAliveTimeout: 5e3 });
       const request0 = fetch(`http://localhost:${port}`, {
         dispatcher,
@@ -161,7 +166,8 @@ describe("monitor()", () => {
       const [httpServer, port] = await makeHttpServer(({}, res) => {
         res.end("foo");
       });
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       await fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,
@@ -177,7 +183,8 @@ describe("monitor()", () => {
     { timeout: 500 },
     async ({ signal }) => {
       const [httpServer, port] = await makeHttpServer(() => {});
-      const graceful = monitor([httpServer], { timeout: 150 });
+      const graceful = monitor({ timeout: 150 });
+      graceful.add(httpServer);
       void fetch(`http://localhost:${port}`, { signal }).catch(() => {});
       await vi.waitFor(() => assert(graceful.sockets.size > 0), {
         timeout: 200,
@@ -200,7 +207,8 @@ describe("monitor()", () => {
       "empties internal socket collection for https server",
       { timeout: 500 },
       async ({ signal }) => {
-        const graceful = monitor([httpsServer], { timeout: 150 });
+        const graceful = monitor({ timeout: 150 });
+        graceful.add(httpsServer);
         await fetch(`https://localhost:${port}`, {
           dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
           headers: { connection: "close" },
@@ -223,7 +231,8 @@ describe("monitor()", () => {
       });
       const [httpServer, port] = await makeHttpServer(spy);
       expect(httpServer.listening).toBeTruthy();
-      const graceful = monitor([httpServer], { timeout: 500 });
+      const graceful = monitor({ timeout: 500 });
+      graceful.add(httpServer);
       void fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,

--- a/express-zod-api/tests/graceful-shutdown.spec.ts
+++ b/express-zod-api/tests/graceful-shutdown.spec.ts
@@ -37,8 +37,7 @@ describe("monitor()", () => {
     async () => {
       const [httpServer] = await makeHttpServer(vi.fn());
       expect(httpServer.listening).toBeTruthy();
-      const graceful = monitor();
-      graceful.add(httpServer);
+      const graceful = monitor().add(httpServer);
       await graceful.shutdown();
       expect(httpServer.listening).toBeFalsy();
     },
@@ -50,8 +49,7 @@ describe("monitor()", () => {
     async ({ signal }) => {
       const handler = vi.fn();
       const [httpServer, port] = await makeHttpServer(handler);
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       void fetch(`http://localhost:${port}`, {
         signal,
         headers: { connection: "close" },
@@ -77,8 +75,7 @@ describe("monitor()", () => {
         await setTimeout(100);
         res.end("foo");
       });
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       const request0 = fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,
@@ -107,8 +104,7 @@ describe("monitor()", () => {
         await setTimeout(100);
         res.end("foo");
       });
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       const request = fetch(`http://localhost:${port}`, {
         keepalive: true,
         signal,
@@ -137,8 +133,7 @@ describe("monitor()", () => {
           res.end("baz");
         });
       const [httpServer, port] = await makeHttpServer(handler);
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       const dispatcher = new Agent({ pipelining: 5, keepAliveTimeout: 5e3 });
       const request0 = fetch(`http://localhost:${port}`, {
         dispatcher,
@@ -168,8 +163,7 @@ describe("monitor()", () => {
       const [httpServer, port] = await makeHttpServer(({}, res) => {
         res.end("foo");
       });
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       await fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,
@@ -185,8 +179,7 @@ describe("monitor()", () => {
     { timeout: 500 },
     async ({ signal }) => {
       const [httpServer, port] = await makeHttpServer(() => {});
-      const graceful = monitor({ timeout: 150 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 150 }).add(httpServer);
       void fetch(`http://localhost:${port}`, { signal }).catch(() => {});
       await vi.waitFor(() => assert(graceful.sockets.size > 0), {
         timeout: 200,
@@ -209,8 +202,7 @@ describe("monitor()", () => {
       "empties internal socket collection for https server",
       { timeout: 500 },
       async ({ signal }) => {
-        const graceful = monitor({ timeout: 150 });
-        graceful.add(httpsServer);
+        const graceful = monitor({ timeout: 150 }).add(httpsServer);
         await fetch(`https://localhost:${port}`, {
           dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
           headers: { connection: "close" },
@@ -233,8 +225,7 @@ describe("monitor()", () => {
       });
       const [httpServer, port] = await makeHttpServer(spy);
       expect(httpServer.listening).toBeTruthy();
-      const graceful = monitor({ timeout: 500 });
-      graceful.add(httpServer);
+      const graceful = monitor({ timeout: 500 }).add(httpServer);
       void fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },
         signal,

--- a/express-zod-api/tests/graceful-shutdown.spec.ts
+++ b/express-zod-api/tests/graceful-shutdown.spec.ts
@@ -84,7 +84,9 @@ describe("monitor()", () => {
         signal,
       });
       await setTimeout(50);
+      expect(graceful.isShuttingDown).toBeFalsy();
       void graceful.shutdown();
+      expect(graceful.isShuttingDown).toBeTruthy();
       await setTimeout(50);
       const request1 = fetch(`http://localhost:${port}`, {
         headers: { connection: "close" },

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -329,6 +329,7 @@ describe("Server helpers", () => {
       expect(spy).toHaveBeenCalledWith("deprecation", expect.any(Function));
       installDeprecationListener(logger);
       expect(spy).toHaveBeenCalledOnce();
+      spy.mockReset();
     });
   });
 

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -335,7 +335,17 @@ describe("Server helpers", () => {
   describe("installTerminationListener", () => {
     test("should install termination signal listener on process only once per event", () => {
       const eventName = "NOT_HAPPEN";
-      expect(process.listenerCount(eventName)).toBe(0);
+      const listeners: Record<string, any[]> = {};
+      const spy = vi
+        .spyOn(process, "on")
+        .mockImplementation((evt: string, fn: any) => {
+          listeners[evt] ??= [];
+          listeners[evt].push(fn);
+          return process;
+        });
+      vi.spyOn(process, "listeners").mockImplementation(
+        (evt: string) => listeners[evt] ?? [],
+      );
       const logger = makeLoggerMock();
       const argument = {
         servers: [],
@@ -343,10 +353,15 @@ describe("Server helpers", () => {
         options: { events: [eventName] },
       };
       installTerminationListener(argument);
-      expect(process.listenerCount(eventName)).toBe(1);
+      expect(spy).toHaveBeenCalledExactlyOnceWith(
+        eventName,
+        expect.any(Function),
+      );
       installTerminationListener(argument);
-      expect(process.listenerCount(eventName)).toBe(1);
-      process.removeAllListeners(eventName);
+      expect(spy).toHaveBeenCalledExactlyOnceWith(
+        eventName,
+        expect.any(Function),
+      );
     });
   });
 });

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -356,7 +356,7 @@ describe("Server helpers", () => {
       installTerminationListener({
         servers: [],
         logger,
-        options: { events: ["NOT_HAPPEN", "ANOTHER_ONE"] },
+        options: { events: ["NOT_HAPPEN", "ANOTHER_ONE", "NOT_HAPPEN"] },
       });
       expect(spy.mock.calls).toEqual([
         ["NOT_HAPPEN", expect.any(Function)],

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -333,15 +333,20 @@ describe("Server helpers", () => {
   });
 
   describe("installTerminationListener", () => {
-    test("should install termination signal listener on process", () => {
-      const spy = vi.spyOn(process, "on").mockImplementation(vi.fn());
+    test("should install termination signal listener on process only once per event", () => {
+      const eventName = "NOT_HAPPEN";
+      expect(process.listenerCount(eventName)).toBe(0);
       const logger = makeLoggerMock();
-      installTerminationListener({
+      const argument = {
         servers: [],
         logger,
-        options: { events: ["NOT_HAPPEN"] },
-      });
-      expect(spy).toHaveBeenCalledWith("NOT_HAPPEN", expect.any(Function));
+        options: { events: [eventName] },
+      };
+      installTerminationListener(argument);
+      expect(process.listenerCount(eventName)).toBe(1);
+      installTerminationListener(argument);
+      expect(process.listenerCount(eventName)).toBe(1);
+      process.removeAllListeners(eventName);
     });
   });
 });

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -334,7 +334,6 @@ describe("Server helpers", () => {
 
   describe("installTerminationListener", () => {
     test("should install termination signal listener on process only once per event", () => {
-      const eventName = "NOT_HAPPEN";
       const listeners: Record<string, any[]> = {};
       const spy = vi
         .spyOn(process, "on")
@@ -347,21 +346,21 @@ describe("Server helpers", () => {
         (evt: string) => listeners[evt] ?? [],
       );
       const logger = makeLoggerMock();
-      const argument = {
+      installTerminationListener({
         servers: [],
         logger,
-        options: { events: [eventName] },
-      };
-      installTerminationListener(argument);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(
-        eventName,
-        expect.any(Function),
-      );
-      installTerminationListener(argument);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(
-        eventName,
-        expect.any(Function),
-      );
+        options: { events: ["NOT_HAPPEN"] },
+      });
+      expect(spy.mock.calls).toEqual([["NOT_HAPPEN", expect.any(Function)]]);
+      installTerminationListener({
+        servers: [],
+        logger,
+        options: { events: ["NOT_HAPPEN", "ANOTHER_ONE"] },
+      });
+      expect(spy.mock.calls).toEqual([
+        ["NOT_HAPPEN", expect.any(Function)],
+        ["ANOTHER_ONE", expect.any(Function)],
+      ]);
     });
   });
 });

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -135,7 +135,7 @@ describe("App in production mode", async () => {
     "post /v1/upload": uploadEndpoint,
   };
   vi.spyOn(process.stdout, "write").mockImplementation(vi.fn()); // mutes logo output
-  const beforeExit = vi.fn();
+  const beforeExit = vi.fn().mockThrowOnce("failure resistant");
   const config = createConfig({
     http: { listen: port },
     compression: { threshold: 1 },


### PR DESCRIPTION
Extracted from #3490 
Minor memory optimization for an edge case of running multiple servers on the same process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated graceful shutdown to use an options-based setup and a runtime `add(...)` helper for registering servers.
  * Exposes `isShuttingDown` to indicate shutdown progress.
* **Bug Fixes**
  * Ensures only one termination listener is installed per signal to avoid duplicates.
  * Prevents concurrent shutdown re-entry and improves reliable socket/server closing, including safe handling of synchronous `beforeExit` errors.
* **Tests**
  * Adjusted graceful shutdown and termination listener tests for the new API flow and added shutdown-state assertions.
* **Documentation**
  * Added `v28.7.3` changelog notes covering listener installation and hook error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->