### PR TITLE
fix(perf): Iterating `Set` through `::values()`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,11 @@ const performanceConcerns = [
     selector: "CallExpression[callee.property.name=/^(shift|unshift)$/]", // #3343
     message: "shifting is 2-20x slower than index-based iteration",
   },
+  {
+    selector:
+      "CallExpression > MemberExpression[property.name='map'] > ArrayExpression > SpreadElement",
+    message: "use Set::values().map() instead (mem+perf)",
+  },
 ];
 
 const tsFactoryConcerns = [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,7 @@ const performanceConcerns = [
   {
     selector:
       "CallExpression > MemberExpression[property.name='map'] > ArrayExpression > SpreadElement",
-    message: "Set::values().map() would be 5% faster and more memory efficient",
+    message: "use Set::values().map() instead (mem+perf)",
   },
 ];
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,7 @@ const performanceConcerns = [
   {
     selector:
       "CallExpression > MemberExpression[property.name='map'] > ArrayExpression > SpreadElement",
-    message: "use Set::values().map() instead (mem+perf)",
+    message: "Set::values().map() would be 5% faster and more memory efficient",
   },
 ];
 

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -4,9 +4,9 @@ describe("Set iteration", () => {
   const set = new Set([1, 2]);
   const mapper = (x: number) => x * 2;
   bench("spread map", () => {
-    return void [...set].map(mapper);
+    [...set].map(mapper);
   });
   bench("values map", () => {
-    return void set.values().map(mapper);
+    set.values().map(mapper);
   });
 });

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -7,6 +7,6 @@ describe("Set iteration", () => {
     return void [...set].map(mapper);
   });
   bench("values map", () => {
-    return void set.values().map(mapper);
+    return void [...set.values().map(mapper)];
   });
 });

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -4,9 +4,9 @@ describe("Set iteration", () => {
   const set = new Set([1, 2]);
   const mapper = (x: number) => x * 2;
   bench("spread map", () => {
-    [...set].map(mapper);
+    return void [...set].map(mapper);
   });
   bench("values map", () => {
-    [...set.values().map(mapper)];
+    return void [...set.values().map(mapper)];
   });
 });

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -1,0 +1,12 @@
+import { bench } from "vitest";
+
+describe("Set iteration", () => {
+  const set = new Set([1, 2]);
+  const mapper = (x: number) => x * 2;
+  bench("spread map", () => {
+    return void [...set].map(mapper);
+  });
+  bench("values map", () => {
+    return void set.values().map(mapper);
+  });
+});

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -7,6 +7,6 @@ describe("Set iteration", () => {
     return void [...set].map(mapper);
   });
   bench("values map", () => {
-    return void [...set.values().map(mapper)];
+    return void set.values().map(mapper);
   });
 });

--- a/express-zod-api/src/graceful-shutdown.ts
+++ b/express-zod-api/src/graceful-shutdown.ts
@@ -42,7 +42,7 @@ export const monitor = ({
     for await (const started of setInterval(10, Date.now()))
       if (sockets.size === 0 || Date.now() - started >= timeout) break;
     for (const socket of sockets) destroy(socket);
-    return Promise.allSettled([...servers].map(closeAsync));
+    return Promise.allSettled(servers.values().map(closeAsync));
   };
 
   const instance = {

--- a/express-zod-api/src/server-helpers.ts
+++ b/express-zod-api/src/server-helpers.ts
@@ -189,7 +189,7 @@ export const installTerminationListener = ({
     if (graceful?.isShuttingDown) return;
     await graceful?.shutdown();
     if (exitHooks)
-      await Promise.allSettled([...exitHooks].map(async (hook) => hook()));
+      await Promise.allSettled(exitHooks.values().map(async (hook) => hook()));
     process.exit();
   };
   for (const trigger of events) {


### PR DESCRIPTION
Complements #3495 

Set::values()::map() is stable in Node 22 without flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved set-iteration handling for shutdown-related workflows, reducing unnecessary array creation and improving memory efficiency.
  * Added a benchmark to compare set iteration approaches and validate the faster pattern.
* **Style**
  * Updated linting guidance to discourage less efficient set-to-array mapping patterns in favor of direct iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->