### PR TITLE
br(29): Dedicated entrypoints for Integration and Documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Markdown files should avoid `---` horizontal rule separators.
 
 ### 13. TypeScript Generators Policy
 
-For generating TypeScript code, prefer using helpers from `TypescriptAPI` class over direct factory methods. Native
+For generating TypeScript code, prefer using helpers from `typescript-api.ts` over direct factory methods. Native
 factory methods have verbose APIs with many redundant arguments.
 
 Files that generate TypeScript code:
@@ -224,11 +224,11 @@ Files that generate TypeScript code:
 **Examples**: Use these helpers instead of verbose factory calls:
 
 ```typescript
-// Use TypescriptAPI methods:
-api.makeId("User");
-api.makeParam("name", { type: "string" });
-api.makeConst("count", api.literally(0));
-api.makeInterface("User", [api.makeInterfaceProp("name", "string")]);
+// Use helpers:
+makeId("User");
+makeParam("name", { type: "string" });
+makeConst("count", api.literally(0));
+makeInterface("User", [api.makeInterfaceProp("name", "string")]);
 
 // Avoid native factory calls:
 ts.factory.createIdentifier("User");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,20 @@
   - `serverUrl` renamed to `server` and now also accepts OpenAPI's ServerObject;
   - `title` and `version` must be wrapped into `info`, assignable with OpenAPI's InfoObject;
 - The Documentation generator is featuring the OpenAPI 3.2.0 with better SSE support and other features;
+- `Integration` and `Documentation` are now available via dedicated subpath exports;
+- Removed `typescript` option from `Integration` constructor — typescript is now imported statically within the integration module;
+- ⚠️? `typescript` is re-exported from `express-zod-api/integration` for use in `brandHandling` callbacks;
+- `Producer` type moved to `express-zod-api/integration`;
+- `Depicter` type moved to `express-zod-api/documentation`;
+- The main entrypoint (`express-zod-api`) no longer exports `Integration`, `Documentation`, `Producer`, or `Depicter`;
 - Consider using [the automated migration](https://www.npmjs.com/package/@express-zod-api/migration).
 
 ```diff
