### PR TITLE
fix(mem): Lazy allocation of exitHooks, only when used.

### DIFF
--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -172,7 +172,7 @@ export const installDeprecationListener = (logger: ActualLogger) => {
 
 let graceful: ReturnType<typeof monitor> | undefined;
 let onTerm: (() => Promise<void>) | undefined;
-const exitHooks = new Set<() => void | Promise<void>>();
+let exitHooks: Set<() => void | Promise<void>> | undefined;
 export const installTerminationListener = ({
   servers,
   logger,
@@ -184,11 +184,11 @@ export const installTerminationListener = ({
 }) => {
   graceful ??= monitor({ logger, timeout });
   graceful.add(...servers);
-  if (beforeExit) exitHooks.add(beforeExit);
+  if (beforeExit) (exitHooks ??= new Set()).add(beforeExit);
   onTerm ??= async () => {
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
-    if (exitHooks.size)
+    if (exitHooks)
       await Promise.allSettled([...exitHooks].map(async (hook) => hook()));
     process.exit();
   };


### PR DESCRIPTION
Complements #3495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so cleanup callbacks are only prepared when needed.
  * Made termination processing more resilient by skipping hook execution when no callbacks were registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->