### PR TITLE
fix(test): Add disposable timers to SSE test

### DIFF
--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -23,6 +23,14 @@ import {
 } from "../src/testing";
 import { AbstractEndpoint } from "../src/endpoint";
 
+const useFakeTimers = () => {
+  vi.useFakeTimers();
+  return {
+    [Symbol.dispose]: () => void vi.useRealTimers(),
+    shift: vi.advanceTimersByTime.bind(vi),
+  };
+};
+
 describe("SSE", () => {
   describe("makeEventSchema()", () => {
     test("should make a valid schema of SSE event", () => {
@@ -112,21 +120,17 @@ describe("SSE", () => {
     });
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
-      vi.useFakeTimers();
-      try {
-        const middleware = makeMiddleware({ test: z.string() });
-        const { requestMock, responseMock, output } = await testMiddleware({
-          middleware,
-        });
-        expect(output.signal?.aborted).toBeFalsy();
-        expect(responseMock.headersSent).toBeFalsy();
-        requestMock.emit("close");
-        expect(output.signal?.aborted).toBeTruthy();
-        vi.advanceTimersByTime(10000);
-        expect(responseMock.headersSent).toBeFalsy();
-      } finally {
-        vi.useRealTimers();
-      }
+      using timers = useFakeTimers();
+      const middleware = makeMiddleware({ test: z.string() });
+      const { requestMock, responseMock, output } = await testMiddleware({
+        middleware,
+      });
+      expect(output.signal?.aborted).toBeFalsy();
+      expect(responseMock.headersSent).toBeFalsy();
+      requestMock.emit("close");
+      expect(output.signal?.aborted).toBeTruthy();
+      timers.shift(1e4);
+      expect(responseMock.headersSent).toBeFalsy();
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability and determinism of server-sent event timeout testing.
  * Added scoped timer cleanup to prevent test state from affecting other tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->