### PR TITLE
fix(types): upgrading `node-mocks-http` for using QUERY method

### DIFF
--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "ansis": "^4.2.0",
-    "node-mocks-http": "^1.17.2",
+    "node-mocks-http": "^1.18.0",
     "openapi3-ts": "^4.6.0",
     "ramda": "catalog:prod"
   },

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -167,8 +167,7 @@ describe("Common Helpers", () => {
           makeRequestMock({
             query: { q: "search" },
             body: { filters: "active" },
-            /** @todo rm when merged: https://github.com/eugef/node-mocks-http/pull/335 */
-            method: "QUERY" as "GET",
+            method: "QUERY",
           }),
           undefined,
         ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: ^4.2.0
         version: 4.3.1
       node-mocks-http:
-        specifier: ^1.17.2
-        version: 1.17.2(@types/express@5.0.6)(@types/node@26.0.1)
+        specifier: ^1.18.0
+        version: 1.18.0(@types/express@5.0.6)(@types/node@26.0.1)
       openapi3-ts:
         specifier: ^4.6.0
         version: 4.6.0
@@ -1446,8 +1446,8 @@ packages:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
-  node-mocks-http@1.17.2:
-    resolution: {integrity: sha512-HVxSnjNzE9NzoWMx9T9z4MLqwMpLwVvA0oVZ+L+gXskYXEJ6tFn3Kx4LargoB6ie7ZlCLplv7QbWO6N+MysWGA==}
+  node-mocks-http@1.18.0:
+    resolution: {integrity: sha512-arItRIarSUnpHAagCV5SB0DARvPXTA2ur+cVPCMm8d/KT2sqr9AF/QuHOoT3/PZ5cYFaQrpVkmoDUmMxuGW1Cw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@types/express': ^4.17.21 || ^5.0.0
@@ -3146,7 +3146,7 @@ snapshots:
 
   node-forge@1.4.0: {}
 
-  node-mocks-http@1.17.2(@types/express@5.0.6)(@types/node@26.0.1):
+  node-mocks-http@1.18.0(@types/express@5.0.6)(@types/node@26.0.1):
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
@@ -3155,7 +3155,6 @@ snapshots:
       merge-descriptors: 1.0.3
       methods: 1.1.2
       mime: 1.6.0
-      parseurl: 1.3.3
       range-parser: 1.3.0
       type-is: 1.6.18
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ dedupePeers: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "@types/express-serve-static-core@5.1.2" # todo remove 15.07.2026
+  - "node-mocks-http" # todo remove 15.07.2026
 publicHoistPattern:
   - "@typescript-eslint/*" # used as an assumed transitive in migration
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts


### PR DESCRIPTION
Another type-related fix for enabling QUERY method support without crutches.