### PR TITLE
fix(types): Using Express native QUERY method support

### DIFF
--- a/express-zod-api/src/method.ts
+++ b/express-zod-api/src/method.ts
@@ -2,10 +2,10 @@ import type { IRouter } from "express";
 
 export type SomeMethod = Lowercase<string>;
 
-type FamiliarMethod =
-  | Exclude<keyof IRouter, "param" | "use" | "route" | "stack" | "all">
-  /** @todo remove when merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75187 */
-  | "query";
+type FamiliarMethod = Exclude<
+  keyof IRouter,
+  "param" | "use" | "route" | "stack" | "all"
+>;
 
 export const methods = [
   "get",

--- a/express-zod-api/src/routing.ts
+++ b/express-zod-api/src/routing.ts
@@ -81,10 +81,7 @@ export const initRouting = ({ app, config, getLogger, ...rest }: InitProps) => {
         const logger = getLogger(request);
         return endpoint.execute({ request, response, logger, config });
       });
-      const register:
-        ((path: string, ...handlers: RequestHandler[]) => IRouter) | undefined =
-        app[method];
-      register?.call(app, path, ...handlers);
+      app[method]?.(path, ...handlers);
     }
     if (config.hintAllowedMethods === false) continue;
     deprioritized.set(path, createWrongMethodHandler(accessMethods));

--- a/express-zod-api/src/routing.ts
+++ b/express-zod-api/src/routing.ts
@@ -1,4 +1,4 @@
-import type { IRouter, RequestHandler, IRouterMatcher } from "express";
+import type { IRouter, RequestHandler } from "express";
 import createHttpError from "http-errors";
 import { isProduction } from "./common-helpers";
 import type { CommonConfig } from "./config-type";
@@ -81,10 +81,10 @@ export const initRouting = ({ app, config, getLogger, ...rest }: InitProps) => {
         const logger = getLogger(request);
         return endpoint.execute({ request, response, logger, config });
       });
-      /** @todo remove type assertion when merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75187 */
-      const register: (path: string, ...handlers: RequestHandler[]) => IRouter =
-        (app as IRouter & { query: IRouterMatcher<IRouter> })[method];
-      register.call(app, path, ...handlers);
+      const register:
+        ((path: string, ...handlers: RequestHandler[]) => IRouter) | undefined =
+        app[method];
+      register?.call(app, path, ...handlers);
     }
     if (config.hintAllowedMethods === false) continue;
     deprioritized.set(path, createWrongMethodHandler(accessMethods));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,8 +630,8 @@ packages:
   '@types/express-fileupload@1.5.1':
     resolution: {integrity: sha512-DllImBVI1lCyjl2klky/TEwk60mbNebgXv1669h66g9TfptWSrEFq5a/raHSutaFzjSm1tmn9ypdNfu4jPSixQ==}
 
-  '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+  '@types/express-serve-static-core@5.1.2':
+    resolution: {integrity: sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==}
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
@@ -2229,7 +2229,7 @@ snapshots:
       '@types/busboy': 1.5.4
       '@types/express': 5.0.6
 
-  '@types/express-serve-static-core@5.1.1':
+  '@types/express-serve-static-core@5.1.2':
     dependencies:
       '@types/node': 26.0.1
       '@types/qs': 6.15.0
@@ -2239,7 +2239,7 @@ snapshots:
   '@types/express@5.0.6':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.1
+      '@types/express-serve-static-core': 5.1.2
       '@types/serve-static': 2.2.0
 
   '@types/http-errors@2.0.5': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ autoInstallPeers: false
 dedupePeers: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - "@types/express-serve-static-core@5.1.2"
+  - "@types/express-serve-static-core@5.1.2" # todo remove 15.07.2026
 publicHoistPattern:
   - "@typescript-eslint/*" # used as an assumed transitive in migration
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ engineStrict: true
 autoInstallPeers: false
 dedupePeers: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@types/express-serve-static-core@5.1.2"
 publicHoistPattern:
   - "@typescript-eslint/*" # used as an assumed transitive in migration
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts


### PR DESCRIPTION
I added QUERY to the Express types myself, so now I can remove the workaround.

Addresses the "todo" made in #3479 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing registration reliability so supported request methods are handled more safely at runtime.
  * Fixed method handling for query-related routes to better match available request types.
* **Chores**
  * Updated workspace release settings to allow a specific dependency version exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->