+- import { Integration, type Producer } from "express-zod-api";
++ import { Integration, type Producer } from "express-zod-api/integration";
+- import { Documentation, type Depicter } from "express-zod-api";
++ import { Documentation, type Depicter } from "express-zod-api/documentation";
+
   const config = createConfig({
 -   cors: () => ({ origin: "https://example.com" }),
 +   cors: cors({ origin: "https://example.com" }), // import cors from "cors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,21 +17,20 @@
   - The hooks (`beforeRouting` and `afterRouting` config options) are no longer async;
   - `beforeRouting` now runs after the installation of globally enabled parsers;
   - Added new `beforeParsers` hook that runs before all parsers are installed.
-- The static async method `Integration::create()` removed — use `new Integration()` instead;
 - The `createServer()` function is now synchronous — that should simplify the daily routines for beginners;
 - Added HTTP QUERY method support (RFC 10008):
   - The QUERY method is like GET but with a body — safe, idempotent, and cacheable;
   - Default input sources for QUERY: `["query", "body", "params"]` (from the lowest priority to highest);
   - Supported by `Integration` and `Documentation` generators.
-- Changes to `Documentation` constructor:
-  - `serverUrl` renamed to `server` and now also accepts OpenAPI's ServerObject;
-  - `title` and `version` must be wrapped into `info`, assignable with OpenAPI's InfoObject;
-- The Documentation generator is featuring the OpenAPI 3.2.0 with better SSE support and other features;
-- `Integration` and `Documentation` are now available via dedicated subpath exports;
-- Removed `typescript` option from `Integration` constructor — typescript is now imported statically within the integration module;
-- `Producer` type moved to `express-zod-api/integration`;
-- `Depicter` type moved to `express-zod-api/documentation`;
-- The main entrypoint (`express-zod-api`) no longer exports `Integration`, `Documentation`, `Producer`, or `Depicter`;
+- Changes to `Documentation`:
+  - Moved to the dedicated subpath `express-zod-api/documentation` along with `Depicter` type;
+  - `serverUrl` constructor option renamed to `server` and now also accepts OpenAPI's ServerObject;
+  - `title` option and `version` must be wrapped into `info`, assignable with OpenAPI's InfoObject;
+  - Now produces OpenAPI 3.2.0 with better SSE support and other features.
+- Changes to `Integration`:
+  - Moved to the dedicated subpath `express-zod-api/integration` along with `Producer` type;
+  - The static async method `create()` removed — use `new Integration()` instead;
+  - Removed `typescript` option from constructor — now imported statically.
 - Consider using [the automated migration](https://www.npmjs.com/package/@express-zod-api/migration).
 
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 - The Documentation generator is featuring the OpenAPI 3.2.0 with better SSE support and other features;
 - `Integration` and `Documentation` are now available via dedicated subpath exports;
 - Removed `typescript` option from `Integration` constructor — typescript is now imported statically within the integration module;
-- ⚠️? `typescript` is re-exported from `express-zod-api/integration` for use in `brandHandling` callbacks;
 - `Producer` type moved to `express-zod-api/integration`;
 - `Depicter` type moved to `express-zod-api/documentation`;
 - The main entrypoint (`express-zod-api`) no longer exports `Integration`, `Documentation`, `Producer`, or `Depicter`;

--- a/README.md
+++ b/README.md
@@ -1213,7 +1213,7 @@ safety between your API and frontend. Make sure you have `typescript` installed.
 and using the async `printFormatted()` method.
 
 ```ts
-import { Integration } from "express-zod-api";
+import { Integration } from "express-zod-api/integration";
 
 const client = new Integration({
   routing,
@@ -1243,7 +1243,7 @@ new Subscription("get /v1/events/stream", {}).on("time", (time) => {}); // Serve
 You can generate the specification of your API and write it to a `.yaml` file, that can be used as the documentation:
 
 ```ts
-import { Documentation } from "express-zod-api";
+import { Documentation } from "express-zod-api/documentation";
 
 const yamlString = new Documentation({
   routing, // the same routing and config that you use to start the server
@@ -1287,7 +1287,8 @@ endpoints is available for that purpose. In order to establish the constraints o
 should be declared as keys of `TagOverrides` interface. Consider the following example:
 
 ```ts
-import { defaultEndpointsFactory, Documentation } from "express-zod-api";
+import { defaultEndpointsFactory } from "express-zod-api";
+import { Documentation } from "express-zod-api/documentation";
 
 // Add similar declaration once, somewhere in your code, preferably near config
 declare module "express-zod-api" {
@@ -1346,12 +1347,8 @@ handling rule for multiple brands, use the exposed types `Depicter` and `Produce
 ```ts
 import ts from "typescript";
 import { z } from "zod";
-import {
-  Documentation,
-  Integration,
-  Depicter,
-  Producer,
-} from "express-zod-api";
+import { Documentation, Depicter } from "express-zod-api/documentation";
+import { Integration, Producer } from "express-zod-api/integration";
 
 const myBrand = Symbol("MamaToldMeImSpecial"); // I recommend to use symbols for this purpose
 const myBrandedSchema = z.string().xBrand(myBrand); // requires Zod Plugin, or .meta({ "x-brand": myBrand })

--- a/README.md
+++ b/README.md
@@ -1347,8 +1347,8 @@ handling rule for multiple brands, use the exposed types `Depicter` and `Produce
 ```ts
 import ts from "typescript";
 import { z } from "zod";
-import { Documentation, Depicter } from "express-zod-api/documentation";
-import { Integration, Producer } from "express-zod-api/integration";
+import { Documentation, type Depicter } from "express-zod-api/documentation";
+import { Integration, type Producer } from "express-zod-api/integration";
 
 const myBrand = Symbol("MamaToldMeImSpecial"); // I recommend to use symbols for this purpose
 const myBrandedSchema = z.string().xBrand(myBrand); // requires Zod Plugin, or .meta({ "x-brand": myBrand })

--- a/compat-test/int.spec.ts
+++ b/compat-test/int.spec.ts
@@ -1,4 +1,4 @@
-import { Integration } from "express-zod-api";
+import { Integration } from "express-zod-api/integration";
 import { describe, test, expect } from "vitest";
 
 describe("Integration", () => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,108 +89,108 @@ const performanceConcerns = [
 const tsFactoryConcerns = [
   {
     selector: "Identifier[name='createConditionalExpression']",
-    message: "use TypescriptAPI::makeTernary()",
+    message: "use makeTernary()",
   },
   {
     selector: "Identifier[name='createArrowFunction']",
-    message: "use TypescriptAPI::makeArrowFn()",
+    message: "use makeArrowFn()",
   },
   {
     selector: "Identifier[name='createTypeParameterDeclaration']",
-    message: "use TypescriptAPI::makeTypeParams()",
+    message: "use makeTypeParams()",
   },
   {
     selector: "Identifier[name='createInterfaceDeclaration']",
-    message: "use TypescriptAPI::makeInterface()",
+    message: "use makeInterface()",
   },
   {
     selector: "Identifier[name='createClassDeclaration']",
-    message: "use TypescriptAPI::makePublicClass()",
+    message: "use makePublicClass()",
   },
   {
     selector: "Identifier[name='createMethodDeclaration']",
-    message: "use TypescriptAPI::makePublicMethod()",
+    message: "use makePublicMethod()",
   },
   {
     selector: "Identifier[name='createTypeAliasDeclaration']",
-    message: "use TypescriptAPI::makeType()",
+    message: "use makeType()",
   },
   {
     selector: "Identifier[name='createVariableStatement']",
-    message: "use TypescriptAPI::makeConst()",
+    message: "use makeConst()",
   },
   {
     selector: "Identifier[name='createArrayBindingPattern']",
-    message: "use TypescriptAPI::makeDeconstruction()",
+    message: "use makeDeconstruction()",
   },
   {
     selector: "Identifier[name='createPropertySignature']",
-    message: "use TypescriptAPI::makeInterfaceProp()",
+    message: "use makeInterfaceProp()",
   },
   {
     selector: "Identifier[name='createConstructorDeclaration']",
-    message: "use TypescriptAPI::makePublicConstructor()",
+    message: "use makePublicConstructor()",
   },
   {
     selector: "Identifier[name='createParameterDeclaration']",
-    message: "use TypescriptAPI::makeParam()",
+    message: "use makeParam()",
   },
   {
     selector: "Identifier[name='createCallExpression']",
-    message: "use TypescriptAPI::makeCall()",
+    message: "use makeCall()",
   },
   {
     selector: "Identifier[name='KeyOfKeyword']",
-    message: "use TypescriptAPI::makeKeyOf()",
+    message: "use makeKeyOf()",
   },
   {
     selector: "Identifier[name='createTemplateExpression']",
-    message: "use TypescriptAPI::makeTemplate()",
+    message: "use makeTemplate()",
   },
   {
     selector: "Identifier[name='createNewExpression']",
-    message: "use TypescriptAPI::makeNew()",
+    message: "use makeNew()",
   },
   {
     selector: "Literal[value='Promise']",
-    message: "use TypescriptAPI::makePromise()",
+    message: "use makePromise()",
   },
   {
     selector: "Identifier[name=/^create(TypeReference|KeywordType)Node$/]",
-    message: "use TypescriptAPI::ensureTypeNode()",
+    message: "use ensureTypeNode()",
   },
   {
     selector: "Literal[value='Extract']",
-    message: "use TypescriptAPI::makeExtract()",
+    message: "use makeExtract()",
   },
   {
     selector: "Identifier[name='EqualsToken']",
-    message: "use TypescriptAPI::makeAssignment()",
+    message: "use makeAssignment()",
   },
   {
     selector: "Identifier[name='createIndexedAccessTypeNode']",
-    message: "use TypescriptAPI::makeIndexed()",
+    message: "use makeIndexed()",
   },
   {
     selector: "Identifier[name='createFunctionTypeNode']",
-    message: "use TypescriptAPI::makeFnType()",
+    message: "use makeFnType()",
   },
   {
     selector: "Identifier[name='createLiteralTypeNode']",
-    message: "use TypescriptAPI::makeLiteralType()",
+    message: "use makeLiteralType()",
   },
   {
     selector:
       "Identifier[name=/^create(NumericLiteral|StringLiteral|True|False|Null)$/]",
-    message: "use TypescriptAPI::literally()",
+    message: "use literally()",
   },
   {
     selector: "Identifier[name='createUnionTypeNode']",
-    message: "use TypescriptAPI::makeUnion()",
+    message: "use makeUnion()",
   },
   {
     selector: "Identifier[name='createIdentifier']",
-    message: "use TypescriptAPI::makeId()",
+    message: "use makeId()",
   },
 ];
 

--- a/example/generate-client.ts
+++ b/example/generate-client.ts
@@ -1,13 +1,11 @@
 import { writeFile } from "node:fs/promises";
-import { Integration } from "express-zod-api";
+import { Integration } from "express-zod-api/integration";
 import { routing } from "./routing.ts";
 import { config } from "./config.ts";
-import typescript from "typescript";
 
 await writeFile(
   "example.client.ts",
   await new Integration({
-    typescript,
     routing,
     config,
     serverUrl: `http://localhost:${config.http!.listen}`,

--- a/example/generate-documentation.ts
+++ b/example/generate-documentation.ts
@@ -1,5 +1,5 @@
 import { writeFile } from "node:fs/promises";
-import { Documentation } from "express-zod-api";
+import { Documentation } from "express-zod-api/documentation";
 import { config } from "./config.ts";
 import { routing } from "./routing.ts";
 import manifest from "./package.json" with { type: "json" };

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -39,6 +39,10 @@
     "./documentation": {
       "types": "./dist/documentation.d.ts",
       "default": "./dist/documentation.js"
+    },
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     }
   },
   "files": [

--- a/express-zod-api/package.json
+++ b/express-zod-api/package.json
@@ -31,6 +31,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./integration": {
+      "types": "./dist/integration.d.ts",
+      "default": "./dist/integration.js"
+    },
+    "./documentation": {
+      "types": "./dist/documentation.d.ts",
+      "default": "./dist/documentation.js"
     }
   },
   "files": [

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -1,3 +1,5 @@
+/** @fileOverview The entrypoint for generating OpenAPI Documentation */
+export type { Depicter } from "./documentation-helpers";
 import {
   type InfoObject,
   type OperationObject,
@@ -297,5 +299,3 @@ export class Documentation extends OpenApiBuilder {
     walkRouting({ ...rest, onEndpoint });
   }
 }
-
-export type { Depicter } from "./documentation-helpers";

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -297,3 +297,5 @@ export class Documentation extends OpenApiBuilder {
     walkRouting({ ...rest, onEndpoint });
   }
 }
+
+export type { Depicter } from "./documentation-helpers";

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -40,7 +40,7 @@ export type { CacheControl, CachePolicy } from "./cache-middleware";
 export type { Routing } from "./routing";
 export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
-export type { IOSchema, FinalInputSchema } from "./io-schema";
+export type { IOSchema } from "./io-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
 export type { ApiResponse } from "./api-response";
 export type {
@@ -52,4 +52,3 @@ export type {
   OAuth2Security,
   OpenIdSecurity,
 } from "./security";
-export type { Endpoint } from "./endpoint";

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -40,7 +40,7 @@ export type { CacheControl, CachePolicy } from "./cache-middleware";
 export type { Routing } from "./routing";
 export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
-export type { IOSchema } from "./io-schema";
+export type { IOSchema, FinalInputSchema } from "./io-schema";
 export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
 export type { ApiResponse } from "./api-response";
 export type {
@@ -52,3 +52,4 @@ export type {
   OAuth2Security,
   OpenIdSecurity,
 } from "./security";
+export type { Endpoint } from "./endpoint";

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -18,7 +18,6 @@ export {
 } from "./result-handler";
 export { ServeStatic } from "./serve-static";
 export { createServer, attachRouting } from "./server";
-export { Documentation } from "./documentation";
 export {
   DocumentationError,
   RoutingError,
@@ -27,14 +26,9 @@ export {
   MissingPeerError,
 } from "./errors";
 export { testEndpoint, testMiddleware } from "./testing";
-export { Integration } from "./integration";
 export { EventStreamFactory } from "./sse";
 
 export { ez } from "./proprietary-schemas";
-
-// Convenience types
-export type { Depicter } from "./documentation-helpers";
-export type { Producer } from "./zts-helpers";
 
 // Interfaces exposed for augmentation
 export type { LoggerOverrides } from "./logger-helpers";

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -1,10 +1,46 @@
 import * as R from "ramda";
-import type ts from "typescript";
 import type { ResponseVariant } from "./api-response";
 import { contentTypes } from "./content-type";
 import { clientMethods, type ClientMethod } from "./method";
 import type { makeEventSchema } from "./sse";
-import { propOf, TypescriptAPI, type Typeable } from "./typescript-api";
+import {
+  type Typeable,
+  accessModifiers,
+  ensureTypeNode,
+  literally,
+  makeAssignment,
+  makeCall,
+  makeConst,
+  makeDeconstruction,
+  makeExtract,
+  makeFnType,
+  makeId,
+  makeIndexed,
+  makeInterface,
+  makeInterfaceProp,
+  makeKeyOf,
+  makeLiteralType,
+  makeMaybeAsync,
+  makeNew,
+  makeOneLine,
+  makeParam,
+  makeParams,
+  makePromise,
+  makePropertyIdentifier,
+  makePublicClass,
+  makePublicConstructor,
+  makePublicLiteralType,
+  makePublicMethod,
+  makePublicProperty,
+  makeRecordStringAny,
+  makeTemplate,
+  makeTernary,
+  makeType,
+  makeUnion,
+  propOf,
+  ts,
+  makeArrowFn,
+} from "./typescript-api";
 import type {
   CursorPaginatedResult,
   OffsetPaginatedResult,
@@ -16,8 +52,6 @@ type Store = Record<IOKind, ts.TypeNode>;
 
 export abstract class IntegrationBase {
   /** @internal */
-  protected readonly api: TypescriptAPI;
-  /** @internal */
   protected paths = new Set<string>();
   /** @internal */
   protected tags = new Map<string, ReadonlyArray<string>>();
@@ -27,12 +61,7 @@ export abstract class IntegrationBase {
     { store: Store; isDeprecated: boolean }
   >();
 
-  protected constructor(
-    typescript: typeof ts,
-    protected readonly serverUrl: string,
-  ) {
-    this.api = new TypescriptAPI(typescript);
-  }
+  protected constructor(protected readonly serverUrl: string) {}
 
   readonly #ids = {
     pathType: "Path",
@@ -82,43 +111,39 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeMethodType = () =>
-    this.api.makePublicLiteralType(this.#ids.methodType, clientMethods);
+    makePublicLiteralType(this.#ids.methodType, clientMethods);
 
   /**
    * @example type SomeOf<T> = T[keyof T];
    * @internal
    * */
   protected makeSomeOfType = () =>
-    this.api.makeType(
-      this.#ids.someOfType,
-      this.api.makeIndexed("T", this.api.makeKeyOf("T")),
-      { params: ["T"] },
-    );
+    makeType(this.#ids.someOfType, makeIndexed("T", makeKeyOf("T")), {
+      params: ["T"],
+    });
 
   /**
    * @example export type Request = keyof Input;
    * @internal
    * */
   protected makeRequestType = () =>
-    this.api.makeType(
-      this.#ids.requestType,
-      this.api.makeKeyOf(this.interfaces.input),
-      { expose: true },
-    );
+    makeType(this.#ids.requestType, makeKeyOf(this.interfaces.input), {
+      expose: true,
+    });
 
   /**
    * @example SomeOf<_>
    * @internal
    **/
   protected someOf = ({ name }: ts.TypeAliasDeclaration) =>
-    this.api.ensureTypeNode(this.#ids.someOfType, [name]);
+    ensureTypeNode(this.#ids.someOfType, [name]);
 
   /**
    * @example export type Path = "/v1/user/retrieve" | ___;
    * @internal
    * */
   protected makePathType = () =>
-    this.api.makePublicLiteralType(this.#ids.pathType, Array.from(this.paths));
+    makePublicLiteralType(this.#ids.pathType, Array.from(this.paths));
 
   /**
    * @example export interface Input { "get /v1/user/retrieve": GetV1UserRetrieveInput; }
@@ -126,10 +151,10 @@ export abstract class IntegrationBase {
    * */
   protected makePublicInterfaces = () =>
     (Object.keys(this.interfaces) as IOKind[]).map((kind) =>
-      this.api.makeInterface(
+      makeInterface(
         this.interfaces[kind],
         Array.from(this.registry).map(([request, { store, isDeprecated }]) =>
-          this.api.makeInterfaceProp(request, store[kind], { isDeprecated }),
+          makeInterfaceProp(request, store[kind], { isDeprecated }),
         ),
         { expose: true },
       ),
@@ -140,15 +165,13 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeEndpointTags = () =>
-    this.api.makeConst(
+    makeConst(
       "endpointTags",
-      this.api.f.createObjectLiteralExpression(
+      ts.factory.createObjectLiteralExpression(
         Array.from(this.tags).map(([request, tags]) =>
-          this.api.f.createPropertyAssignment(
-            this.api.makePropertyIdentifier(request),
-            this.api.f.createArrayLiteralExpression(
-              R.map(this.api.literally, tags),
-            ),
+          ts.factory.createPropertyAssignment(
+            makePropertyIdentifier(request),
+            ts.factory.createArrayLiteralExpression(R.map(literally, tags)),
           ),
         ),
       ),
@@ -160,20 +183,20 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeImplementationType = () =>
-    this.api.makeType(
+    makeType(
       this.#ids.implementationType,
-      this.api.makeFnType(
+      makeFnType(
         {
           [this.#ids.methodParameter]: this.#ids.methodType,
-          [this.#ids.pathParameter]: this.api.ts.SyntaxKind.StringKeyword,
-          [this.#ids.paramsArgument]: this.api.makeRecordStringAny(),
+          [this.#ids.pathParameter]: ts.SyntaxKind.StringKeyword,
+          [this.#ids.paramsArgument]: makeRecordStringAny(),
           [this.#ids.ctxArgument]: { optional: true, type: "T" },
         },
-        this.api.makePromise(this.api.ts.SyntaxKind.AnyKeyword),
+        makePromise(ts.SyntaxKind.AnyKeyword),
       ),
       {
         expose: true,
-        params: { T: { init: this.api.ts.SyntaxKind.UnknownKeyword } },
+        params: { T: { init: ts.SyntaxKind.UnknownKeyword } },
       },
     );
 
@@ -182,21 +205,18 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeParseRequestFn = () =>
-    this.api.makeConst(
+    makeConst(
       this.#ids.parseRequestFn,
-      this.api.makeArrowFn(
-        { [this.#ids.requestParameter]: this.api.ts.SyntaxKind.StringKeyword },
-        this.api.f.createAsExpression(
-          this.api.makeCall(
-            this.#ids.requestParameter,
-            propOf<string>("split"),
-          )(
-            this.api.f.createRegularExpressionLiteral("/ (.+)/"), // split once
-            this.api.literally(2), // excludes third empty element
+      makeArrowFn(
+        { [this.#ids.requestParameter]: ts.SyntaxKind.StringKeyword },
+        ts.factory.createAsExpression(
+          makeCall(this.#ids.requestParameter, propOf<string>("split"))(
+            ts.factory.createRegularExpressionLiteral("/ (.+)/"), // split once
+            literally(2), // excludes third empty element
           ),
-          this.api.f.createTupleTypeNode([
-            this.api.ensureTypeNode(this.#ids.methodType),
-            this.api.ensureTypeNode(this.#ids.pathType),
+          ts.factory.createTupleTypeNode([
+            ensureTypeNode(this.#ids.methodType),
+            ensureTypeNode(this.#ids.pathType),
           ]),
         ),
       ),
@@ -207,51 +227,48 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeSubstituteFn = () =>
-    this.api.makeConst(
+    makeConst(
       this.#ids.substituteFn,
-      this.api.makeArrowFn(
+      makeArrowFn(
         {
-          [this.#ids.pathParameter]: this.api.ts.SyntaxKind.StringKeyword,
-          [this.#ids.paramsArgument]: this.api.makeRecordStringAny(),
+          [this.#ids.pathParameter]: ts.SyntaxKind.StringKeyword,
+          [this.#ids.paramsArgument]: makeRecordStringAny(),
         },
-        this.api.f.createBlock([
-          this.api.makeConst(
+        ts.factory.createBlock([
+          makeConst(
             this.#ids.restConst,
-            this.api.f.createObjectLiteralExpression([
-              this.api.f.createSpreadAssignment(
-                this.api.makeId(this.#ids.paramsArgument),
+            ts.factory.createObjectLiteralExpression([
+              ts.factory.createSpreadAssignment(
+                makeId(this.#ids.paramsArgument),
               ),
             ]),
           ),
-          this.api.f.createForInStatement(
-            this.api.f.createVariableDeclarationList(
-              [this.api.f.createVariableDeclaration(this.#ids.keyParameter)],
-              this.api.ts.NodeFlags.Const,
+          ts.factory.createForInStatement(
+            ts.factory.createVariableDeclarationList(
+              [ts.factory.createVariableDeclaration(this.#ids.keyParameter)],
+              ts.NodeFlags.Const,
             ),
-            this.api.makeId(this.#ids.paramsArgument),
-            this.api.f.createBlock([
-              this.api.makeAssignment(
+            makeId(this.#ids.paramsArgument),
+            ts.factory.createBlock([
+              makeAssignment(
                 this.#ids.pathParameter,
-                this.api.makeCall(
-                  this.#ids.pathParameter,
-                  propOf<string>("replace"),
-                )(
-                  this.api.makeTemplate(":", [this.#ids.keyParameter]), // `:${key}`
-                  this.api.makeArrowFn(
+                makeCall(this.#ids.pathParameter, propOf<string>("replace"))(
+                  makeTemplate(":", [this.#ids.keyParameter]), // `:${key}`
+                  makeArrowFn(
                     [],
-                    this.api.f.createBlock([
-                      this.api.f.createExpressionStatement(
-                        this.api.f.createDeleteExpression(
-                          this.api.f.createElementAccessExpression(
-                            this.api.makeId(this.#ids.restConst),
-                            this.api.makeId(this.#ids.keyParameter),
+                    ts.factory.createBlock([
+                      ts.factory.createExpressionStatement(
+                        ts.factory.createDeleteExpression(
+                          ts.factory.createElementAccessExpression(
+                            makeId(this.#ids.restConst),
+                            makeId(this.#ids.keyParameter),
                           ),
                         ),
                       ),
-                      this.api.f.createReturnStatement(
-                        this.api.f.createElementAccessExpression(
-                          this.api.makeId(this.#ids.paramsArgument),
-                          this.api.makeId(this.#ids.keyParameter),
+                      ts.factory.createReturnStatement(
+                        ts.factory.createElementAccessExpression(
+                          makeId(this.#ids.paramsArgument),
+                          makeId(this.#ids.keyParameter),
                         ),
                       ),
                     ]),
@@ -260,13 +277,13 @@ export abstract class IntegrationBase {
               ),
             ]),
           ),
-          this.api.f.createReturnStatement(
-            this.api.f.createAsExpression(
-              this.api.f.createArrayLiteralExpression([
-                this.api.makeId(this.#ids.pathParameter),
-                this.api.makeId(this.#ids.restConst),
+          ts.factory.createReturnStatement(
+            ts.factory.createAsExpression(
+              ts.factory.createArrayLiteralExpression([
+                makeId(this.#ids.pathParameter),
+                makeId(this.#ids.restConst),
               ]),
-              this.api.ensureTypeNode("const"),
+              ensureTypeNode("const"),
             ),
           ),
         ]),
@@ -284,23 +301,23 @@ export abstract class IntegrationBase {
     const limitProp = propOf<OffsetPaginatedResult["output"]["shape"]>("limit");
     const offsetProp =
       propOf<OffsetPaginatedResult["output"]["shape"]>("offset");
-    const cursorShape = this.api.f.createTypeLiteralNode([
-      this.api.makeInterfaceProp(
+    const cursorShape = ts.factory.createTypeLiteralNode([
+      makeInterfaceProp(
         nextCursorProp,
-        this.api.makeUnion([
-          this.api.ensureTypeNode(this.api.ts.SyntaxKind.StringKeyword),
-          this.api.makeLiteralType(null),
+        makeUnion([
+          ensureTypeNode(ts.SyntaxKind.StringKeyword),
+          makeLiteralType(null),
         ]),
       ),
     ]);
-    const offsetShape = this.api.f.createTypeLiteralNode(
+    const offsetShape = ts.factory.createTypeLiteralNode(
       [totalProp, limitProp, offsetProp].map((prop) =>
-        this.api.makeInterfaceProp(prop, this.api.ts.SyntaxKind.NumberKeyword),
+        makeInterfaceProp(prop, ts.SyntaxKind.NumberKeyword),
       ),
     );
-    return this.api.makeType(
+    return makeType(
       this.#ids.paginationType,
-      this.api.makeUnion([cursorShape, offsetShape]),
+      makeUnion([cursorShape, offsetShape]),
     );
   };
 
@@ -309,43 +326,43 @@ export abstract class IntegrationBase {
    * @internal
    */
   #makeHasMoreMethod = () => {
-    const responseId = this.api.makeId(this.#ids.responseConst);
+    const responseId = makeId(this.#ids.responseConst);
     const nextCursorProp =
       propOf<CursorPaginatedResult["output"]["shape"]>("nextCursor");
     const totalProp = propOf<OffsetPaginatedResult["output"]["shape"]>("total");
     const limitProp = propOf<OffsetPaginatedResult["output"]["shape"]>("limit");
     const offsetProp =
       propOf<OffsetPaginatedResult["output"]["shape"]>("offset");
-    const inExpression = this.api.f.createBinaryExpression(
-      this.api.literally(nextCursorProp),
-      this.api.ts.SyntaxKind.InKeyword,
+    const inExpression = ts.factory.createBinaryExpression(
+      literally(nextCursorProp),
+      ts.SyntaxKind.InKeyword,
       responseId,
     );
-    const returnCursor = this.api.f.createReturnStatement(
-      this.api.f.createBinaryExpression(
-        this.api.f.createPropertyAccessExpression(responseId, nextCursorProp),
-        this.api.ts.SyntaxKind.ExclamationEqualsEqualsToken,
-        this.api.literally(null),
+    const returnCursor = ts.factory.createReturnStatement(
+      ts.factory.createBinaryExpression(
+        ts.factory.createPropertyAccessExpression(responseId, nextCursorProp),
+        ts.SyntaxKind.ExclamationEqualsEqualsToken,
+        literally(null),
       ),
     );
-    const offsetPlusLimit = this.api.f.createBinaryExpression(
-      this.api.f.createPropertyAccessExpression(responseId, offsetProp),
-      this.api.ts.SyntaxKind.PlusToken,
-      this.api.f.createPropertyAccessExpression(responseId, limitProp),
+    const offsetPlusLimit = ts.factory.createBinaryExpression(
+      ts.factory.createPropertyAccessExpression(responseId, offsetProp),
+      ts.SyntaxKind.PlusToken,
+      ts.factory.createPropertyAccessExpression(responseId, limitProp),
     );
-    const returnOffset = this.api.f.createReturnStatement(
-      this.api.f.createBinaryExpression(
+    const returnOffset = ts.factory.createReturnStatement(
+      ts.factory.createBinaryExpression(
         offsetPlusLimit,
-        this.api.ts.SyntaxKind.LessThanToken,
-        this.api.f.createPropertyAccessExpression(responseId, totalProp),
+        ts.SyntaxKind.LessThanToken,
+        ts.factory.createPropertyAccessExpression(responseId, totalProp),
       ),
     );
-    return this.api.makePublicMethod(
+    return makePublicMethod(
       "hasMore",
-      [this.api.makeParam(responseId, { type: this.#ids.paginationType })],
-      [this.api.f.createIfStatement(inExpression, returnCursor), returnOffset],
+      [makeParam(responseId, { type: this.#ids.paginationType })],
+      [ts.factory.createIfStatement(inExpression, returnCursor), returnOffset],
       {
-        returns: this.api.ensureTypeNode(this.api.ts.SyntaxKind.BooleanKeyword),
+        returns: ensureTypeNode(ts.SyntaxKind.BooleanKeyword),
         isStatic: true,
       },
     );
@@ -353,36 +370,28 @@ export abstract class IntegrationBase {
 
   // public provide<K extends MethodPath>(request: K, params: Input[K]): Promise<Response[K]> {}
   #makeProvider = () =>
-    this.api.makePublicMethod(
+    makePublicMethod(
       this.#ids.provideMethod,
-      this.api.makeParams({
+      makeParams({
         [this.#ids.requestParameter]: "K",
-        [this.#ids.paramsArgument]: this.api.makeIndexed(
-          this.interfaces.input,
-          "K",
-        ),
+        [this.#ids.paramsArgument]: makeIndexed(this.interfaces.input, "K"),
         [this.#ids.ctxArgument]: { optional: true, type: "T" },
       }),
       [
-        this.api.makeConst(
+        makeConst(
           // const [method, path] = this.parseRequest(request);
-          this.api.makeDeconstruction(
+          makeDeconstruction(
             this.#ids.methodParameter,
             this.#ids.pathParameter,
           ),
-          this.api.makeCall(this.#ids.parseRequestFn)(
-            this.#ids.requestParameter,
-          ),
+          makeCall(this.#ids.parseRequestFn)(this.#ids.requestParameter),
         ),
         // return this.implementation(___)
-        this.api.f.createReturnStatement(
-          this.api.makeCall(
-            this.api.f.createThis(),
-            this.#ids.implementationArgument,
-          )(
+        ts.factory.createReturnStatement(
+          makeCall(ts.factory.createThis(), this.#ids.implementationArgument)(
             this.#ids.methodParameter,
-            this.api.f.createSpreadElement(
-              this.api.makeCall(this.#ids.substituteFn)(
+            ts.factory.createSpreadElement(
+              makeCall(this.#ids.substituteFn)(
                 this.#ids.pathParameter,
                 this.#ids.paramsArgument,
               ),
@@ -393,9 +402,7 @@ export abstract class IntegrationBase {
       ],
       {
         typeParams: { K: this.#ids.requestType },
-        returns: this.api.makePromise(
-          this.api.makeIndexed(this.interfaces.response, "K"),
-        ),
+        returns: makePromise(makeIndexed(this.interfaces.response, "K")),
       },
     );
 
@@ -404,14 +411,14 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeClientClass = (name: string) =>
-    this.api.makePublicClass(
+    makePublicClass(
       name,
       [
         // public constructor(protected readonly implementation: Implementation = defaultImplementation) {}
-        this.api.makePublicConstructor([
-          this.api.makeParam(this.#ids.implementationArgument, {
-            type: this.api.ensureTypeNode(this.#ids.implementationType, ["T"]),
-            mod: this.api.accessModifiers.protectedReadonly,
+        makePublicConstructor([
+          makeParam(this.#ids.implementationArgument, {
+            type: ensureTypeNode(this.#ids.implementationType, ["T"]),
+            mod: accessModifiers.protectedReadonly,
             initId: this.#ids.defaultImplementationConst,
           }),
         ]),
@@ -423,20 +430,18 @@ export abstract class IntegrationBase {
 
   // `?${new URLSearchParams(____)}`
   #makeSearchParams = (fromId: string) =>
-    this.api.makeTemplate("?", [
-      this.api.makeNew(URLSearchParams.name, this.api.makeId(fromId)),
-    ]);
+    makeTemplate("?", [makeNew(URLSearchParams.name, makeId(fromId))]);
 
   // new URL(`${path}${searchParams}`, "http:____")
   #makeFetchURL = () =>
-    this.api.makeNew(
+    makeNew(
       URL.name,
-      this.api.makeTemplate(
+      makeTemplate(
         "",
         [this.#ids.pathParameter],
         [this.#ids.searchParamsConst],
       ),
-      this.api.literally(this.serverUrl),
+      literally(this.serverUrl),
     );
 
   /**
@@ -445,23 +450,20 @@ export abstract class IntegrationBase {
    * */
   protected makeDefaultImplementation = () => {
     // method: method.toUpperCase()
-    const methodProperty = this.api.f.createPropertyAssignment(
+    const methodProperty = ts.factory.createPropertyAssignment(
       propOf<RequestInit>("method"),
-      this.api.makeCall(
-        this.#ids.methodParameter,
-        propOf<string>("toUpperCase"),
-      )(),
+      makeCall(this.#ids.methodParameter, propOf<string>("toUpperCase"))(),
     );
 
     // headers: hasBody ? { "Content-Type": "application/json" } : undefined
-    const headersProperty = this.api.f.createPropertyAssignment(
+    const headersProperty = ts.factory.createPropertyAssignment(
       propOf<RequestInit>("headers"),
-      this.api.makeTernary(
+      makeTernary(
         this.#ids.hasBodyConst,
-        this.api.f.createObjectLiteralExpression([
-          this.api.f.createPropertyAssignment(
-            this.api.literally("Content-Type"),
-            this.api.literally(contentTypes.json),
+        ts.factory.createObjectLiteralExpression([
+          ts.factory.createPropertyAssignment(
+            literally("Content-Type"),
+            literally(contentTypes.json),
           ),
         ]),
         this.#ids.undefinedValue,
@@ -469,11 +471,11 @@ export abstract class IntegrationBase {
     );
 
     // body: hasBody ? JSON.stringify(params) : undefined
-    const bodyProperty = this.api.f.createPropertyAssignment(
+    const bodyProperty = ts.factory.createPropertyAssignment(
       propOf<RequestInit>("body"),
-      this.api.makeTernary(
+      makeTernary(
         this.#ids.hasBodyConst,
-        this.api.makeCall(
+        makeCall(
           JSON[Symbol.toStringTag],
           propOf<JSON>("stringify"),
         )(this.#ids.paramsArgument),
@@ -482,12 +484,12 @@ export abstract class IntegrationBase {
     );
 
     // const response = await fetch(new URL(`${path}${searchParams}`, "https://example.com"), { ___ });
-    const responseStatement = this.api.makeConst(
+    const responseStatement = makeConst(
       this.#ids.responseConst,
-      this.api.f.createAwaitExpression(
-        this.api.makeCall(fetch.name)(
+      ts.factory.createAwaitExpression(
+        makeCall(fetch.name)(
           this.#makeFetchURL(),
-          this.api.f.createObjectLiteralExpression([
+          ts.factory.createObjectLiteralExpression([
             methodProperty,
             headersProperty,
             bodyProperty,
@@ -497,14 +499,14 @@ export abstract class IntegrationBase {
     );
 
     // const hasBody = !["get", "delete"].includes(method);
-    const hasBodyStatement = this.api.makeConst(
+    const hasBodyStatement = makeConst(
       this.#ids.hasBodyConst,
-      this.api.f.createLogicalNot(
-        this.api.makeCall(
-          this.api.f.createArrayLiteralExpression([
-            this.api.literally("get" satisfies ClientMethod),
-            this.api.literally("head" satisfies ClientMethod),
-            this.api.literally("delete" satisfies ClientMethod),
+      ts.factory.createLogicalNot(
+        makeCall(
+          ts.factory.createArrayLiteralExpression([
+            literally("get" satisfies ClientMethod),
+            literally("head" satisfies ClientMethod),
+            literally("delete" satisfies ClientMethod),
           ]),
           propOf<string[]>("includes"),
         )(this.#ids.methodParameter),
@@ -512,64 +514,64 @@ export abstract class IntegrationBase {
     );
 
     // const searchParams = hasBody ? "" : ___;
-    const searchParamsStatement = this.api.makeConst(
+    const searchParamsStatement = makeConst(
       this.#ids.searchParamsConst,
-      this.api.makeTernary(
+      makeTernary(
         this.#ids.hasBodyConst,
-        this.api.literally(""),
+        literally(""),
         this.#makeSearchParams(this.#ids.paramsArgument),
       ),
     );
 
     // const contentType = response.headers.get("content-type");
-    const contentTypeStatement = this.api.makeConst(
+    const contentTypeStatement = makeConst(
       this.#ids.contentTypeConst,
-      this.api.makeCall(
+      makeCall(
         this.#ids.responseConst,
         propOf<Response>("headers"),
         propOf<Headers>("get"),
-      )(this.api.literally("content-type")),
+      )(literally("content-type")),
     );
 
     // if (!contentType) return;
-    const noBodyStatement = this.api.f.createIfStatement(
-      this.api.f.createPrefixUnaryExpression(
-        this.api.ts.SyntaxKind.ExclamationToken,
-        this.api.makeId(this.#ids.contentTypeConst),
+    const noBodyStatement = ts.factory.createIfStatement(
+      ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.ExclamationToken,
+        makeId(this.#ids.contentTypeConst),
       ),
-      this.api.f.createReturnStatement(),
+      ts.factory.createReturnStatement(),
     );
 
     // const isJSON = contentType.startsWith("application/json");
-    const isJsonConst = this.api.makeConst(
+    const isJsonConst = makeConst(
       this.#ids.isJsonConst,
-      this.api.makeCall(
+      makeCall(
         this.#ids.contentTypeConst,
         propOf<string>("startsWith"),
-      )(this.api.literally(contentTypes.json)),
+      )(literally(contentTypes.json)),
     );
 
     // return response[isJSON ? "json" : "text"]();
-    const returnStatement = this.api.f.createReturnStatement(
-      this.api.makeCall(
+    const returnStatement = ts.factory.createReturnStatement(
+      makeCall(
         this.#ids.responseConst,
-        this.api.makeTernary(
+        makeTernary(
           this.#ids.isJsonConst,
-          this.api.literally(propOf<Response>("json")),
-          this.api.literally(propOf<Response>("text")),
+          literally(propOf<Response>("json")),
+          literally(propOf<Response>("text")),
         ),
       )(),
     );
 
-    return this.api.makeConst(
+    return makeConst(
       this.#ids.defaultImplementationConst,
-      this.api.makeArrowFn(
+      makeArrowFn(
         [
           this.#ids.methodParameter,
           this.#ids.pathParameter,
           this.#ids.paramsArgument,
         ],
-        this.api.f.createBlock([
+        ts.factory.createBlock([
           hasBodyStatement,
           searchParamsStatement,
           responseStatement,
@@ -585,84 +587,76 @@ export abstract class IntegrationBase {
   };
 
   #makeSubscriptionConstructor = () =>
-    this.api.makePublicConstructor(
-      this.api.makeParams({
+    makePublicConstructor(
+      makeParams({
         request: "K",
-        params: this.api.makeIndexed(this.interfaces.input, "K"),
+        params: makeIndexed(this.interfaces.input, "K"),
       }),
       [
-        this.api.makeConst(
-          this.api.makeDeconstruction(
-            this.#ids.pathParameter,
-            this.#ids.restConst,
-          ),
-          this.api.makeCall(this.#ids.substituteFn)(
-            this.api.f.createElementAccessExpression(
-              this.api.makeCall(this.#ids.parseRequestFn)(
-                this.#ids.requestParameter,
-              ),
-              this.api.literally(1),
+        makeConst(
+          makeDeconstruction(this.#ids.pathParameter, this.#ids.restConst),
+          makeCall(this.#ids.substituteFn)(
+            ts.factory.createElementAccessExpression(
+              makeCall(this.#ids.parseRequestFn)(this.#ids.requestParameter),
+              literally(1),
             ),
             this.#ids.paramsArgument,
           ),
         ),
-        this.api.makeConst(
+        makeConst(
           this.#ids.searchParamsConst,
           this.#makeSearchParams(this.#ids.restConst),
         ),
-        this.api.makeAssignment(
-          this.api.f.createPropertyAccessExpression(
-            this.api.f.createThis(),
+        makeAssignment(
+          ts.factory.createPropertyAccessExpression(
+            ts.factory.createThis(),
             this.#ids.sourceProp,
           ),
-          this.api.makeNew("EventSource", this.#makeFetchURL()),
+          makeNew("EventSource", this.#makeFetchURL()),
         ),
       ],
     );
 
   #makeEventNarrow = (value: Typeable) =>
-    this.api.f.createTypeLiteralNode([
-      this.api.makeInterfaceProp(propOf<SSEShape>("event"), value),
+    ts.factory.createTypeLiteralNode([
+      makeInterfaceProp(propOf<SSEShape>("event"), value),
     ]);
 
   #makeOnMethod = () =>
-    this.api.makePublicMethod(
+    makePublicMethod(
       this.#ids.onMethod,
-      this.api.makeParams({
+      makeParams({
         [this.#ids.eventParameter]: "E",
-        [this.#ids.handlerParameter]: this.api.makeFnType(
+        [this.#ids.handlerParameter]: makeFnType(
           {
-            [this.#ids.dataParameter]: this.api.makeIndexed(
-              this.api.makeExtract(
-                "R",
-                this.api.makeOneLine(this.#makeEventNarrow("E")),
-              ),
-              this.api.makeLiteralType(propOf<SSEShape>("data")),
+            [this.#ids.dataParameter]: makeIndexed(
+              makeExtract("R", makeOneLine(this.#makeEventNarrow("E"))),
+              makeLiteralType(propOf<SSEShape>("data")),
             ),
           },
-          this.api.makeMaybeAsync(this.api.ts.SyntaxKind.VoidKeyword),
+          makeMaybeAsync(ts.SyntaxKind.VoidKeyword),
         ),
       }),
       [
-        this.api.f.createExpressionStatement(
-          this.api.makeCall(
-            this.api.f.createThis(),
+        ts.factory.createExpressionStatement(
+          makeCall(
+            ts.factory.createThis(),
             this.#ids.sourceProp,
             propOf<EventSource>("addEventListener"),
           )(
             this.#ids.eventParameter,
-            this.api.makeArrowFn(
+            makeArrowFn(
               [this.#ids.msgParameter],
-              this.api.makeCall(this.#ids.handlerParameter)(
-                this.api.makeCall(
+              makeCall(this.#ids.handlerParameter)(
+                makeCall(
                   JSON[Symbol.toStringTag],
                   propOf<JSON>("parse"),
                 )(
-                  this.api.f.createPropertyAccessExpression(
-                    this.api.f.createParenthesizedExpression(
-                      this.api.f.createAsExpression(
-                        this.api.makeId(this.#ids.msgParameter),
-                        this.api.ensureTypeNode(MessageEvent.name),
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createParenthesizedExpression(
+                      ts.factory.createAsExpression(
+                        makeId(this.#ids.msgParameter),
+                        ensureTypeNode(MessageEvent.name),
                       ),
                     ),
                     propOf<SSEShape>("data"),
@@ -672,14 +666,11 @@ export abstract class IntegrationBase {
             ),
           ),
         ),
-        this.api.f.createReturnStatement(this.api.f.createThis()),
+        ts.factory.createReturnStatement(ts.factory.createThis()),
       ],
       {
         typeParams: {
-          E: this.api.makeIndexed(
-            "R",
-            this.api.makeLiteralType(propOf<SSEShape>("event")),
-          ),
+          E: makeIndexed("R", makeLiteralType(propOf<SSEShape>("event"))),
         },
       },
     );
@@ -689,32 +680,30 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeSubscriptionClass = (name: string) =>
-    this.api.makePublicClass(
+    makePublicClass(
       name,
       [
-        this.api.makePublicProperty(this.#ids.sourceProp, "EventSource"),
+        makePublicProperty(this.#ids.sourceProp, "EventSource"),
         this.#makeSubscriptionConstructor(),
         this.#makeOnMethod(),
       ],
       {
         typeParams: {
-          K: this.api.makeExtract(
+          K: makeExtract(
             this.#ids.requestType,
-            this.api.f.createTemplateLiteralType(
-              this.api.f.createTemplateHead("get "),
+            ts.factory.createTemplateLiteralType(
+              ts.factory.createTemplateHead("get "),
               [
-                this.api.f.createTemplateLiteralTypeSpan(
-                  this.api.ensureTypeNode(this.api.ts.SyntaxKind.StringKeyword),
-                  this.api.f.createTemplateTail(""),
+                ts.factory.createTemplateLiteralTypeSpan(
+                  ensureTypeNode(ts.SyntaxKind.StringKeyword),
+                  ts.factory.createTemplateTail(""),
                 ),
               ],
             ),
           ),
-          R: this.api.makeExtract(
-            this.api.makeIndexed(this.interfaces.positive, "K"),
-            this.api.makeOneLine(
-              this.#makeEventNarrow(this.api.ts.SyntaxKind.StringKeyword),
-            ),
+          R: makeExtract(
+            makeIndexed(this.interfaces.positive, "K"),
+            makeOneLine(this.#makeEventNarrow(ts.SyntaxKind.StringKeyword)),
           ),
         },
       },
@@ -725,28 +714,22 @@ export abstract class IntegrationBase {
     clientClassName: string,
     subscriptionClassName: string,
   ): ts.Node[] => [
-    this.api.makeConst(
-      this.#ids.clientConst,
-      this.api.makeNew(clientClassName),
-    ), // const client = new Client();
+    makeConst(this.#ids.clientConst, makeNew(clientClassName)), // const client = new Client();
     // client.provide("get /v1/user/retrieve", { id: "10" });
-    this.api.makeCall(this.#ids.clientConst, this.#ids.provideMethod)(
-      this.api.literally(`${"get" satisfies ClientMethod} /v1/user/retrieve`),
-      this.api.f.createObjectLiteralExpression([
-        this.api.f.createPropertyAssignment("id", this.api.literally("10")),
+    makeCall(this.#ids.clientConst, this.#ids.provideMethod)(
+      literally(`${"get" satisfies ClientMethod} /v1/user/retrieve`),
+      ts.factory.createObjectLiteralExpression([
+        ts.factory.createPropertyAssignment("id", literally("10")),
       ]),
     ),
     // new Subscription("get /v1/events/stream", {}).on("time", (time) => {});
-    this.api.makeCall(
-      this.api.makeNew(
+    makeCall(
+      makeNew(
         subscriptionClassName,
-        this.api.literally(`${"get" satisfies ClientMethod} /v1/events/stream`),
-        this.api.f.createObjectLiteralExpression(),
+        literally(`${"get" satisfies ClientMethod} /v1/events/stream`),
+        ts.factory.createObjectLiteralExpression(),
       ),
       this.#ids.onMethod,
-    )(
-      this.api.literally("time"),
-      this.api.makeArrowFn(["time"], this.api.f.createBlock([])),
-    ),
+    )(literally("time"), makeArrowFn(["time"], ts.factory.createBlock([]))),
   ];
 }

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -40,6 +40,7 @@ import {
   propOf,
   ts,
   makeArrowFn,
+  f,
 } from "./typescript-api";
 import type {
   CursorPaginatedResult,
@@ -167,11 +168,11 @@ export abstract class IntegrationBase {
   protected makeEndpointTags = () =>
     makeConst(
       "endpointTags",
-      ts.factory.createObjectLiteralExpression(
+      f.createObjectLiteralExpression(
         Array.from(this.tags).map(([request, tags]) =>
-          ts.factory.createPropertyAssignment(
+          f.createPropertyAssignment(
             makePropertyIdentifier(request),
-            ts.factory.createArrayLiteralExpression(R.map(literally, tags)),
+            f.createArrayLiteralExpression(R.map(literally, tags)),
           ),
         ),
       ),
@@ -209,12 +210,12 @@ export abstract class IntegrationBase {
       this.#ids.parseRequestFn,
       makeArrowFn(
         { [this.#ids.requestParameter]: ts.SyntaxKind.StringKeyword },
-        ts.factory.createAsExpression(
+        f.createAsExpression(
           makeCall(this.#ids.requestParameter, propOf<string>("split"))(
-            ts.factory.createRegularExpressionLiteral("/ (.+)/"), // split once
+            f.createRegularExpressionLiteral("/ (.+)/"), // split once
             literally(2), // excludes third empty element
           ),
-          ts.factory.createTupleTypeNode([
+          f.createTupleTypeNode([
             ensureTypeNode(this.#ids.methodType),
             ensureTypeNode(this.#ids.pathType),
           ]),
@@ -234,39 +235,37 @@ export abstract class IntegrationBase {
           [this.#ids.pathParameter]: ts.SyntaxKind.StringKeyword,
           [this.#ids.paramsArgument]: makeRecordStringAny(),
         },
-        ts.factory.createBlock([
+        f.createBlock([
           makeConst(
             this.#ids.restConst,
-            ts.factory.createObjectLiteralExpression([
-              ts.factory.createSpreadAssignment(
-                makeId(this.#ids.paramsArgument),
-              ),
+            f.createObjectLiteralExpression([
+              f.createSpreadAssignment(makeId(this.#ids.paramsArgument)),
             ]),
           ),
-          ts.factory.createForInStatement(
-            ts.factory.createVariableDeclarationList(
-              [ts.factory.createVariableDeclaration(this.#ids.keyParameter)],
+          f.createForInStatement(
+            f.createVariableDeclarationList(
+              [f.createVariableDeclaration(this.#ids.keyParameter)],
               ts.NodeFlags.Const,
             ),
             makeId(this.#ids.paramsArgument),
-            ts.factory.createBlock([
+            f.createBlock([
               makeAssignment(
                 this.#ids.pathParameter,
                 makeCall(this.#ids.pathParameter, propOf<string>("replace"))(
                   makeTemplate(":", [this.#ids.keyParameter]), // `:${key}`
                   makeArrowFn(
                     [],
-                    ts.factory.createBlock([
-                      ts.factory.createExpressionStatement(
-                        ts.factory.createDeleteExpression(
-                          ts.factory.createElementAccessExpression(
+                    f.createBlock([
+                      f.createExpressionStatement(
+                        f.createDeleteExpression(
+                          f.createElementAccessExpression(
                             makeId(this.#ids.restConst),
                             makeId(this.#ids.keyParameter),
                           ),
                         ),
                       ),
-                      ts.factory.createReturnStatement(
-                        ts.factory.createElementAccessExpression(
+                      f.createReturnStatement(
+                        f.createElementAccessExpression(
                           makeId(this.#ids.paramsArgument),
                           makeId(this.#ids.keyParameter),
                         ),
@@ -277,9 +276,9 @@ export abstract class IntegrationBase {
               ),
             ]),
           ),
-          ts.factory.createReturnStatement(
-            ts.factory.createAsExpression(
-              ts.factory.createArrayLiteralExpression([
+          f.createReturnStatement(
+            f.createAsExpression(
+              f.createArrayLiteralExpression([
                 makeId(this.#ids.pathParameter),
                 makeId(this.#ids.restConst),
               ]),
@@ -301,7 +300,7 @@ export abstract class IntegrationBase {
     const limitProp = propOf<OffsetPaginatedResult["output"]["shape"]>("limit");
     const offsetProp =
       propOf<OffsetPaginatedResult["output"]["shape"]>("offset");
-    const cursorShape = ts.factory.createTypeLiteralNode([
+    const cursorShape = f.createTypeLiteralNode([
       makeInterfaceProp(
         nextCursorProp,
         makeUnion([
@@ -310,7 +309,7 @@ export abstract class IntegrationBase {
         ]),
       ),
     ]);
-    const offsetShape = ts.factory.createTypeLiteralNode(
+    const offsetShape = f.createTypeLiteralNode(
       [totalProp, limitProp, offsetProp].map((prop) =>
         makeInterfaceProp(prop, ts.SyntaxKind.NumberKeyword),
       ),
@@ -333,34 +332,34 @@ export abstract class IntegrationBase {
     const limitProp = propOf<OffsetPaginatedResult["output"]["shape"]>("limit");
     const offsetProp =
       propOf<OffsetPaginatedResult["output"]["shape"]>("offset");
-    const inExpression = ts.factory.createBinaryExpression(
+    const inExpression = f.createBinaryExpression(
       literally(nextCursorProp),
       ts.SyntaxKind.InKeyword,
       responseId,
     );
-    const returnCursor = ts.factory.createReturnStatement(
-      ts.factory.createBinaryExpression(
-        ts.factory.createPropertyAccessExpression(responseId, nextCursorProp),
+    const returnCursor = f.createReturnStatement(
+      f.createBinaryExpression(
+        f.createPropertyAccessExpression(responseId, nextCursorProp),
         ts.SyntaxKind.ExclamationEqualsEqualsToken,
         literally(null),
       ),
     );
-    const offsetPlusLimit = ts.factory.createBinaryExpression(
-      ts.factory.createPropertyAccessExpression(responseId, offsetProp),
+    const offsetPlusLimit = f.createBinaryExpression(
+      f.createPropertyAccessExpression(responseId, offsetProp),
       ts.SyntaxKind.PlusToken,
-      ts.factory.createPropertyAccessExpression(responseId, limitProp),
+      f.createPropertyAccessExpression(responseId, limitProp),
     );
-    const returnOffset = ts.factory.createReturnStatement(
-      ts.factory.createBinaryExpression(
+    const returnOffset = f.createReturnStatement(
+      f.createBinaryExpression(
         offsetPlusLimit,
         ts.SyntaxKind.LessThanToken,
-        ts.factory.createPropertyAccessExpression(responseId, totalProp),
+        f.createPropertyAccessExpression(responseId, totalProp),
       ),
     );
     return makePublicMethod(
       "hasMore",
       [makeParam(responseId, { type: this.#ids.paginationType })],
-      [ts.factory.createIfStatement(inExpression, returnCursor), returnOffset],
+      [f.createIfStatement(inExpression, returnCursor), returnOffset],
       {
         returns: ensureTypeNode(ts.SyntaxKind.BooleanKeyword),
         isStatic: true,
@@ -387,10 +386,10 @@ export abstract class IntegrationBase {
           makeCall(this.#ids.parseRequestFn)(this.#ids.requestParameter),
         ),
         // return this.implementation(___)
-        ts.factory.createReturnStatement(
-          makeCall(ts.factory.createThis(), this.#ids.implementationArgument)(
+        f.createReturnStatement(
+          makeCall(f.createThis(), this.#ids.implementationArgument)(
             this.#ids.methodParameter,
-            ts.factory.createSpreadElement(
+            f.createSpreadElement(
               makeCall(this.#ids.substituteFn)(
                 this.#ids.pathParameter,
                 this.#ids.paramsArgument,
@@ -450,18 +449,18 @@ export abstract class IntegrationBase {
    * */
   protected makeDefaultImplementation = () => {
     // method: method.toUpperCase()
-    const methodProperty = ts.factory.createPropertyAssignment(
+    const methodProperty = f.createPropertyAssignment(
       propOf<RequestInit>("method"),
       makeCall(this.#ids.methodParameter, propOf<string>("toUpperCase"))(),
     );
 
     // headers: hasBody ? { "Content-Type": "application/json" } : undefined
-    const headersProperty = ts.factory.createPropertyAssignment(
+    const headersProperty = f.createPropertyAssignment(
       propOf<RequestInit>("headers"),
       makeTernary(
         this.#ids.hasBodyConst,
-        ts.factory.createObjectLiteralExpression([
-          ts.factory.createPropertyAssignment(
+        f.createObjectLiteralExpression([
+          f.createPropertyAssignment(
             literally("Content-Type"),
             literally(contentTypes.json),
           ),
@@ -471,7 +470,7 @@ export abstract class IntegrationBase {
     );
 
     // body: hasBody ? JSON.stringify(params) : undefined
-    const bodyProperty = ts.factory.createPropertyAssignment(
+    const bodyProperty = f.createPropertyAssignment(
       propOf<RequestInit>("body"),
       makeTernary(
         this.#ids.hasBodyConst,
@@ -486,10 +485,10 @@ export abstract class IntegrationBase {
     // const response = await fetch(new URL(`${path}${searchParams}`, "https://example.com"), { ___ });
     const responseStatement = makeConst(
       this.#ids.responseConst,
-      ts.factory.createAwaitExpression(
+      f.createAwaitExpression(
         makeCall(fetch.name)(
           this.#makeFetchURL(),
-          ts.factory.createObjectLiteralExpression([
+          f.createObjectLiteralExpression([
             methodProperty,
             headersProperty,
             bodyProperty,
@@ -501,9 +500,9 @@ export abstract class IntegrationBase {
     // const hasBody = !["get", "delete"].includes(method);
     const hasBodyStatement = makeConst(
       this.#ids.hasBodyConst,
-      ts.factory.createLogicalNot(
+      f.createLogicalNot(
         makeCall(
-          ts.factory.createArrayLiteralExpression([
+          f.createArrayLiteralExpression([
             literally("get" satisfies ClientMethod),
             literally("head" satisfies ClientMethod),
             literally("delete" satisfies ClientMethod),
@@ -534,12 +533,12 @@ export abstract class IntegrationBase {
     );
 
     // if (!contentType) return;
-    const noBodyStatement = ts.factory.createIfStatement(
-      ts.factory.createPrefixUnaryExpression(
+    const noBodyStatement = f.createIfStatement(
+      f.createPrefixUnaryExpression(
         ts.SyntaxKind.ExclamationToken,
         makeId(this.#ids.contentTypeConst),
       ),
-      ts.factory.createReturnStatement(),
+      f.createReturnStatement(),
     );
 
     // const isJSON = contentType.startsWith("application/json");
@@ -552,7 +551,7 @@ export abstract class IntegrationBase {
     );
 
     // return response[isJSON ? "json" : "text"]();
-    const returnStatement = ts.factory.createReturnStatement(
+    const returnStatement = f.createReturnStatement(
       makeCall(
         this.#ids.responseConst,
         makeTernary(
@@ -571,7 +570,7 @@ export abstract class IntegrationBase {
           this.#ids.pathParameter,
           this.#ids.paramsArgument,
         ],
-        ts.factory.createBlock([
+        f.createBlock([
           hasBodyStatement,
           searchParamsStatement,
           responseStatement,
@@ -596,7 +595,7 @@ export abstract class IntegrationBase {
         makeConst(
           makeDeconstruction(this.#ids.pathParameter, this.#ids.restConst),
           makeCall(this.#ids.substituteFn)(
-            ts.factory.createElementAccessExpression(
+            f.createElementAccessExpression(
               makeCall(this.#ids.parseRequestFn)(this.#ids.requestParameter),
               literally(1),
             ),
@@ -608,8 +607,8 @@ export abstract class IntegrationBase {
           this.#makeSearchParams(this.#ids.restConst),
         ),
         makeAssignment(
-          ts.factory.createPropertyAccessExpression(
-            ts.factory.createThis(),
+          f.createPropertyAccessExpression(
+            f.createThis(),
             this.#ids.sourceProp,
           ),
           makeNew("EventSource", this.#makeFetchURL()),
@@ -618,7 +617,7 @@ export abstract class IntegrationBase {
     );
 
   #makeEventNarrow = (value: Typeable) =>
-    ts.factory.createTypeLiteralNode([
+    f.createTypeLiteralNode([
       makeInterfaceProp(propOf<SSEShape>("event"), value),
     ]);
 
@@ -638,9 +637,9 @@ export abstract class IntegrationBase {
         ),
       }),
       [
-        ts.factory.createExpressionStatement(
+        f.createExpressionStatement(
           makeCall(
-            ts.factory.createThis(),
+            f.createThis(),
             this.#ids.sourceProp,
             propOf<EventSource>("addEventListener"),
           )(
@@ -652,9 +651,9 @@ export abstract class IntegrationBase {
                   JSON[Symbol.toStringTag],
                   propOf<JSON>("parse"),
                 )(
-                  ts.factory.createPropertyAccessExpression(
-                    ts.factory.createParenthesizedExpression(
-                      ts.factory.createAsExpression(
+                  f.createPropertyAccessExpression(
+                    f.createParenthesizedExpression(
+                      f.createAsExpression(
                         makeId(this.#ids.msgParameter),
                         ensureTypeNode(MessageEvent.name),
                       ),
@@ -666,7 +665,7 @@ export abstract class IntegrationBase {
             ),
           ),
         ),
-        ts.factory.createReturnStatement(ts.factory.createThis()),
+        f.createReturnStatement(f.createThis()),
       ],
       {
         typeParams: {
@@ -691,15 +690,12 @@ export abstract class IntegrationBase {
         typeParams: {
           K: makeExtract(
             this.#ids.requestType,
-            ts.factory.createTemplateLiteralType(
-              ts.factory.createTemplateHead("get "),
-              [
-                ts.factory.createTemplateLiteralTypeSpan(
-                  ensureTypeNode(ts.SyntaxKind.StringKeyword),
-                  ts.factory.createTemplateTail(""),
-                ),
-              ],
-            ),
+            f.createTemplateLiteralType(f.createTemplateHead("get "), [
+              f.createTemplateLiteralTypeSpan(
+                ensureTypeNode(ts.SyntaxKind.StringKeyword),
+                f.createTemplateTail(""),
+              ),
+            ]),
           ),
           R: makeExtract(
             makeIndexed(this.interfaces.positive, "K"),
@@ -718,8 +714,8 @@ export abstract class IntegrationBase {
     // client.provide("get /v1/user/retrieve", { id: "10" });
     makeCall(this.#ids.clientConst, this.#ids.provideMethod)(
       literally(`${"get" satisfies ClientMethod} /v1/user/retrieve`),
-      ts.factory.createObjectLiteralExpression([
-        ts.factory.createPropertyAssignment("id", literally("10")),
+      f.createObjectLiteralExpression([
+        f.createPropertyAssignment("id", literally("10")),
       ]),
     ),
     // new Subscription("get /v1/events/stream", {}).on("time", (time) => {});
@@ -727,9 +723,9 @@ export abstract class IntegrationBase {
       makeNew(
         subscriptionClassName,
         literally(`${"get" satisfies ClientMethod} /v1/events/stream`),
-        ts.factory.createObjectLiteralExpression(),
+        f.createObjectLiteralExpression(),
       ),
       this.#ids.onMethod,
-    )(literally("time"), makeArrowFn(["time"], ts.factory.createBlock([]))),
+    )(literally("time"), makeArrowFn(["time"], f.createBlock([]))),
   ];
 }

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -15,6 +15,7 @@ import {
   makeUnion,
   printNode,
   ts,
+  f,
 } from "./typescript-api";
 import { walkRouting, withHead, type OnEndpoint } from "./routing-walker";
 import type { HandlingRules } from "./schema-walker";
@@ -147,7 +148,7 @@ export class Integration extends IntegrationBase {
           makeIndexed(this.interfaces.positive, literalIdx),
           makeIndexed(this.interfaces.negative, literalIdx),
         ]),
-        encoded: ts.factory.createIntersectionTypeNode([
+        encoded: f.createIntersectionTypeNode([
           ensureTypeNode(dictionaries.positive.name),
           ensureTypeNode(dictionaries.negative.name),
         ]),
@@ -205,7 +206,7 @@ export class Integration extends IntegrationBase {
       usageExampleText &&
       ts.addSyntheticLeadingComment(
         ts.addSyntheticLeadingComment(
-          ts.factory.createEmptyStatement(),
+          f.createEmptyStatement(),
           ts.SyntaxKind.SingleLineCommentTrivia,
           " Usage example:",
         ),

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -240,3 +240,5 @@ export class Integration extends IntegrationBase {
     return format ? format(output) : output;
   }
 }
+
+export type { Producer } from "./zts-helpers";

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -1,3 +1,8 @@
+/**
+ * @fileOverview The entrypoint for generating Integration code
+ * @requires typescript
+ * */
+export type { Producer } from "./zts-helpers";
 import * as R from "ramda";
 import { z } from "zod";
 import { responseVariants, type ResponseVariant } from "./api-response";
@@ -246,5 +251,3 @@ export class Integration extends IntegrationBase {
     return format ? format(output) : output;
   }
 }
-
-export type { Producer } from "./zts-helpers";

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -1,11 +1,21 @@
 import * as R from "ramda";
-import type ts from "typescript";
 import { z } from "zod";
 import { responseVariants, type ResponseVariant } from "./api-response";
 import { IntegrationBase } from "./integration-base";
 import { shouldHaveContent, makeCleanId } from "./common-helpers";
 import { loadPeer } from "./peer-helpers";
 import type { Routing } from "./routing";
+import {
+  ensureTypeNode,
+  makeInterface,
+  makeInterfaceProp,
+  makeIndexed,
+  makeLiteralType,
+  makeType,
+  makeUnion,
+  printNode,
+  ts,
+} from "./typescript-api";
 import { walkRouting, withHead, type OnEndpoint } from "./routing-walker";
 import type { HandlingRules } from "./schema-walker";
 import { zodToTs } from "./zts";
@@ -15,8 +25,6 @@ import type { ClientMethod } from "./method";
 import type { CommonConfig } from "./config-type";
 
 interface IntegrationParams {
-  /** @default loadPeer("typescript") */
-  typescript?: typeof ts;
   routing: Routing;
   config: CommonConfig;
   /**
@@ -74,15 +82,14 @@ export class Integration extends IntegrationBase {
     let name = this.#aliases.get(key)?.name?.text;
     if (!name) {
       name = `Type${this.#aliases.size + 1}`;
-      const temp = this.api.makeLiteralType(null);
-      this.#aliases.set(key, this.api.makeType(name, temp));
-      this.#aliases.set(key, this.api.makeType(name, produce()));
+      const temp = makeLiteralType(null);
+      this.#aliases.set(key, makeType(name, temp));
+      this.#aliases.set(key, makeType(name, produce()));
     }
-    return this.api.ensureTypeNode(name);
+    return ensureTypeNode(name);
   }
 
   public constructor({
-    typescript = loadPeer<typeof ts>("typescript"),
     routing,
     config,
     brandHandling,
@@ -93,36 +100,34 @@ export class Integration extends IntegrationBase {
     noBodySchema = z.undefined(),
     hasHeadMethod = true,
   }: IntegrationParams) {
-    super(typescript, serverUrl);
-    const commons = { makeAlias: this.#makeAlias.bind(this), api: this.api };
+    super(serverUrl);
+    const commons = { makeAlias: this.#makeAlias.bind(this) };
     const ctxIn = { brandHandling, ctx: { ...commons, isResponse: false } };
     const ctxOut = { brandHandling, ctx: { ...commons, isResponse: true } };
     const onEndpoint: OnEndpoint<ClientMethod> = (method, path, endpoint) => {
       const entitle = makeCleanId.bind(null, method, path); // clean id with method+path prefix
       const { isDeprecated, inputSchema, tags } = endpoint;
       const request = `${method} ${path}`;
-      const input = this.api.makeType(
-        entitle("input"),
-        zodToTs(inputSchema, ctxIn),
-        { comment: request },
-      );
+      const input = makeType(entitle("input"), zodToTs(inputSchema, ctxIn), {
+        comment: request,
+      });
       this.#program.push(input);
       const dictionaries = responseVariants.reduce(
         (agg, responseVariant) => {
           const responses = endpoint.getResponses(responseVariant);
           const props = R.chain(([idx, { schema, mimeTypes, statusCodes }]) => {
             const hasBody = shouldHaveContent(method, mimeTypes);
-            const variantType = this.api.makeType(
+            const variantType = makeType(
               entitle(responseVariant, "variant", `${idx + 1}`),
               zodToTs(hasBody ? schema : noBodySchema, ctxOut),
               { comment: request },
             );
             this.#program.push(variantType);
             return statusCodes.map((code) =>
-              this.api.makeInterfaceProp(code, variantType.name),
+              makeInterfaceProp(code, variantType.name),
             );
           }, Array.from(responses.entries()));
-          const dict = this.api.makeInterface(
+          const dict = makeInterface(
             entitle(responseVariant, "response", "variants"),
             props,
             { comment: request },
@@ -133,18 +138,18 @@ export class Integration extends IntegrationBase {
         {} as Record<ResponseVariant, ts.TypeAliasDeclaration>,
       );
       this.paths.add(path);
-      const literalIdx = this.api.makeLiteralType(request);
+      const literalIdx = makeLiteralType(request);
       const store = {
-        input: this.api.ensureTypeNode(input.name),
+        input: ensureTypeNode(input.name),
         positive: this.someOf(dictionaries.positive),
         negative: this.someOf(dictionaries.negative),
-        response: this.api.makeUnion([
-          this.api.makeIndexed(this.interfaces.positive, literalIdx),
-          this.api.makeIndexed(this.interfaces.negative, literalIdx),
+        response: makeUnion([
+          makeIndexed(this.interfaces.positive, literalIdx),
+          makeIndexed(this.interfaces.negative, literalIdx),
         ]),
-        encoded: this.api.f.createIntersectionTypeNode([
-          this.api.ensureTypeNode(dictionaries.positive.name),
-          this.api.ensureTypeNode(dictionaries.negative.name),
+        encoded: ts.factory.createIntersectionTypeNode([
+          ensureTypeNode(dictionaries.positive.name),
+          ensureTypeNode(dictionaries.negative.name),
         ]),
       };
       this.registry.set(request, { isDeprecated, store });
@@ -188,7 +193,7 @@ export class Integration extends IntegrationBase {
           .map((entry) =>
             typeof entry === "string"
               ? entry
-              : this.api.printNode(entry, printerOptions),
+              : printNode(entry, printerOptions),
           )
           .join("\n")
       : undefined;
@@ -198,19 +203,19 @@ export class Integration extends IntegrationBase {
     const usageExampleText = this.#printUsage(printerOptions);
     const commentNode =
       usageExampleText &&
-      this.api.ts.addSyntheticLeadingComment(
-        this.api.ts.addSyntheticLeadingComment(
-          this.api.f.createEmptyStatement(),
-          this.api.ts.SyntaxKind.SingleLineCommentTrivia,
+      ts.addSyntheticLeadingComment(
+        ts.addSyntheticLeadingComment(
+          ts.factory.createEmptyStatement(),
+          ts.SyntaxKind.SingleLineCommentTrivia,
           " Usage example:",
         ),
-        this.api.ts.SyntaxKind.MultiLineCommentTrivia,
+        ts.SyntaxKind.MultiLineCommentTrivia,
         `\n${usageExampleText}`,
       );
     return this.#program
       .concat(commentNode || [])
       .map((node, index) =>
-        this.api.printNode(
+        printNode(
           node,
           index < this.#program.length
             ? printerOptions

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -1,5 +1,5 @@
 import * as R from "ramda";
-import ts from "typescript";
+import ts from "typescript"; // eslint-disable-line allowed/dependencies -- opt-in export
 
 export { ts };
 

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -1,5 +1,39 @@
 import * as R from "ramda";
-import type ts from "typescript";
+import ts from "typescript";
+
+export { ts };
+
+const f = ts.factory;
+
+export const exportModifier = [f.createModifier(ts.SyntaxKind.ExportKeyword)];
+export const asyncModifier = [f.createModifier(ts.SyntaxKind.AsyncKeyword)];
+export const accessModifiers = {
+  public: [f.createModifier(ts.SyntaxKind.PublicKeyword)],
+  publicStatic: [
+    f.createModifier(ts.SyntaxKind.PublicKeyword),
+    f.createModifier(ts.SyntaxKind.StaticKeyword),
+  ],
+  protectedReadonly: [
+    f.createModifier(ts.SyntaxKind.ProtectedKeyword),
+    f.createModifier(ts.SyntaxKind.ReadonlyKeyword),
+  ],
+} as const;
+
+const safePropRegex = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const primitives: ts.KeywordTypeSyntaxKind[] = [
+  ts.SyntaxKind.AnyKeyword,
+  ts.SyntaxKind.BigIntKeyword,
+  ts.SyntaxKind.BooleanKeyword,
+  ts.SyntaxKind.NeverKeyword,
+  ts.SyntaxKind.NumberKeyword,
+  ts.SyntaxKind.ObjectKeyword,
+  ts.SyntaxKind.StringKeyword,
+  ts.SyntaxKind.SymbolKeyword,
+  ts.SyntaxKind.UndefinedKeyword,
+  ts.SyntaxKind.UnknownKeyword,
+  ts.SyntaxKind.VoidKeyword,
+];
 
 export type Typeable =
   ts.TypeNode | ts.Identifier | string | ts.KeywordTypeSyntaxKind;
@@ -8,480 +42,422 @@ type TypeParams =
   | string[]
   | Partial<Record<string, Typeable | { type?: ts.TypeNode; init: Typeable }>>;
 
-export class TypescriptAPI {
-  public ts: typeof ts;
-  public f: typeof ts.factory;
-  public exportModifier: ts.ModifierToken<ts.SyntaxKind.ExportKeyword>[];
-  public asyncModifier: ts.ModifierToken<ts.SyntaxKind.AsyncKeyword>[];
-  public accessModifiers: Record<
-    "public" | "publicStatic" | "protectedReadonly",
-    ts.Modifier[]
-  >;
-  #primitives: ts.KeywordTypeSyntaxKind[];
-  static #safePropRegex = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-
-  constructor(typescript: typeof ts) {
-    this.ts = typescript;
-    this.f = this.ts.factory;
-    this.exportModifier = [
-      this.f.createModifier(this.ts.SyntaxKind.ExportKeyword),
-    ];
-    this.asyncModifier = [
-      this.f.createModifier(this.ts.SyntaxKind.AsyncKeyword),
-    ];
-    this.accessModifiers = {
-      public: [this.f.createModifier(this.ts.SyntaxKind.PublicKeyword)],
-      publicStatic: [
-        this.f.createModifier(this.ts.SyntaxKind.PublicKeyword),
-        this.f.createModifier(this.ts.SyntaxKind.StaticKeyword),
-      ],
-      protectedReadonly: [
-        this.f.createModifier(this.ts.SyntaxKind.ProtectedKeyword),
-        this.f.createModifier(this.ts.SyntaxKind.ReadonlyKeyword),
-      ],
-    };
-    this.#primitives = [
-      this.ts.SyntaxKind.AnyKeyword,
-      this.ts.SyntaxKind.BigIntKeyword,
-      this.ts.SyntaxKind.BooleanKeyword,
-      this.ts.SyntaxKind.NeverKeyword,
-      this.ts.SyntaxKind.NumberKeyword,
-      this.ts.SyntaxKind.ObjectKeyword,
-      this.ts.SyntaxKind.StringKeyword,
-      this.ts.SyntaxKind.SymbolKeyword,
-      this.ts.SyntaxKind.UndefinedKeyword,
-      this.ts.SyntaxKind.UnknownKeyword,
-      this.ts.SyntaxKind.VoidKeyword,
-    ];
-  }
-
-  public addJsDoc = <T extends ts.Node>(node: T, text: string) =>
-    this.ts.addSyntheticLeadingComment(
-      node,
-      this.ts.SyntaxKind.MultiLineCommentTrivia,
-      `* ${text} `,
-      true,
-    );
-
-  public printNode = (node: ts.Node, printerOptions?: ts.PrinterOptions) => {
-    const sourceFile = this.ts.createSourceFile(
-      "print.ts",
-      "",
-      this.ts.ScriptTarget.Latest,
-      false,
-      this.ts.ScriptKind.TS,
-    );
-    const printer = this.ts.createPrinter(printerOptions);
-    return printer.printNode(this.ts.EmitHint.Unspecified, node, sourceFile);
-  };
-
-  public makeId = (name: string) => this.f.createIdentifier(name);
-
-  public makePropertyIdentifier = (name: string | number) =>
-    typeof name === "string" && TypescriptAPI.#safePropRegex.test(name)
-      ? this.makeId(name)
-      : this.literally(name);
-
-  public makeTemplate = (
-    head: string,
-    ...rest: [ts.Expression | string, string?][]
-  ) =>
-    this.f.createTemplateExpression(
-      this.f.createTemplateHead(head),
-      rest.map(([id, str = ""], idx) =>
-        this.f.createTemplateSpan(
-          typeof id === "string" ? this.makeId(id) : id,
-          idx === rest.length - 1
-            ? this.f.createTemplateTail(str)
-            : this.f.createTemplateMiddle(str),
-        ),
-      ),
-    );
-
-  public makeParam = (
-    name: string | ts.Identifier,
-    {
-      type,
-      mod,
-      initId,
-      optional,
-    }: {
-      type?: Typeable;
-      mod?: ts.Modifier[];
-      initId?: string;
-      optional?: boolean;
-    } = {},
-  ) =>
-    this.f.createParameterDeclaration(
-      mod,
-      undefined,
-      name,
-      optional
-        ? this.f.createToken(this.ts.SyntaxKind.QuestionToken)
-        : undefined,
-      type ? this.ensureTypeNode(type) : undefined,
-      initId ? this.makeId(initId) : undefined,
-    );
-
-  public makeParams = (
-    params: Partial<
-      Record<string, Typeable | Parameters<typeof this.makeParam>[1]>
-    >,
-  ) =>
-    Object.entries(params).map(([name, value]) =>
-      this.makeParam(
-        name,
-        typeof value === "string" ||
-          typeof value === "number" ||
-          (typeof value === "object" && "kind" in value)
-          ? { type: value }
-          : value,
-      ),
-    );
-
-  public makePublicConstructor = (
-    params: ts.ParameterDeclaration[],
-    statements: ts.Statement[] = [],
-  ) =>
-    this.f.createConstructorDeclaration(
-      this.accessModifiers.public,
-      params,
-      this.f.createBlock(statements),
-    );
-
-  public ensureTypeNode = (
-    subject: Typeable,
-    args?: Typeable[], // only for string and id
-  ): ts.TypeNode =>
-    typeof subject === "number"
-      ? this.f.createKeywordTypeNode(subject)
-      : typeof subject === "string" || this.ts.isIdentifier(subject)
-        ? this.f.createTypeReferenceNode(
-            subject,
-            args && R.map(this.ensureTypeNode, args),
-          )
-        : subject;
-
-  /**
-   * @internal
-   * @example Record<string, any>
-   * */
-  public makeRecordStringAny = () =>
-    this.ensureTypeNode("Record", [
-      this.ts.SyntaxKind.StringKeyword,
-      this.ts.SyntaxKind.AnyKeyword,
-    ]);
-
-  /**
-   * @internal
-   * ensures distinct union (unique primitives)
-   * */
-  public makeUnion = (entries: ts.TypeNode[]) => {
-    const nodes = new Map<
-      ts.TypeNode | ts.KeywordTypeSyntaxKind,
-      ts.TypeNode
-    >();
-    for (const entry of entries)
-      nodes.set(this.isPrimitive(entry) ? entry.kind : entry, entry);
-    return this.f.createUnionTypeNode(Array.from(nodes.values()));
-  };
-
-  public makeInterfaceProp = (
-    name: string | number,
-    value: Typeable,
-    {
-      isOptional,
-      hasUndefined = isOptional,
-      isDeprecated,
-      comment,
-    }: {
-      isOptional?: boolean;
-      hasUndefined?: boolean;
-      isDeprecated?: boolean;
-      comment?: string;
-    } = {},
-  ) => {
-    const propType = this.ensureTypeNode(value);
-    const node = this.f.createPropertySignature(
-      undefined,
-      this.makePropertyIdentifier(name),
-      isOptional
-        ? this.f.createToken(this.ts.SyntaxKind.QuestionToken)
-        : undefined,
-      hasUndefined
-        ? this.makeUnion([
-            propType,
-            this.ensureTypeNode(this.ts.SyntaxKind.UndefinedKeyword),
-          ])
-        : propType,
-    );
-    const jsdoc = R.reject(R.isNil, [
-      isDeprecated ? "@deprecated" : undefined,
-      comment,
-    ]);
-    return jsdoc.length ? this.addJsDoc(node, jsdoc.join(" ")) : node;
-  };
-
-  public makeOneLine = (subject: ts.TypeNode) =>
-    this.ts.setEmitFlags(subject, this.ts.EmitFlags.SingleLine);
-
-  public makeDeconstruction = (...names: string[]): ts.ArrayBindingPattern =>
-    this.f.createArrayBindingPattern(
-      names.map(
-        (name) => this.f.createBindingElement(undefined, undefined, name), // can also add default value at last
-      ),
-    );
-
-  public makeConst = (
-    name: string | ts.Identifier | ts.ArrayBindingPattern,
-    value: ts.Expression,
-    { type, expose }: { type?: Typeable; expose?: true } = {},
-  ) =>
-    this.f.createVariableStatement(
-      expose && this.exportModifier,
-      this.f.createVariableDeclarationList(
-        [
-          this.f.createVariableDeclaration(
-            name,
-            undefined,
-            type ? this.ensureTypeNode(type) : undefined,
-            value,
-          ),
-        ],
-        this.ts.NodeFlags.Const,
-      ),
-    );
-
-  public makePublicLiteralType = (
-    name: ts.Identifier | string,
-    literals: string[],
-  ) =>
-    this.makeType(name, this.makeUnion(R.map(this.makeLiteralType, literals)), {
-      expose: true,
-    });
-
-  public makeType = (
-    name: ts.Identifier | string,
-    value: ts.TypeNode,
-    {
-      expose,
-      comment,
-      params,
-    }: { expose?: boolean; comment?: string; params?: TypeParams } = {},
-  ) => {
-    const node = this.f.createTypeAliasDeclaration(
-      expose ? this.exportModifier : undefined,
-      name,
-      params && this.makeTypeParams(params),
-      value,
-    );
-    return comment ? this.addJsDoc(node, comment) : node;
-  };
-
-  public makePublicProperty = (
-    name: string | ts.PropertyName,
-    type: Typeable,
-  ) =>
-    this.f.createPropertyDeclaration(
-      this.accessModifiers.public,
-      name,
-      undefined,
-      this.ensureTypeNode(type),
-      undefined,
-    );
-
-  public makePublicMethod = (
-    name: string,
-    params: ts.ParameterDeclaration[],
-    statements: ts.Statement[],
-    {
-      typeParams,
-      returns,
-      isStatic,
-    }: {
-      typeParams?: TypeParams;
-      returns?: ts.TypeNode;
-      isStatic?: boolean;
-    } = {},
-  ) =>
-    this.f.createMethodDeclaration(
-      isStatic
-        ? this.accessModifiers.publicStatic
-        : this.accessModifiers.public,
-      undefined,
-      name,
-      undefined,
-      typeParams && this.makeTypeParams(typeParams),
-      params,
-      returns,
-      this.f.createBlock(statements),
-    );
-
-  public makePublicClass = (
-    name: string,
-    statements: ts.ClassElement[],
-    { typeParams }: { typeParams?: TypeParams } = {},
-  ) =>
-    this.f.createClassDeclaration(
-      this.exportModifier,
-      name,
-      typeParams && this.makeTypeParams(typeParams),
-      undefined,
-      statements,
-    );
-
-  public makeKeyOf = (subj: Typeable) =>
-    this.f.createTypeOperatorNode(
-      this.ts.SyntaxKind.KeyOfKeyword,
-      this.ensureTypeNode(subj),
-    );
-
-  public makePromise = (subject: Typeable) =>
-    this.ensureTypeNode(Promise.name, [subject]);
-
-  public makeInterface = (
-    name: ts.Identifier | string,
-    props: ts.PropertySignature[],
-    { expose, comment }: { expose?: boolean; comment?: string } = {},
-  ) => {
-    const node = this.f.createInterfaceDeclaration(
-      expose ? this.exportModifier : undefined,
-      name,
-      undefined,
-      undefined,
-      props,
-    );
-    return comment ? this.addJsDoc(node, comment) : node;
-  };
-
-  public makeTypeParams = (
-    params:
-      | string[]
-      | Partial<
-          Record<string, Typeable | { type?: ts.TypeNode; init: Typeable }>
-        >,
-  ) =>
-    (Array.isArray(params)
-      ? params.map((name) => R.pair(name, undefined))
-      : Object.entries(params)
-    ).map(([name, val]) => {
-      const { type, init } =
-        typeof val === "object" && "init" in val ? val : { type: val };
-      return this.f.createTypeParameterDeclaration(
-        [],
-        name,
-        type ? this.ensureTypeNode(type) : undefined,
-        init ? this.ensureTypeNode(init) : undefined,
-      );
-    });
-
-  public makeArrowFn = (
-    params:
-      | Array<Parameters<typeof this.makeParam>[0]>
-      | Parameters<typeof this.makeParams>[0],
-    body: ts.ConciseBody,
-    { isAsync }: { isAsync?: boolean } = {},
-  ) =>
-    this.f.createArrowFunction(
-      isAsync ? this.asyncModifier : undefined,
-      undefined,
-      Array.isArray(params)
-        ? R.map(this.makeParam, params)
-        : this.makeParams(params),
-      undefined,
-      undefined,
-      body,
-    );
-
-  public makeTernary = (
-    ...args: [
-      ts.Expression | string,
-      ts.Expression | string,
-      ts.Expression | string,
-    ]
-  ) => {
-    const [condition, positive, negative] = args.map((arg) =>
-      typeof arg === "string" ? this.makeId(arg) : arg,
-    );
-    return this.f.createConditionalExpression(
-      condition!, // ensured by tuple type
-      this.f.createToken(this.ts.SyntaxKind.QuestionToken),
-      positive!, // ensured by tuple type
-      this.f.createToken(this.ts.SyntaxKind.ColonToken),
-      negative!, // ensured by tuple type
-    );
-  };
-
-  public makeCall =
-    (
-      first: ts.Expression | string,
-      ...rest: Array<ts.Identifier | ts.ConditionalExpression | string>
-    ) =>
-    (...args: Array<ts.Expression | string>) =>
-      this.f.createCallExpression(
-        rest.reduce(
-          (acc, entry) =>
-            typeof entry === "string" || this.ts.isIdentifier(entry)
-              ? this.f.createPropertyAccessExpression(acc, entry)
-              : this.f.createElementAccessExpression(acc, entry),
-          typeof first === "string" ? this.makeId(first) : first,
-        ),
-        undefined,
-        args.map((arg) => (typeof arg === "string" ? this.makeId(arg) : arg)),
-      );
-
-  public makeNew = (cls: string, ...args: ts.Expression[]) =>
-    this.f.createNewExpression(this.makeId(cls), undefined, args);
-
-  public makeExtract = (base: Typeable, narrow: ts.TypeNode) =>
-    this.ensureTypeNode("Extract", [base, narrow]);
-
-  public makeAssignment = (
-    left: ts.Expression | string,
-    right: ts.Expression,
-  ) =>
-    this.f.createExpressionStatement(
-      this.f.createBinaryExpression(
-        typeof left === "string" ? this.makeId(left) : left,
-        this.f.createToken(this.ts.SyntaxKind.EqualsToken),
-        right,
-      ),
-    );
-
-  public makeIndexed = (subject: Typeable, index: Typeable) =>
-    this.f.createIndexedAccessTypeNode(
-      this.ensureTypeNode(subject),
-      this.ensureTypeNode(index),
-    );
-
-  public makeMaybeAsync = (subj: Typeable) =>
-    this.makeUnion([this.ensureTypeNode(subj), this.makePromise(subj)]);
-
-  public makeFnType = (
-    params: Parameters<typeof this.makeParams>[0],
-    returns: Typeable,
-  ) =>
-    this.f.createFunctionTypeNode(
-      undefined,
-      this.makeParams(params),
-      this.ensureTypeNode(returns),
-    );
-
-  /* eslint-disable prettier/prettier -- shorter and works better this way than overrides */
-  public literally = <T extends string | null | boolean | number | bigint>(subj: T) => (
-    typeof subj === "number" ? this.f.createNumericLiteral(subj)
-      : typeof subj === "bigint" ? this.f.createBigIntLiteral(subj.toString())
-        : typeof subj === "boolean" ? subj ? this.f.createTrue() : this.f.createFalse()
-          : subj === null ? this.f.createNull() : this.f.createStringLiteral(subj)
-  ) as T extends string ? ts.StringLiteral : T extends number ? ts.NumericLiteral
-    : T extends boolean ? ts.BooleanLiteral : ts.NullLiteral;
-  /* eslint-enable prettier/prettier */
-
-  public makeLiteralType = (subj: Parameters<typeof this.literally>[0]) =>
-    this.f.createLiteralTypeNode(this.literally(subj));
-
-  public isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
-    (this.#primitives as ts.SyntaxKind[]).includes(node.kind);
-}
-
 export const propOf = <T>(name: keyof NoInfer<T>) => name as string;
+
+/* eslint-disable prettier/prettier -- shorter and works better this way than overrides */
+export const literally = <T extends string | null | boolean | number | bigint>(subj: T) => (
+  typeof subj === "number" ? f.createNumericLiteral(subj)
+    : typeof subj === "bigint" ? f.createBigIntLiteral(subj.toString())
+      : typeof subj === "boolean" ? subj ? f.createTrue() : f.createFalse()
+        : subj === null ? f.createNull() : f.createStringLiteral(subj)
+) as T extends string ? ts.StringLiteral : T extends number ? ts.NumericLiteral
+  : T extends boolean ? ts.BooleanLiteral : ts.NullLiteral;
+/* eslint-enable prettier/prettier */
+
+export const makeId = (name: string) => f.createIdentifier(name);
+
+const makePropertyIdentifier = (name: string | number) =>
+  typeof name === "string" && safePropRegex.test(name)
+    ? makeId(name)
+    : literally(name);
+
+export const ensureTypeNode = (
+  subject: Typeable,
+  args?: Typeable[], // only for string and id
+): ts.TypeNode =>
+  typeof subject === "number"
+    ? f.createKeywordTypeNode(subject)
+    : typeof subject === "string" || ts.isIdentifier(subject)
+      ? f.createTypeReferenceNode(subject, args && R.map(ensureTypeNode, args))
+      : subject;
+
+/**
+ * @internal
+ * @example Record<string, any>
+ * */
+export const makeRecordStringAny = () =>
+  ensureTypeNode("Record", [
+    ts.SyntaxKind.StringKeyword,
+    ts.SyntaxKind.AnyKeyword,
+  ]);
+
+/**
+ * @internal
+ * ensures distinct union (unique primitives)
+ * */
+export const makeUnion = (entries: ts.TypeNode[]) => {
+  const nodes = new Map<ts.TypeNode | ts.KeywordTypeSyntaxKind, ts.TypeNode>();
+  for (const entry of entries)
+    nodes.set(isPrimitive(entry) ? entry.kind : entry, entry);
+  return f.createUnionTypeNode(Array.from(nodes.values()));
+};
+
+const isPrimitive = (node: ts.TypeNode): node is ts.KeywordTypeNode =>
+  (primitives as ts.SyntaxKind[]).includes(node.kind);
+
+const addJsDoc = <T extends ts.Node>(node: T, text: string) =>
+  ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    `* ${text} `,
+    true,
+  );
+
+export const printNode = (
+  node: ts.Node,
+  printerOptions?: ts.PrinterOptions,
+) => {
+  const sourceFile = ts.createSourceFile(
+    "print.ts",
+    "",
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS,
+  );
+  const printer = ts.createPrinter(printerOptions);
+  return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
+};
+
+export const makeTemplate = (
+  head: string,
+  ...rest: [ts.Expression | string, string?][]
+) =>
+  f.createTemplateExpression(
+    f.createTemplateHead(head),
+    rest.map(([id, str = ""], idx) =>
+      f.createTemplateSpan(
+        typeof id === "string" ? makeId(id) : id,
+        idx === rest.length - 1
+          ? f.createTemplateTail(str)
+          : f.createTemplateMiddle(str),
+      ),
+    ),
+  );
+
+export const makeParam = (
+  name: string | ts.Identifier,
+  {
+    type,
+    mod,
+    initId,
+    optional,
+  }: {
+    type?: Typeable;
+    mod?: ts.Modifier[];
+    initId?: string;
+    optional?: boolean;
+  } = {},
+) =>
+  f.createParameterDeclaration(
+    mod,
+    undefined,
+    name,
+    optional ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
+    type ? ensureTypeNode(type) : undefined,
+    initId ? makeId(initId) : undefined,
+  );
+
+export const makeParams = (
+  params: Partial<
+    Record<
+      string,
+      | Typeable
+      | {
+          type?: Typeable;
+          mod?: ts.Modifier[];
+          initId?: string;
+          optional?: boolean;
+        }
+    >
+  >,
+) =>
+  Object.entries(params).map(([name, value]) =>
+    makeParam(
+      name,
+      typeof value === "string" ||
+        typeof value === "number" ||
+        (typeof value === "object" && "kind" in value)
+        ? { type: value }
+        : value,
+    ),
+  );
+
+export const makePublicConstructor = (
+  params: ts.ParameterDeclaration[],
+  statements: ts.Statement[] = [],
+) =>
+  f.createConstructorDeclaration(
+    accessModifiers.public,
+    params,
+    f.createBlock(statements),
+  );
+
+export const makeInterfaceProp = (
+  name: string | number,
+  value: Typeable,
+  {
+    isOptional,
+    hasUndefined = isOptional,
+    isDeprecated,
+    comment,
+  }: {
+    isOptional?: boolean;
+    hasUndefined?: boolean;
+    isDeprecated?: boolean;
+    comment?: string;
+  } = {},
+) => {
+  const propType = ensureTypeNode(value);
+  const node = f.createPropertySignature(
+    undefined,
+    makePropertyIdentifier(name),
+    isOptional ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
+    hasUndefined
+      ? makeUnion([propType, ensureTypeNode(ts.SyntaxKind.UndefinedKeyword)])
+      : propType,
+  );
+  const jsdoc = R.reject(R.isNil, [
+    isDeprecated ? "@deprecated" : undefined,
+    comment,
+  ]);
+  return jsdoc.length ? addJsDoc(node, jsdoc.join(" ")) : node;
+};
+
+export const makeOneLine = (subject: ts.TypeNode) =>
+  ts.setEmitFlags(subject, ts.EmitFlags.SingleLine);
+
+export const makeDeconstruction = (
+  ...names: string[]
+): ts.ArrayBindingPattern =>
+  f.createArrayBindingPattern(
+    names.map(
+      (name) => f.createBindingElement(undefined, undefined, name), // can also add default value at last
+    ),
+  );
+
+export const makeConst = (
+  name: string | ts.Identifier | ts.ArrayBindingPattern,
+  value: ts.Expression,
+  { type, expose }: { type?: Typeable; expose?: true } = {},
+) =>
+  f.createVariableStatement(
+    expose && exportModifier,
+    f.createVariableDeclarationList(
+      [
+        f.createVariableDeclaration(
+          name,
+          undefined,
+          type ? ensureTypeNode(type) : undefined,
+          value,
+        ),
+      ],
+      ts.NodeFlags.Const,
+    ),
+  );
+
+export const makeType = (
+  name: ts.Identifier | string,
+  value: ts.TypeNode,
+  {
+    expose,
+    comment,
+    params,
+  }: { expose?: boolean; comment?: string; params?: TypeParams } = {},
+) => {
+  const node = f.createTypeAliasDeclaration(
+    expose ? exportModifier : undefined,
+    name,
+    params && makeTypeParams(params),
+    value,
+  );
+  return comment ? addJsDoc(node, comment) : node;
+};
+
+export const makePublicLiteralType = (
+  name: ts.Identifier | string,
+  literals: string[],
+) =>
+  makeType(name, makeUnion(R.map(makeLiteralType, literals)), {
+    expose: true,
+  });
+
+export const makeTypeParams = (
+  params:
+    | string[]
+    | Partial<
+        Record<string, Typeable | { type?: ts.TypeNode; init: Typeable }>
+      >,
+) =>
+  (Array.isArray(params)
+    ? params.map((name) => R.pair(name, undefined))
+    : Object.entries(params)
+  ).map(([name, val]) => {
+    const { type, init } =
+      typeof val === "object" && "init" in val ? val : { type: val };
+    return f.createTypeParameterDeclaration(
+      [],
+      name,
+      type ? ensureTypeNode(type) : undefined,
+      init ? ensureTypeNode(init) : undefined,
+    );
+  });
+
+export const makePublicProperty = (
+  name: string | ts.PropertyName,
+  type: Typeable,
+) =>
+  f.createPropertyDeclaration(
+    accessModifiers.public,
+    name,
+    undefined,
+    ensureTypeNode(type),
+    undefined,
+  );
+
+export const makePublicMethod = (
+  name: string,
+  params: ts.ParameterDeclaration[],
+  statements: ts.Statement[],
+  {
+    typeParams,
+    returns,
+    isStatic,
+  }: {
+    typeParams?: TypeParams;
+    returns?: ts.TypeNode;
+    isStatic?: boolean;
+  } = {},
+) =>
+  f.createMethodDeclaration(
+    isStatic ? accessModifiers.publicStatic : accessModifiers.public,
+    undefined,
+    name,
+    undefined,
+    typeParams && makeTypeParams(typeParams),
+    params,
+    returns,
+    f.createBlock(statements),
+  );
+
+export const makePublicClass = (
+  name: string,
+  statements: ts.ClassElement[],
+  { typeParams }: { typeParams?: TypeParams } = {},
+) =>
+  f.createClassDeclaration(
+    exportModifier,
+    name,
+    typeParams && makeTypeParams(typeParams),
+    undefined,
+    statements,
+  );
+
+export const makeKeyOf = (subj: Typeable) =>
+  f.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, ensureTypeNode(subj));
+
+export const makePromise = (subject: Typeable) =>
+  ensureTypeNode(Promise.name, [subject]);
+
+export const makeInterface = (
+  name: ts.Identifier | string,
+  props: ts.PropertySignature[],
+  { expose, comment }: { expose?: boolean; comment?: string } = {},
+) => {
+  const node = f.createInterfaceDeclaration(
+    expose ? exportModifier : undefined,
+    name,
+    undefined,
+    undefined,
+    props,
+  );
+  return comment ? addJsDoc(node, comment) : node;
+};
+
+export const makeArrowFn = (
+  params:
+    Array<Parameters<typeof makeParam>[0]> | Parameters<typeof makeParams>[0],
+  body: ts.ConciseBody,
+  { isAsync }: { isAsync?: boolean } = {},
+) =>
+  f.createArrowFunction(
+    isAsync ? asyncModifier : undefined,
+    undefined,
+    Array.isArray(params) ? R.map(makeParam, params) : makeParams(params),
+    undefined,
+    undefined,
+    body,
+  );
+
+export const makeTernary = (
+  ...args: [
+    ts.Expression | string,
+    ts.Expression | string,
+    ts.Expression | string,
+  ]
+) => {
+  const [condition, positive, negative] = args.map((arg) =>
+    typeof arg === "string" ? makeId(arg) : arg,
+  );
+  return f.createConditionalExpression(
+    condition!, // ensured by tuple type
+    f.createToken(ts.SyntaxKind.QuestionToken),
+    positive!, // ensured by tuple type
+    f.createToken(ts.SyntaxKind.ColonToken),
+    negative!, // ensured by tuple type
+  );
+};
+
+export const makeCall =
+  (
+    first: ts.Expression | string,
+    ...rest: Array<ts.Identifier | ts.ConditionalExpression | string>
+  ) =>
+  (...args: Array<ts.Expression | string>) =>
+    f.createCallExpression(
+      rest.reduce(
+        (acc, entry) =>
+          typeof entry === "string" || ts.isIdentifier(entry)
+            ? f.createPropertyAccessExpression(acc, entry)
+            : f.createElementAccessExpression(acc, entry),
+        typeof first === "string" ? makeId(first) : first,
+      ),
+      undefined,
+      args.map((arg) => (typeof arg === "string" ? makeId(arg) : arg)),
+    );
+
+export const makeNew = (cls: string, ...args: ts.Expression[]) =>
+  f.createNewExpression(makeId(cls), undefined, args);
+
+export const makeExtract = (base: Typeable, narrow: ts.TypeNode) =>
+  ensureTypeNode("Extract", [base, narrow]);
+
+export const makeAssignment = (
+  left: ts.Expression | string,
+  right: ts.Expression,
+) =>
+  f.createExpressionStatement(
+    f.createBinaryExpression(
+      typeof left === "string" ? makeId(left) : left,
+      f.createToken(ts.SyntaxKind.EqualsToken),
+      right,
+    ),
+  );
+
+export const makeIndexed = (subject: Typeable, index: Typeable) =>
+  f.createIndexedAccessTypeNode(ensureTypeNode(subject), ensureTypeNode(index));
+
+export const makeMaybeAsync = (subj: Typeable) =>
+  makeUnion([ensureTypeNode(subj), makePromise(subj)]);
+
+export const makeFnType = (
+  params: Parameters<typeof makeParams>[0],
+  returns: Typeable,
+) =>
+  f.createFunctionTypeNode(
+    undefined,
+    makeParams(params),
+    ensureTypeNode(returns),
+  );
+
+export const makeLiteralType = (subj: Parameters<typeof literally>[0]) =>
+  f.createLiteralTypeNode(literally(subj));

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -17,7 +17,7 @@ export const accessModifiers = {
     f.createModifier(ts.SyntaxKind.ProtectedKeyword),
     f.createModifier(ts.SyntaxKind.ReadonlyKeyword),
   ],
-} as const;
+};
 
 const safePropRegex = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
@@ -56,7 +56,7 @@ export const literally = <T extends string | null | boolean | number | bigint>(s
 
 export const makeId = (name: string) => f.createIdentifier(name);
 
-const makePropertyIdentifier = (name: string | number) =>
+export const makePropertyIdentifier = (name: string | number) =>
   typeof name === "string" && safePropRegex.test(name)
     ? makeId(name)
     : literally(name);

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -51,7 +51,7 @@ export const literally = <T extends string | null | boolean | number | bigint>(s
       : typeof subj === "boolean" ? subj ? f.createTrue() : f.createFalse()
         : subj === null ? f.createNull() : f.createStringLiteral(subj)
 ) as T extends string ? ts.StringLiteral : T extends number ? ts.NumericLiteral
-  : T extends boolean ? ts.BooleanLiteral : ts.NullLiteral;
+  : T extends boolean ? ts.BooleanLiteral : T extends bigint ? ts.BigIntLiteral : ts.NullLiteral;
 /* eslint-enable prettier/prettier */
 
 export const makeId = (name: string) => f.createIdentifier(name);

--- a/express-zod-api/src/typescript-api.ts
+++ b/express-zod-api/src/typescript-api.ts
@@ -3,7 +3,7 @@ import ts from "typescript"; // eslint-disable-line allowed/dependencies -- opt-
 
 export { ts };
 
-const f = ts.factory;
+export const f = ts.factory;
 
 export const exportModifier = [f.createModifier(ts.SyntaxKind.ExportKeyword)];
 export const asyncModifier = [f.createModifier(ts.SyntaxKind.AsyncKeyword)];

--- a/express-zod-api/src/zts-helpers.ts
+++ b/express-zod-api/src/zts-helpers.ts
@@ -1,13 +1,10 @@
 import type ts from "typescript";
 import type { FlatObject } from "./common-helpers";
 import type { SchemaHandler } from "./schema-walker";
-import type { TypescriptAPI } from "./typescript-api";
 
 export interface ZTSContext extends FlatObject {
   isResponse: boolean;
   makeAlias: (key: object, produce: () => ts.TypeNode) => ts.TypeNode;
-  /** @internal */
-  api: TypescriptAPI;
 }
 
 export type Producer = SchemaHandler<ts.TypeNode, ZTSContext>;

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -1,5 +1,4 @@
 import * as R from "ramda";
-import type ts from "typescript";
 import { globalRegistry, z } from "zod";
 import { ezBufferBrand } from "./buffer-schema";
 import { getTransformedType, isSchema } from "./common-helpers";
@@ -13,7 +12,13 @@ import {
   type FirstPartyKind,
   type HandlingRules,
 } from "./schema-walker";
-import type { TypescriptAPI } from "./typescript-api";
+import {
+  ensureTypeNode,
+  makeInterfaceProp,
+  makeLiteralType,
+  makeUnion,
+  ts,
+} from "./typescript-api";
 import type { Producer, ZTSContext } from "./zts-helpers";
 
 const nodePath = {
@@ -28,22 +33,19 @@ const nodePath = {
   optional: R.path(["questionToken" satisfies keyof ts.TypeElement]),
 };
 
-const onLiteral: Producer = (
-  { _zod: { def } }: z.core.$ZodLiteral,
-  { api },
-) => {
+const onLiteral: Producer = ({ _zod: { def } }: z.core.$ZodLiteral) => {
   const values = def.values.map((entry) =>
     entry === undefined
-      ? api.ensureTypeNode(api.ts.SyntaxKind.UndefinedKeyword)
-      : api.makeLiteralType(entry),
+      ? ensureTypeNode(ts.SyntaxKind.UndefinedKeyword)
+      : makeLiteralType(entry),
   );
   // ensured by runtime check since Zod 4.0.9 4e7a3ef180f6a5525d9021638e9df20b3ca50456
-  return values.length === 1 ? values[0]! : api.makeUnion(values);
+  return values.length === 1 ? values[0]! : makeUnion(values);
 };
 
 const onTemplateLiteral: Producer = (
   { _zod: { def } }: z.core.$ZodTemplateLiteral,
-  { next, api },
+  { next },
 ) => {
   const { parts } = def;
   let idx = 0;
@@ -57,24 +59,26 @@ const onTemplateLiteral: Producer = (
     }
     return text;
   };
-  const head = api.f.createTemplateHead(readText());
+  const head = ts.factory.createTemplateHead(readText());
   const spans: ts.TemplateLiteralTypeSpan[] = [];
   while (idx < parts.length) {
     const schema = next(parts[idx++] as z.core.$ZodType);
     const text = readText();
     const textWrapper =
       idx < parts.length
-        ? api.f.createTemplateMiddle
-        : api.f.createTemplateTail;
-    spans.push(api.f.createTemplateLiteralTypeSpan(schema, textWrapper(text)));
+        ? ts.factory.createTemplateMiddle
+        : ts.factory.createTemplateTail;
+    spans.push(
+      ts.factory.createTemplateLiteralTypeSpan(schema, textWrapper(text)),
+    );
   }
-  if (!spans.length) return api.makeLiteralType(head.text);
-  return api.f.createTemplateLiteralType(head, spans);
+  if (!spans.length) return makeLiteralType(head.text);
+  return ts.factory.createTemplateLiteralType(head, spans);
 };
 
 const onObject: Producer = (
   obj: z.core.$ZodObject,
-  { isResponse, next, makeAlias, api },
+  { isResponse, next, makeAlias },
 ) => {
   const produce = () => {
     const members = Object.entries(obj._zod.def.shape).map<ts.TypeElement>(
@@ -85,7 +89,7 @@ const onObject: Producer = (
           (isResponse ? value._zod.optout : value._zod.optin) === "optional";
         const hasUndefined =
           isOptional && !(value instanceof z.core.$ZodExactOptional);
-        return api.makeInterfaceProp(key, next(value), {
+        return makeInterfaceProp(key, next(value), {
           comment,
           isDeprecated,
           isOptional,
@@ -93,60 +97,52 @@ const onObject: Producer = (
         });
       },
     );
-    return api.f.createTypeLiteralNode(members);
+    return ts.factory.createTypeLiteralNode(members);
   };
   return hasCycle(obj, { io: isResponse ? "output" : "input" })
     ? makeAlias(obj, produce)
     : produce();
 };
 
-const onArray: Producer = (
-  { _zod: { def } }: z.core.$ZodArray,
-  { next, api },
-) => api.f.createArrayTypeNode(next(def.element));
+const onArray: Producer = ({ _zod: { def } }: z.core.$ZodArray, { next }) =>
+  ts.factory.createArrayTypeNode(next(def.element));
 
-const onEnum: Producer = ({ _zod: { def } }: z.core.$ZodEnum, { api }) =>
-  api.makeUnion(R.map(api.makeLiteralType, Object.values(def.entries)));
+const onEnum: Producer = ({ _zod: { def } }: z.core.$ZodEnum) =>
+  makeUnion(R.map(makeLiteralType, Object.values(def.entries)));
 
 const onSomeUnion: Producer = (
   { _zod: { def } }: z.core.$ZodUnion | z.core.$ZodDiscriminatedUnion,
-  { next, api },
-) => api.makeUnion(def.options.map(next));
+  { next },
+) => makeUnion(def.options.map(next));
 
 const onNullable: Producer = (
   { _zod: { def } }: z.core.$ZodNullable,
-  { next, api },
-) => api.makeUnion([next(def.innerType), api.makeLiteralType(null)]);
+  { next },
+) => makeUnion([next(def.innerType), makeLiteralType(null)]);
 
-const onTuple: Producer = (
-  { _zod: { def } }: z.core.$ZodTuple,
-  { next, api },
-) =>
-  api.f.createTupleTypeNode(
+const onTuple: Producer = ({ _zod: { def } }: z.core.$ZodTuple, { next }) =>
+  ts.factory.createTupleTypeNode(
     def.items
       .map(next)
       .concat(
-        def.rest === null ? [] : api.f.createRestTypeNode(next(def.rest)),
+        def.rest === null ? [] : ts.factory.createRestTypeNode(next(def.rest)),
       ),
   );
 
-const onRecord: Producer = (
-  { _zod: { def } }: z.core.$ZodRecord,
-  { next, api },
-) => {
+const onRecord: Producer = ({ _zod: { def } }: z.core.$ZodRecord, { next }) => {
   const [keyNode, valueNode] = [def.keyType, def.valueType].map(next);
-  const primary = api.ensureTypeNode("Record", [keyNode!, valueNode!]);
+  const primary = ensureTypeNode("Record", [keyNode!, valueNode!]);
   const isLoose = def.mode === "loose";
   if (!isLoose) return primary;
-  return api.f.createIntersectionTypeNode([
+  return ts.factory.createIntersectionTypeNode([
     primary,
-    api.ensureTypeNode("Record", ["PropertyKey", valueNode!]),
+    ensureTypeNode("Record", ["PropertyKey", valueNode!]),
   ]);
 };
 
 const intersect = R.tryCatch(
-  (api: TypescriptAPI, nodes: ts.TypeNode[]) => {
-    if (!nodes.every(api.ts.isTypeLiteralNode)) throw new Error("Not objects");
+  (nodes: ts.TypeNode[]) => {
+    if (!nodes.every(ts.isTypeLiteralNode)) throw new Error("Not objects");
     const members = R.chain(R.prop("members"), nodes);
     const uniqs = R.uniqWith((...props) => {
       if (!R.eqBy(nodePath.name, ...props)) return false;
@@ -154,31 +150,20 @@ const intersect = R.tryCatch(
         return true;
       throw new Error("Has conflicting prop");
     }, members);
-    return api.f.createTypeLiteralNode(uniqs);
+    return ts.factory.createTypeLiteralNode(uniqs);
   },
-  (_err, api, nodes) => api.f.createIntersectionTypeNode(nodes),
+  (_err, nodes) => ts.factory.createIntersectionTypeNode(nodes),
 );
 
 const onIntersection: Producer = (
   { _zod: { def } }: z.core.$ZodIntersection,
-  { next, api },
-) => intersect(api, [def.left, def.right].map(next));
+  { next },
+) => intersect([def.left, def.right].map(next));
 
 const onPrimitive =
-  (
-    syntaxKind:
-      | "AnyKeyword"
-      | "BigIntKeyword"
-      | "BooleanKeyword"
-      | "NeverKeyword"
-      | "NumberKeyword"
-      | "StringKeyword"
-      | "UndefinedKeyword"
-      | "UnknownKeyword"
-      | "VoidKeyword",
-  ): Producer =>
-  ({}, { api }) =>
-    api.ensureTypeNode(api.ts.SyntaxKind[syntaxKind]);
+  (syntaxKind: ts.KeywordTypeSyntaxKind): Producer =>
+  () =>
+    ensureTypeNode(syntaxKind);
 
 const onWrapped: Producer = (
   {
@@ -193,55 +178,53 @@ const onWrapped: Producer = (
   { next },
 ) => next(def.innerType);
 
-const getFallback = (api: TypescriptAPI, isResponse: boolean) =>
-  api.ensureTypeNode(
-    isResponse
-      ? api.ts.SyntaxKind.UnknownKeyword
-      : api.ts.SyntaxKind.AnyKeyword,
+const getFallback = (isResponse: boolean) =>
+  ensureTypeNode(
+    isResponse ? ts.SyntaxKind.UnknownKeyword : ts.SyntaxKind.AnyKeyword,
   );
 
 const onPipeline: Producer = (
   { _zod: { def } }: z.core.$ZodPipe,
-  { next, isResponse, api },
+  { next, isResponse },
 ) => {
   const target = def[isResponse ? "out" : "in"];
   const opposite = def[isResponse ? "in" : "out"];
   if (!isSchema<z.core.$ZodTransform>(target, "transform")) return next(target);
   const opposingType = next(opposite);
   const samples = {
-    [api.ts.SyntaxKind.AnyKeyword]: "",
-    [api.ts.SyntaxKind.BigIntKeyword]: BigInt(0),
-    [api.ts.SyntaxKind.BooleanKeyword]: false,
-    [api.ts.SyntaxKind.NumberKeyword]: 0,
-    [api.ts.SyntaxKind.ObjectKeyword]: {},
-    [api.ts.SyntaxKind.StringKeyword]: "",
-    [api.ts.SyntaxKind.UndefinedKeyword]: undefined,
+    [ts.SyntaxKind.AnyKeyword]: "",
+    [ts.SyntaxKind.BigIntKeyword]: BigInt(0),
+    [ts.SyntaxKind.BooleanKeyword]: false,
+    [ts.SyntaxKind.NumberKeyword]: 0,
+    [ts.SyntaxKind.ObjectKeyword]: {},
+    [ts.SyntaxKind.StringKeyword]: "",
+    [ts.SyntaxKind.UndefinedKeyword]: undefined,
   } satisfies Partial<Record<ts.KeywordTypeSyntaxKind, unknown>>;
   const sample = samples[opposingType.kind as keyof typeof samples];
   const targetType = getTransformedType(target, sample);
   const resolutions: Partial<
     Record<NonNullable<typeof targetType>, ts.KeywordTypeSyntaxKind>
   > = {
-    number: api.ts.SyntaxKind.NumberKeyword,
-    bigint: api.ts.SyntaxKind.BigIntKeyword,
-    boolean: api.ts.SyntaxKind.BooleanKeyword,
-    string: api.ts.SyntaxKind.StringKeyword,
-    undefined: api.ts.SyntaxKind.UndefinedKeyword,
-    object: api.ts.SyntaxKind.ObjectKeyword,
+    number: ts.SyntaxKind.NumberKeyword,
+    bigint: ts.SyntaxKind.BigIntKeyword,
+    boolean: ts.SyntaxKind.BooleanKeyword,
+    string: ts.SyntaxKind.StringKeyword,
+    undefined: ts.SyntaxKind.UndefinedKeyword,
+    object: ts.SyntaxKind.ObjectKeyword,
   };
-  return api.ensureTypeNode(
-    (targetType && resolutions[targetType]) || getFallback(api, isResponse),
+  return ensureTypeNode(
+    (targetType && resolutions[targetType]) || getFallback(isResponse),
   );
 };
 
-const onNull: Producer = ({}, { api }) => api.makeLiteralType(null);
+const onNull: Producer = () => makeLiteralType(null);
 
 const onLazy: Producer = (
   { _zod: { def } }: z.core.$ZodLazy,
   { makeAlias, next },
 ) => makeAlias(def.getter, () => next(def.getter()));
 
-const onBuffer: Producer = ({}, { api }) => api.ensureTypeNode("Buffer");
+const onBuffer: Producer = () => ensureTypeNode("Buffer");
 
 const onRaw: Producer = (schema: RawSchema, { next }) =>
   next(schema._zod.def.shape.raw);
@@ -251,17 +234,17 @@ const producers: HandlingRules<
   ZTSContext,
   FirstPartyKind | ProprietaryBrand
 > = {
-  string: onPrimitive("StringKeyword"),
-  number: onPrimitive("NumberKeyword"),
-  bigint: onPrimitive("BigIntKeyword"),
-  boolean: onPrimitive("BooleanKeyword"),
-  any: onPrimitive("AnyKeyword"),
-  undefined: onPrimitive("UndefinedKeyword"),
-  [ezDateInBrand]: onPrimitive("StringKeyword"),
-  [ezDateOutBrand]: onPrimitive("StringKeyword"),
-  never: onPrimitive("NeverKeyword"),
-  void: onPrimitive("UndefinedKeyword"),
-  unknown: onPrimitive("UnknownKeyword"),
+  string: onPrimitive(ts.SyntaxKind.StringKeyword),
+  number: onPrimitive(ts.SyntaxKind.NumberKeyword),
+  bigint: onPrimitive(ts.SyntaxKind.BigIntKeyword),
+  boolean: onPrimitive(ts.SyntaxKind.BooleanKeyword),
+  any: onPrimitive(ts.SyntaxKind.AnyKeyword),
+  undefined: onPrimitive(ts.SyntaxKind.UndefinedKeyword),
+  [ezDateInBrand]: onPrimitive(ts.SyntaxKind.StringKeyword),
+  [ezDateOutBrand]: onPrimitive(ts.SyntaxKind.StringKeyword),
+  never: onPrimitive(ts.SyntaxKind.NeverKeyword),
+  void: onPrimitive(ts.SyntaxKind.UndefinedKeyword),
+  unknown: onPrimitive(ts.SyntaxKind.UnknownKeyword),
   null: onNull,
   array: onArray,
   tuple: onTuple,
@@ -296,6 +279,6 @@ export const zodToTs = (
 ) =>
   walkSchema(schema, {
     rules: { ...brandHandling, ...producers },
-    onMissing: ({}, { isResponse, api }) => getFallback(api, isResponse),
+    onMissing: ({}, { isResponse }) => getFallback(isResponse),
     ctx,
   });

--- a/express-zod-api/src/zts.ts
+++ b/express-zod-api/src/zts.ts
@@ -14,6 +14,7 @@ import {
 } from "./schema-walker";
 import {
   ensureTypeNode,
+  f,
   makeInterfaceProp,
   makeLiteralType,
   makeUnion,
@@ -59,21 +60,17 @@ const onTemplateLiteral: Producer = (
     }
     return text;
   };
-  const head = ts.factory.createTemplateHead(readText());
+  const head = f.createTemplateHead(readText());
   const spans: ts.TemplateLiteralTypeSpan[] = [];
   while (idx < parts.length) {
     const schema = next(parts[idx++] as z.core.$ZodType);
     const text = readText();
     const textWrapper =
-      idx < parts.length
-        ? ts.factory.createTemplateMiddle
-        : ts.factory.createTemplateTail;
-    spans.push(
-      ts.factory.createTemplateLiteralTypeSpan(schema, textWrapper(text)),
-    );
+      idx < parts.length ? f.createTemplateMiddle : f.createTemplateTail;
+    spans.push(f.createTemplateLiteralTypeSpan(schema, textWrapper(text)));
   }
   if (!spans.length) return makeLiteralType(head.text);
-  return ts.factory.createTemplateLiteralType(head, spans);
+  return f.createTemplateLiteralType(head, spans);
 };
 
 const onObject: Producer = (
@@ -97,7 +94,7 @@ const onObject: Producer = (
         });
       },
     );
-    return ts.factory.createTypeLiteralNode(members);
+    return f.createTypeLiteralNode(members);
   };
   return hasCycle(obj, { io: isResponse ? "output" : "input" })
     ? makeAlias(obj, produce)
@@ -105,7 +102,7 @@ const onObject: Producer = (
 };
 
 const onArray: Producer = ({ _zod: { def } }: z.core.$ZodArray, { next }) =>
-  ts.factory.createArrayTypeNode(next(def.element));
+  f.createArrayTypeNode(next(def.element));
 
 const onEnum: Producer = ({ _zod: { def } }: z.core.$ZodEnum) =>
   makeUnion(R.map(makeLiteralType, Object.values(def.entries)));
@@ -121,12 +118,10 @@ const onNullable: Producer = (
 ) => makeUnion([next(def.innerType), makeLiteralType(null)]);
 
 const onTuple: Producer = ({ _zod: { def } }: z.core.$ZodTuple, { next }) =>
-  ts.factory.createTupleTypeNode(
+  f.createTupleTypeNode(
     def.items
       .map(next)
-      .concat(
-        def.rest === null ? [] : ts.factory.createRestTypeNode(next(def.rest)),
-      ),
+      .concat(def.rest === null ? [] : f.createRestTypeNode(next(def.rest))),
   );
 
 const onRecord: Producer = ({ _zod: { def } }: z.core.$ZodRecord, { next }) => {
@@ -134,7 +129,7 @@ const onRecord: Producer = ({ _zod: { def } }: z.core.$ZodRecord, { next }) => {
   const primary = ensureTypeNode("Record", [keyNode!, valueNode!]);
   const isLoose = def.mode === "loose";
   if (!isLoose) return primary;
-  return ts.factory.createIntersectionTypeNode([
+  return f.createIntersectionTypeNode([
     primary,
     ensureTypeNode("Record", ["PropertyKey", valueNode!]),
   ]);
@@ -150,9 +145,9 @@ const intersect = R.tryCatch(
         return true;
       throw new Error("Has conflicting prop");
     }, members);
-    return ts.factory.createTypeLiteralNode(uniqs);
+    return f.createTypeLiteralNode(uniqs);
   },
-  (_err, nodes) => ts.factory.createIntersectionTypeNode(nodes),
+  (_err, nodes) => f.createIntersectionTypeNode(nodes),
 );
 
 const onIntersection: Producer = (

--- a/express-zod-api/tests/__snapshots__/index.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/index.spec.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`Index Entrypoint > exports > BuiltinLogger should have certain value 1`] = `[Function]`;
 
-exports[`Index Entrypoint > exports > Documentation should have certain value 1`] = `[Function]`;
-
 exports[`Index Entrypoint > exports > DocumentationError should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint > exports > EndpointsFactory should have certain value 1`] = `[Function]`;
@@ -11,8 +9,6 @@ exports[`Index Entrypoint > exports > EndpointsFactory should have certain value
 exports[`Index Entrypoint > exports > EventStreamFactory should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint > exports > InputValidationError should have certain value 1`] = `[Function]`;
-
-exports[`Index Entrypoint > exports > Integration should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint > exports > Middleware should have certain value 1`] = `[Function]`;
 
@@ -95,7 +91,6 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "ServeStatic",
   "createServer",
   "attachRouting",
-  "Documentation",
   "DocumentationError",
   "RoutingError",
   "OutputValidationError",
@@ -103,7 +98,6 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "MissingPeerError",
   "testEndpoint",
   "testMiddleware",
-  "Integration",
   "EventStreamFactory",
   "ez",
 ]

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1,7 +1,6 @@
 import camelize from "camelize-ts";
 import snakify from "snakify-ts";
 import {
-  Documentation,
   DocumentationError,
   EndpointsFactory,
   createConfig,
@@ -9,9 +8,9 @@ import {
   defaultEndpointsFactory,
   ez,
   ResultHandler,
-  type Depicter,
   type Method,
 } from "../src";
+import { Documentation, type Depicter } from "../src/documentation";
 import { contentTypes } from "../src/content-type";
 import { z } from "zod";
 import { givePort } from "../../tools/ports";
@@ -1228,5 +1227,16 @@ describe("Documentation", () => {
       }).getSpecAsYaml();
       expect(spec).toMatchSnapshot();
     });
+  });
+
+  test("Depicter type should be satisfied", () => {
+    expectTypeOf(
+      ({
+        jsonSchema,
+      }: {
+        zodSchema: z.core.$ZodType;
+        jsonSchema: z.core.JSONSchema.BaseSchema;
+      }) => jsonSchema,
+    ).toExtend<Depicter>();
   });
 });

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -1,5 +1,4 @@
 import type { IRouter } from "express";
-import ts from "typescript";
 import { z } from "zod";
 import * as entrypoint from "../src";
 import type {
@@ -9,16 +8,14 @@ import type {
   BearerSecurity,
   CommonConfig,
   CookieSecurity,
-  HeaderSecurity,
-  Depicter,
   FlatObject,
+  HeaderSecurity,
   IOSchema,
   InputSecurity,
   LoggerOverrides,
   Method,
   OAuth2Security,
   OpenIdSecurity,
-  Producer,
   Routing,
   ServerConfig,
 } from "../src";
@@ -34,20 +31,6 @@ describe("Index Entrypoint", () => {
     test.each(entities)("%s should have certain value", (entry) => {
       const entity = entrypoint[entry as keyof typeof entrypoint];
       if (entity !== undefined) expect(entity).toMatchSnapshot();
-    });
-
-    test("Convenience types should be exposed", () => {
-      expectTypeOf(
-        ({
-          jsonSchema,
-        }: {
-          zodSchema: z.core.$ZodType;
-          jsonSchema: z.core.JSONSchema.BaseSchema;
-        }) => jsonSchema,
-      ).toExtend<Depicter>();
-      expectTypeOf(() =>
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-      ).toExtend<Producer>();
     });
 
     test("Issue 952, 1182, 1269: should expose certain types and interfaces", () => {

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -2,11 +2,10 @@ import ts from "typescript";
 import { globalRegistry, z } from "zod";
 import {
   EndpointsFactory,
-  Integration,
   defaultEndpointsFactory,
   ResultHandler,
-  type Producer,
 } from "../src";
+import { Integration, type Producer } from "../src/integration";
 import { brandProperty } from "../src/metadata";
 
 describe("Integration", () => {
@@ -28,7 +27,6 @@ describe("Integration", () => {
     "Should support types variant and handle recursive schemas %#",
     (recursiveSchema) => {
       const client = new Integration({
-        typescript: ts,
         variant: "types",
         config: configMock,
         routing: {
@@ -163,5 +161,11 @@ describe("Integration", () => {
       });
       expect(await client.printFormatted()).toMatchSnapshot();
     });
+  });
+
+  test("Producer type should be satisfied", () => {
+    expectTypeOf(() =>
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+    ).toExtend<Producer>();
   });
 });

--- a/express-zod-api/tests/zts.spec.ts
+++ b/express-zod-api/tests/zts.spec.ts
@@ -1,18 +1,16 @@
 import ts from "typescript";
 import { z } from "zod";
 import { ez } from "../src";
-import { TypescriptAPI } from "../src/typescript-api";
+import { printNode } from "../src/typescript-api";
 import { zodToTs } from "../src/zts";
 import type { ZTSContext } from "../src/zts-helpers";
 
 describe("zod-to-ts", () => {
-  const api = new TypescriptAPI(ts);
   const printNodeTest = (node: ts.Node) =>
-    api.printNode(node, { newLine: ts.NewLineKind.LineFeed });
+    printNode(node, { newLine: ts.NewLineKind.LineFeed });
   const ctx: ZTSContext = {
     isResponse: false,
-    makeAlias: vi.fn(() => api.f.createTypeReferenceNode("SomeType")),
-    api,
+    makeAlias: vi.fn(() => ts.factory.createTypeReferenceNode("SomeType")),
   };
 
   describe("z.array()", () => {

--- a/express-zod-api/tsdown.config.ts
+++ b/express-zod-api/tsdown.config.ts
@@ -3,7 +3,11 @@ import manifest from "./package.json" with { type: "json" };
 import { fixDtsPlugin } from "../tools/fixDts.ts";
 
 export default defineConfig({
-  entry: "src/index.ts",
+  entry: {
+    index: "src/index.ts",
+    integration: "src/integration.ts",
+    documentation: "src/documentation.ts",
+  },
   fixedExtension: false,
   minify: true,
   attw: { profile: "esm-only", level: "error" },

--- a/issue952-test/tags.ts
+++ b/issue952-test/tags.ts
@@ -1,8 +1,5 @@
-import {
-  defaultEndpointsFactory,
-  Documentation,
-  type TagOverrides,
-} from "express-zod-api";
+import { defaultEndpointsFactory, type TagOverrides } from "express-zod-api";
+import { Documentation } from "express-zod-api/documentation";
 
 declare module "express-zod-api" {
   export interface TagOverrides {

--- a/migration/helpers.ts
+++ b/migration/helpers.ts
@@ -35,3 +35,23 @@ export const changeProp = ({
       return changes;
     },
   });
+
+export const removeProp = ({
+  ctx,
+  node,
+}: {
+  ctx: TSESLint.RuleContext<"remove", unknown[]>;
+  node: NamedProp;
+}) =>
+  ctx.report({
+    node,
+    messageId: "remove",
+    data: { subject: `${getPropName(node)} property` },
+    fix: (fixer) => {
+      const next = ctx.sourceCode.getTokenAfter(node);
+      return fixer.removeRange([
+        node.range[0],
+        next?.value === "," ? next.range[1] : node.range[1],
+      ]);
+    },
+  });

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -378,7 +378,7 @@ describe("Migration", async () => {
         errors: [
           {
             messageId: "remove",
-            data: { subject: "typescript option" },
+            data: { subject: "typescript property" },
           },
         ],
       },
@@ -389,7 +389,7 @@ describe("Migration", async () => {
         errors: [
           {
             messageId: "remove",
-            data: { subject: "typescript option" },
+            data: { subject: "typescript property" },
           },
         ],
       },

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -40,6 +40,11 @@ describe("Migration", async () => {
       `new Documentation({ info: { title: "x", version: "y" }, server: "https://", routing, config })`,
       `new Documentation({ info: { }, server: "https://", routing, config })`,
       `new Documentation({ routing, config })`,
+      // expressZodApiImport
+      `import { createServer } from "express-zod-api"`,
+      `import { Integration } from "express-zod-api/integration"`,
+      `import { Documentation } from "express-zod-api/documentation"`,
+      // integrationNewTypescript
       // corsConfig
       `createConfig({ cors: true })`,
       `createConfig({ cors: someHandler })`,
@@ -252,6 +257,84 @@ describe("Migration", async () => {
               from: "function returning object",
               to: "request handler",
             },
+          },
+        ],
+      },
+      {
+        name: "import Integration from main entrypoint",
+        code: `import { Integration } from "express-zod-api"`,
+        output: `import { Integration } from "express-zod-api/integration"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Integration",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
+        name: "import Documentation from main entrypoint",
+        code: `import { Documentation } from "express-zod-api"`,
+        output: `import { Documentation } from "express-zod-api/documentation"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Documentation",
+              to: "express-zod-api/documentation",
+            },
+          },
+        ],
+      },
+      {
+        name: "import Producer from main entrypoint",
+        code: `import { Producer } from "express-zod-api"`,
+        output: `import { Producer } from "express-zod-api/integration"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Producer",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
+        name: "import Depicter from main entrypoint",
+        code: `import { Depicter } from "express-zod-api"`,
+        output: `import { Depicter } from "express-zod-api/documentation"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Depicter",
+              to: "express-zod-api/documentation",
+            },
+          },
+        ],
+      },
+      {
+        name: "remove typescript option from Integration constructor",
+        code: `new Integration({ typescript: ts, routing, config })`,
+        output: `new Integration({ routing, config })`,
+        errors: [
+          {
+            messageId: "remove",
+            data: { subject: "typescript option" },
+          },
+        ],
+      },
+      {
+        name: "remove typescript option as the only property",
+        code: `new Integration({ typescript: ts })`,
+        output: `new Integration({})`,
+        errors: [
+          {
+            messageId: "remove",
+            data: { subject: "typescript option" },
           },
         ],
       },

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -317,6 +317,62 @@ describe("Migration", async () => {
         ],
       },
       {
+        name: "split mixed import with Integration and main",
+        code: `import { createConfig, Integration } from "express-zod-api"`,
+        output: `import { createConfig } from "express-zod-api"\nimport { Integration } from "express-zod-api/integration"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Integration",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
+        name: "split mixed import across both subpaths",
+        code: `import { Integration, Documentation } from "express-zod-api"`,
+        output: `import { Integration } from "express-zod-api/integration"\nimport { Documentation } from "express-zod-api/documentation"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Integration",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
+        name: "split mixed import with main and both subpaths",
+        code: `import { createConfig, Integration, Depicter } from "express-zod-api"`,
+        output: `import { createConfig } from "express-zod-api"\nimport { Integration } from "express-zod-api/integration"\nimport { Depicter } from "express-zod-api/documentation"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Integration",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
+        name: "split import type across subpaths",
+        code: `import type { Producer, Depicter } from "express-zod-api"`,
+        output: `import type { Producer } from "express-zod-api/integration"\nimport type { Depicter } from "express-zod-api/documentation"`,
+        errors: [
+          {
+            messageId: "move",
+            data: {
+              subject: "Producer",
+              to: "express-zod-api/integration",
+            },
+          },
+        ],
+      },
+      {
         name: "remove typescript option from Integration constructor",
         code: `new Integration({ typescript: ts, routing, config })`,
         output: `new Integration({ routing, config })`,

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -374,7 +374,7 @@ describe("Migration", async () => {
       {
         name: "remove typescript option from Integration constructor",
         code: `new Integration({ typescript: ts, routing, config })`,
-        output: `new Integration({ routing, config })`,
+        output: `new Integration({  routing, config })`,
         errors: [
           {
             messageId: "remove",
@@ -385,7 +385,7 @@ describe("Migration", async () => {
       {
         name: "remove typescript option as the only property",
         code: `new Integration({ typescript: ts })`,
-        output: `new Integration({})`,
+        output: `new Integration({  })`,
         errors: [
           {
             messageId: "remove",

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -44,7 +44,6 @@ describe("Migration", async () => {
       `import { createServer } from "express-zod-api"`,
       `import { Integration } from "express-zod-api/integration"`,
       `import { Documentation } from "express-zod-api/documentation"`,
-      // integrationNewTypescript
       // corsConfig
       `createConfig({ cors: true })`,
       `createConfig({ cors: someHandler })`,

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -222,27 +222,60 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
           ["express-zod-api/integration", ["Integration", "Producer"]],
           ["express-zod-api/documentation", ["Documentation", "Depicter"]],
         ];
-        for (const [target, names] of targets) {
-          const found = node.specifiers.filter(
-            (s) =>
-              s.type === NT.ImportSpecifier &&
-              s.imported.type === NT.Identifier &&
-              names.includes(s.imported.name),
-          );
-          if (found.length === 0) continue;
-          const spec = found[0] as TSESTree.ImportSpecifier;
-          const imported =
+        const groups = new Map<string, TSESTree.ImportSpecifier[]>();
+        const remaining: TSESTree.ImportSpecifier[] = [];
+        const nonNamed: TSESTree.ImportDeclaration["specifiers"] = [];
+        for (const spec of node.specifiers) {
+          if (spec.type !== NT.ImportSpecifier) {
+            nonNamed.push(spec);
+            continue;
+          }
+          const name =
             spec.imported.type === NT.Identifier
               ? spec.imported.name
               : spec.imported.value;
-          ctx.report({
-            node,
-            messageId: "move",
-            data: { subject: imported, to: target },
-            fix: (fixer) => fixer.replaceText(node.source, `"${target}"`),
-          });
-          return;
+          let found = false;
+          for (const [target, names] of targets) {
+            if (names.includes(name)) {
+              if (!groups.has(target)) groups.set(target, []);
+              groups.get(target)!.push(spec);
+              found = true;
+              break;
+            }
+          }
+          if (!found) remaining.push(spec);
         }
+        if (groups.size === 0) return;
+        const importKind = node.importKind === "type" ? "type " : "";
+        const first = groups.entries().next().value!;
+        const firstName =
+          first[1][0]!.imported.type === NT.Identifier
+            ? first[1][0]!.imported.name
+            : first[1][0]!.imported.value;
+        ctx.report({
+          node,
+          messageId: "move",
+          data: { subject: firstName, to: first[0] },
+          fix: (fixer) => {
+            const parts: string[] = [];
+            const allMain = [...nonNamed, ...remaining];
+            if (allMain.length > 0) {
+              const text = allMain
+                .map((s) => ctx.sourceCode.getText(s))
+                .join(", ");
+              parts.push(
+                `import ${importKind}{ ${text} } from "express-zod-api"`,
+              );
+            }
+            for (const [target, specs] of groups) {
+              const text = specs
+                .map((s) => ctx.sourceCode.getText(s))
+                .join(", ");
+              parts.push(`import ${importKind}{ ${text} } from "${target}"`);
+            }
+            return fixer.replaceText(node, parts.join("\n"));
+          },
+        });
       },
       integrationNewTypescript: (node) => {
         const arg = node.arguments[0];

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -12,6 +12,8 @@ interface Queries {
   asyncLifecycleHook: NamedProp;
   documentationConfig: TSESTree.ObjectExpression;
   corsConfig: NamedProp;
+  expressZodApiImport: TSESTree.ImportDeclaration;
+  integrationNewTypescript: TSESTree.NewExpression;
 }
 
 type Listener = keyof Queries;
@@ -38,6 +40,8 @@ const queries: Record<Listener, string> = {
     `${NT.CallExpression}[callee.name="createConfig"] > ` +
     `${NT.ObjectExpression} > ` +
     queryNamedProp("cors"),
+  expressZodApiImport: `${NT.ImportDeclaration}[source.value="express-zod-api"]`,
+  integrationNewTypescript: `${NT.NewExpression}[callee.name="Integration"]`,
 };
 
 const listen = <
@@ -211,6 +215,58 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
             to: entries.map(([, v]) => v).join(", "),
           },
           fix: (fixer) => fixer.replaceText(node, newText),
+        });
+      },
+      expressZodApiImport: (node) => {
+        const targets: [string, string[]][] = [
+          ["express-zod-api/integration", ["Integration", "Producer"]],
+          ["express-zod-api/documentation", ["Documentation", "Depicter"]],
+        ];
+        for (const [target, names] of targets) {
+          const found = node.specifiers.filter(
+            (s) =>
+              s.type === NT.ImportSpecifier &&
+              s.imported.type === NT.Identifier &&
+              names.includes(s.imported.name),
+          );
+          if (found.length === 0) continue;
+          const spec = found[0] as TSESTree.ImportSpecifier;
+          const imported =
+            spec.imported.type === NT.Identifier
+              ? spec.imported.name
+              : spec.imported.value;
+          ctx.report({
+            node,
+            messageId: "move",
+            data: { subject: imported, to: target },
+            fix: (fixer) => fixer.replaceText(node.source, `"${target}"`),
+          });
+          return;
+        }
+      },
+      integrationNewTypescript: (node) => {
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== NT.ObjectExpression) return;
+        const typescriptProp = arg.properties.find(
+          (p) =>
+            p.type === NT.Property &&
+            p.key.type === NT.Identifier &&
+            p.key.name === "typescript",
+        );
+        if (!typescriptProp) return;
+        ctx.report({
+          node,
+          messageId: "remove",
+          data: { subject: "typescript option" },
+          fix: (fixer) => {
+            const remaining = arg.properties.filter(
+              (p) => p !== typescriptProp,
+            );
+            const newText = remaining.length
+              ? `{ ${remaining.map((p) => ctx.sourceCode.getText(p)).join(", ")} }`
+              : "{}";
+            return fixer.replaceText(arg, newText);
+          },
         });
       },
     }),

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -65,6 +65,11 @@ const listen = <
     {},
   );
 
+const moveTargets = new Map<string, string[]>([
+  ["express-zod-api/integration", ["Integration", "Producer"]],
+  ["express-zod-api/documentation", ["Documentation", "Depicter"]],
+]);
+
 const ruleName = `v${process.env.TSDOWN_VERSION?.split(".")[0]}`;
 
 const theRule = ESLintUtils.RuleCreator.withoutDocs({
@@ -226,10 +231,6 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
         });
       },
       expressZodApiImport: (node) => {
-        const targets: [string, string[]][] = [
-          ["express-zod-api/integration", ["Integration", "Producer"]],
-          ["express-zod-api/documentation", ["Documentation", "Depicter"]],
-        ];
         const groups = new Map<string, TSESTree.ImportSpecifier[]>();
         const remaining: TSESTree.ImportSpecifier[] = [];
         const nonNamed: TSESTree.ImportDeclaration["specifiers"] = [];
@@ -243,7 +244,7 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
               ? spec.imported.name
               : spec.imported.value;
           let found = false;
-          for (const [target, names] of targets) {
+          for (const [target, names] of moveTargets) {
             if (names.includes(name)) {
               if (!groups.has(target)) groups.set(target, []);
               groups.get(target)!.push(spec);

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -4,7 +4,12 @@ import {
   type TSESLint,
   type TSESTree,
 } from "@typescript-eslint/utils"; // eslint-disable-line allowed/dependencies -- assumed transitive dependency
-import { queryNamedProp, type NamedProp, getPropName } from "./helpers.ts";
+import {
+  queryNamedProp,
+  type NamedProp,
+  getPropName,
+  removeProp,
+} from "./helpers.ts";
 
 interface Queries {
   integrationCreate: TSESTree.CallExpression;
@@ -280,19 +285,7 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
           },
         });
       },
-      integrationNewTypescript: (node) =>
-        ctx.report({
-          node,
-          messageId: "remove",
-          data: { subject: "typescript option" },
-          fix: (fixer) => {
-            const next = ctx.sourceCode.getTokenAfter(node);
-            return fixer.removeRange([
-              node.range[0],
-              next?.value === "," ? next.range[1] : node.range[1],
-            ]);
-          },
-        }),
+      integrationNewTypescript: (node) => removeProp({ ctx, node }),
     }),
 });
 

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -280,7 +280,7 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
           },
         });
       },
-      integrationNewTypescript: (node) => {
+      integrationNewTypescript: (node) =>
         ctx.report({
           node,
           messageId: "remove",
@@ -292,8 +292,7 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
               next?.value === "," ? next.range[1] : node.range[1],
             ]);
           },
-        });
-      },
+        }),
     }),
 });
 

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -13,7 +13,7 @@ interface Queries {
   documentationConfig: TSESTree.ObjectExpression;
   corsConfig: NamedProp;
   expressZodApiImport: TSESTree.ImportDeclaration;
-  integrationNewTypescript: TSESTree.ObjectExpression;
+  integrationNewTypescript: NamedProp;
 }
 
 type Listener = keyof Queries;
@@ -43,7 +43,8 @@ const queries: Record<Listener, string> = {
   expressZodApiImport: `${NT.ImportDeclaration}[source.value="express-zod-api"]`,
   integrationNewTypescript:
     `${NT.NewExpression}[callee.name="Integration"] > ` +
-    `${NT.ObjectExpression}`,
+    `${NT.ObjectExpression} > ` +
+    queryNamedProp("typescript"),
 };
 
 const listen = <
@@ -280,25 +281,16 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
         });
       },
       integrationNewTypescript: (node) => {
-        const typescriptProp = node.properties.find(
-          (p) =>
-            p.type === NT.Property &&
-            p.key.type === NT.Identifier &&
-            p.key.name === "typescript",
-        );
-        if (!typescriptProp) return;
         ctx.report({
           node,
           messageId: "remove",
           data: { subject: "typescript option" },
           fix: (fixer) => {
-            const remaining = node.properties.filter(
-              (p) => p !== typescriptProp,
-            );
-            const newText = remaining.length
-              ? `{ ${remaining.map((p) => ctx.sourceCode.getText(p)).join(", ")} }`
-              : "{}";
-            return fixer.replaceText(node, newText);
+            const next = ctx.sourceCode.getTokenAfter(node);
+            return fixer.removeRange([
+              node.range[0],
+              next?.value === "," ? next.range[1] : node.range[1],
+            ]);
           },
         });
       },

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -13,7 +13,7 @@ interface Queries {
   documentationConfig: TSESTree.ObjectExpression;
   corsConfig: NamedProp;
   expressZodApiImport: TSESTree.ImportDeclaration;
-  integrationNewTypescript: TSESTree.NewExpression;
+  integrationNewTypescript: TSESTree.ObjectExpression;
 }
 
 type Listener = keyof Queries;
@@ -41,7 +41,9 @@ const queries: Record<Listener, string> = {
     `${NT.ObjectExpression} > ` +
     queryNamedProp("cors"),
   expressZodApiImport: `${NT.ImportDeclaration}[source.value="express-zod-api"]`,
-  integrationNewTypescript: `${NT.NewExpression}[callee.name="Integration"]`,
+  integrationNewTypescript:
+    `${NT.NewExpression}[callee.name="Integration"] > ` +
+    `${NT.ObjectExpression}`,
 };
 
 const listen = <
@@ -278,9 +280,7 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
         });
       },
       integrationNewTypescript: (node) => {
-        const arg = node.arguments[0];
-        if (!arg || arg.type !== NT.ObjectExpression) return;
-        const typescriptProp = arg.properties.find(
+        const typescriptProp = node.properties.find(
           (p) =>
             p.type === NT.Property &&
             p.key.type === NT.Identifier &&
@@ -292,13 +292,13 @@ const theRule = ESLintUtils.RuleCreator.withoutDocs({
           messageId: "remove",
           data: { subject: "typescript option" },
           fix: (fixer) => {
-            const remaining = arg.properties.filter(
+            const remaining = node.properties.filter(
               (p) => p !== typescriptProp,
             );
             const newText = remaining.length
               ? `{ ${remaining.map((p) => ctx.sourceCode.getText(p)).join(", ")} }`
               : "{}";
-            return fixer.replaceText(arg, newText);
+            return fixer.replaceText(node, newText);
           },
         });
       },


### PR DESCRIPTION
This restores the static imports of `typescript`, simplifies the TypeScript API back to the standalone functions, while moving `Integration` and `Documentation` do the dedicated entrypoints as another suggested approach to avoid such static import in the runtime context of the framework's server.

Related to #3126 
Previously addressed by dynamically importing the TypeScript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated module entry points for integration and documentation tooling.
  * Added support for the HTTP `QUERY` method.
  * `createServer()` is now synchronous.

* **Migration**
  * Migration guidance and automated fixes now update imports to the new entry points.
  * Obsolete `typescript` options are automatically removed from `Integration` configuration.

* **Documentation**
  * Updated examples and release notes with the new import paths and migration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->