### PR TITLE
fix(perf): Add cache to Endpoint::requestType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 28
 
+### v28.7.5
+
+- Small performance improvement for startup and Documentation generator (cache for request type resolution).
+
 ### v28.7.4
 
 - Centralized the `ResultHandler` error handling by `AbstractResultHandler::execute()`:

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -86,6 +86,7 @@ export class Endpoint<
   CTX extends FlatObject,
 > extends AbstractEndpoint {
   readonly #def: ConstructorParameters<typeof Endpoint<IN, OUT, CTX>>[0];
+  #requestType?: ContentType;
 
   /** considered an expensive operation, only required for generators */
   #ensureOutputExamples = R.once(() => {
@@ -159,14 +160,16 @@ export class Endpoint<
 
   /** @internal */
   public override get requestType() {
-    const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
-    if (found) {
-      const brand = getBrand(found);
-      if (brand === ezUploadBrand) return "upload";
-      if (brand === ezRawBrand) return "raw";
-      if (brand === ezFormBrand) return "form";
-    }
-    return "json";
+    return (this.#requestType ??= (() => {
+      const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
+      if (found) {
+        const brand = getBrand(found);
+        if (brand === ezUploadBrand) return "upload";
+        if (brand === ezRawBrand) return "raw";
+        if (brand === ezFormBrand) return "form";
+      }
+      return "json";
+    })());
   }
 
   /** @internal */


### PR DESCRIPTION
Found it useful during #3507 

This should improve the startup performance in `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved request content-type detection by caching the resolved value and reusing it on subsequent checks.
  * This avoids repeated computation and makes request handling slightly more efficient when the value is accessed multiple times.
* **Documentation**
  * Updated the changelog with a new release entry highlighting a small startup/performance improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->