### PR TITLE
br(29): rm redundant exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### v29.0.0
 
 - Supported Node.js versions: `^22.19.0 || ^24.11.0 || ^26.0.0`;
+- Major changes to the package distribution:
+  - `Documentation` and `Depicter` type moved to the `express-zod-api/documentation` subpath;
+  - `Integration` and `Producer` type moved to the `express-zod-api/integration` subpath;
+  - Several types and interfaces are no longer exposed:
+    - `CommonConfig`, `AppConfig`, `ServerConfig` — use `createConfig()` instead;
+    - `ApiResponse` — use `createApiResponse()` instead (previously removed in v9.0.0);
+    - `CacheControl` and `CachePolicy` — use `createCacheMiddleware()` or `EndpointsFactory::useCacheMiddleware()`;
+    - `FlatObject`, `IOSchema` and every type ending with `Security`;
+    - The public nature of these types was a workaround for user-side type declarations, but it's solved differently.
 - Breaking change to the `cors` config option:
   - Changed from `boolean | HeadersProvider` to `boolean | RequestHandler`;
   - You can now use the well-known `cors` package or pass a conventional `RequestHandler` directly.
@@ -23,12 +32,10 @@
   - Default input sources for QUERY: `["query", "body", "params"]` (from the lowest priority to highest);
   - Supported by `Integration` and `Documentation` generators.
 - Changes to `Documentation`:
-  - Moved to the dedicated subpath `express-zod-api/documentation` along with `Depicter` type;
   - `serverUrl` constructor option renamed to `server` and now also accepts OpenAPI's ServerObject;
   - `title` option and `version` must be wrapped into `info`, assignable with OpenAPI's InfoObject;
   - Now produces OpenAPI 3.2.0 with better SSE support and other features.
 - Changes to `Integration`:
-  - Moved to the dedicated subpath `express-zod-api/integration` along with `Producer` type;
   - The static async method `create()` removed — use `new Integration()` instead;
   - Removed `typescript` option from constructor — now imported statically.
 - Consider using [the automated migration](https://www.npmjs.com/package/@express-zod-api/migration).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - `Integration` and `Producer` type moved to the `express-zod-api/integration` subpath;
   - Several types and interfaces are no longer exposed:
     - `CommonConfig`, `AppConfig`, `ServerConfig` — use `createConfig()` instead;
-    - `ApiResponse` — use `createApiResponse()` instead (previously removed in v9.0.0);
+    - `ApiResponse` — use `createApiResponse()` instead (new);
     - `CacheControl` and `CachePolicy` — use `createCacheMiddleware()` or `EndpointsFactory::useCacheMiddleware()`;
     - `FlatObject`, `IOSchema` and every type ending with `Security`;
     - The public nature of these types was a workaround for user-side type declarations, but it's solved differently.

--- a/express-zod-api/src/api-response.ts
+++ b/express-zod-api/src/api-response.ts
@@ -30,6 +30,19 @@ export interface ApiResponse<S extends z.ZodType> {
   mimeType?: string | [string, ...string[]] | null;
 }
 
+export function createApiResponse<S extends z.ZodType>(
+  schema: S,
+): ApiResponse<S>;
+export function createApiResponse<S extends z.ZodType>(
+  response: ApiResponse<S>,
+): ApiResponse<S>;
+export function createApiResponse<S extends z.ZodType>(
+  subject: S | ApiResponse<S>,
+) {
+  if (subject instanceof z.ZodType) return { schema: subject };
+  return subject;
+}
+
 /**
  * @private This is what the framework entities operate internally.
  * @see normalize

--- a/express-zod-api/src/api-response.ts
+++ b/express-zod-api/src/api-response.ts
@@ -30,9 +30,11 @@ export interface ApiResponse<S extends z.ZodType> {
   mimeType?: string | [string, ...string[]] | null;
 }
 
+/** @desc Creates an ApiResponse from a schema */
 export function createApiResponse<S extends z.ZodType>(
   schema: S,
 ): ApiResponse<S>;
+/** @desc Convenience method for asserting ApiResponse */
 export function createApiResponse<S extends z.ZodType>(
   response: ApiResponse<S>,
 ): ApiResponse<S>;

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -28,27 +28,15 @@ export {
 export { testEndpoint, testMiddleware } from "./testing";
 export { EventStreamFactory } from "./sse";
 
-export type { Routing } from "./routing";
 export { ez } from "./proprietary-schemas";
+
+// Types and interfaces that can be used for user convenience
+export type { Method } from "./method";
+export type { Routing } from "./routing";
 
 // Interfaces exposed for augmentation
 export type { LoggerOverrides } from "./logger-helpers";
 export type { TagOverrides } from "./common-helpers";
 
-// Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
-import type {} from "qs"; // fixes TS2742 for attachRouting, makeRequestMock, testEndpoint, testMiddleware
-export type { CacheControl, CachePolicy } from "./cache-middleware";
-export type { FlatObject } from "./common-helpers";
-export type { Method } from "./method";
-export type { IOSchema } from "./io-schema";
-export type { CommonConfig, AppConfig, ServerConfig } from "./config-type";
-export type { ApiResponse } from "./api-response";
-export type {
-  BasicSecurity,
-  BearerSecurity,
-  CookieSecurity,
-  HeaderSecurity,
-  InputSecurity,
-  OAuth2Security,
-  OpenIdSecurity,
-} from "./security";
+// Fixes TS2742 during the build: inferred types need ParsedQs from qs
+import type {} from "qs"; // for attachRouting, makeRequestMock, testEndpoint, testMiddleware

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -28,6 +28,7 @@ export {
 export { testEndpoint, testMiddleware } from "./testing";
 export { EventStreamFactory } from "./sse";
 
+export type { Routing } from "./routing";
 export { ez } from "./proprietary-schemas";
 
 // Interfaces exposed for augmentation
@@ -37,7 +38,6 @@ export type { TagOverrides } from "./common-helpers";
 // Issues 952, 1182, 1269: Insufficient exports for consumer's declaration
 import type {} from "qs"; // fixes TS2742 for attachRouting, makeRequestMock, testEndpoint, testMiddleware
 export type { CacheControl, CachePolicy } from "./cache-middleware";
-export type { Routing } from "./routing";
 export type { FlatObject } from "./common-helpers";
 export type { Method } from "./method";
 export type { IOSchema } from "./io-schema";

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -16,6 +16,7 @@ export {
   defaultResultHandler,
   arrayResultHandler,
 } from "./result-handler";
+export { createApiResponse } from "./api-response";
 export { ServeStatic } from "./serve-static";
 export { createServer, attachRouting } from "./server";
 export {

--- a/express-zod-api/tests/__snapshots__/index.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/index.spec.ts.snap
@@ -35,6 +35,8 @@ exports[`Index Entrypoint > exports > arrayResultHandler should have certain val
 
 exports[`Index Entrypoint > exports > attachRouting should have certain value 1`] = `[Function]`;
 
+exports[`Index Entrypoint > exports > createApiResponse should have certain value 1`] = `[Function]`;
+
 exports[`Index Entrypoint > exports > createCacheMiddleware should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint > exports > createConfig should have certain value 1`] = `[Function]`;
@@ -88,6 +90,7 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "ResultHandler",
   "defaultResultHandler",
   "arrayResultHandler",
+  "createApiResponse",
   "ServeStatic",
   "createServer",
   "attachRouting",

--- a/express-zod-api/tests/api-response.spec.ts
+++ b/express-zod-api/tests/api-response.spec.ts
@@ -1,5 +1,6 @@
 import {
   type ApiResponse,
+  createApiResponse,
   defaultStatusCodes,
   responseVariants,
 } from "../src/api-response";
@@ -19,6 +20,23 @@ describe("ApiResponse", () => {
   describe("responseVariants", () => {
     test("should consist of positive and negative", () => {
       expect(responseVariants).toMatchSnapshot();
+    });
+  });
+
+  describe("createApiResponse()", () => {
+    test("should accept schema", () => {
+      const schema = z.string();
+      expect(createApiResponse(schema)).toEqual({ schema });
+      expectTypeOf(createApiResponse(schema)).toEqualTypeOf<
+        ApiResponse<z.ZodString>
+      >();
+    });
+    test("should accept ApiResponse", () => {
+      const response = { schema: z.string(), statusCode: 204 };
+      expect(createApiResponse(response)).toEqual(response);
+      expectTypeOf(createApiResponse(response)).toEqualTypeOf<
+        ApiResponse<z.ZodString>
+      >();
     });
   });
 });

--- a/express-zod-api/tests/api-response.spec.ts
+++ b/express-zod-api/tests/api-response.spec.ts
@@ -1,6 +1,15 @@
-import { defaultStatusCodes, responseVariants } from "../src/api-response";
+import {
+  type ApiResponse,
+  defaultStatusCodes,
+  responseVariants,
+} from "../src/api-response";
+import { z } from "zod";
 
 describe("ApiResponse", () => {
+  test("type should satisfy", () => {
+    expectTypeOf({ schema: z.string() }).toExtend<ApiResponse<z.ZodString>>();
+  });
+
   describe("defaultStatusCodes", () => {
     test("should be 200 and 400", () => {
       expect(defaultStatusCodes).toMatchSnapshot();

--- a/express-zod-api/tests/cache-middleware.spec.ts
+++ b/express-zod-api/tests/cache-middleware.spec.ts
@@ -1,8 +1,5 @@
-import {
-  createCacheMiddleware,
-  testMiddleware,
-  type CachePolicy,
-} from "../src";
+import { createCacheMiddleware, testMiddleware } from "../src";
+import type { CachePolicy } from "../src/cache-middleware";
 
 describe("Cache middleware", () => {
   describe("createCacheMiddleware", () => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -12,6 +12,7 @@ import {
   emptySchema,
   type EmptySchema,
   type EmptyObject,
+  type FlatObject,
 } from "../src/common-helpers";
 import { z } from "zod";
 import { makeRequestMock } from "../src/testing";
@@ -34,6 +35,12 @@ describe("Common Helpers", () => {
   describe("EmptyObject", () => {
     test("should be a Record of never", () => {
       expectTypeOf<EmptyObject>().toEqualTypeOf<Record<string, never>>();
+    });
+  });
+
+  describe("FlatObject", () => {
+    test("type should satisfy", () => {
+      expectTypeOf({}).toExtend<FlatObject>();
     });
   });
 

--- a/express-zod-api/tests/config-type.spec.ts
+++ b/express-zod-api/tests/config-type.spec.ts
@@ -1,8 +1,30 @@
 import type { Express, IRouter } from "express";
 import { createConfig } from "../src";
-import type { InputSource } from "../src/config-type";
+import type {
+  AppConfig,
+  CommonConfig,
+  InputSource,
+  ServerConfig,
+} from "../src/config-type";
 
 describe("ConfigType", () => {
+  test("types should satisfy", () => {
+    expectTypeOf<{
+      cors: true;
+      logger: { level: "silent" };
+    }>().toExtend<CommonConfig>();
+    expectTypeOf<{
+      app: IRouter;
+      cors: true;
+      logger: { level: "silent" };
+    }>().toExtend<AppConfig>();
+    expectTypeOf<{
+      http: { listen: 1234 };
+      logger: { level: "silent" };
+      cors: false;
+    }>().toExtend<ServerConfig>();
+  });
+
   describe("createConfig()", () => {
     const httpConfig = { http: { listen: 3333 } };
     const httpsConfig = { https: { options: {}, listen: 4444 } };

--- a/express-zod-api/tests/index.spec.ts
+++ b/express-zod-api/tests/index.spec.ts
@@ -1,24 +1,5 @@
-import type { IRouter } from "express";
-import { z } from "zod";
 import * as entrypoint from "../src";
-import type {
-  ApiResponse,
-  AppConfig,
-  BasicSecurity,
-  BearerSecurity,
-  CommonConfig,
-  CookieSecurity,
-  FlatObject,
-  HeaderSecurity,
-  IOSchema,
-  InputSecurity,
-  LoggerOverrides,
-  Method,
-  OAuth2Security,
-  OpenIdSecurity,
-  Routing,
-  ServerConfig,
-} from "../src";
+import type { Routing, LoggerOverrides, Method } from "../src";
 
 describe("Index Entrypoint", () => {
   describe("exports", () => {
@@ -33,48 +14,10 @@ describe("Index Entrypoint", () => {
       if (entity !== undefined) expect(entity).toMatchSnapshot();
     });
 
-    test("Issue 952, 1182, 1269: should expose certain types and interfaces", () => {
+    test("should expose certain types and interfaces", () => {
       expectTypeOf<"get">().toExtend<Method>();
-      expectTypeOf(z.object({})).toExtend<IOSchema>();
-      expectTypeOf({}).toExtend<FlatObject>();
       expectTypeOf({}).toEqualTypeOf<LoggerOverrides>();
       expectTypeOf({}).toExtend<Routing>();
-      expectTypeOf<{
-        cors: true;
-        logger: { level: "silent" };
-      }>().toExtend<CommonConfig>();
-      expectTypeOf<{
-        app: IRouter;
-        cors: true;
-        logger: { level: "silent" };
-      }>().toExtend<AppConfig>();
-      expectTypeOf<{
-        http: { listen: 1234 };
-        logger: { level: "silent" };
-        cors: false;
-      }>().toExtend<ServerConfig>();
-      expectTypeOf<{ type: "basic" }>().toEqualTypeOf<BasicSecurity>();
-      expectTypeOf<{
-        type: "bearer";
-        format?: string;
-      }>().toEqualTypeOf<BearerSecurity>();
-      expectTypeOf<{
-        type: "cookie";
-        name: string;
-      }>().toEqualTypeOf<CookieSecurity>();
-      expectTypeOf<{
-        type: "header";
-        name: string;
-      }>().toEqualTypeOf<HeaderSecurity>();
-      expectTypeOf<{ type: "input"; name: string }>().toEqualTypeOf<
-        InputSecurity<string>
-      >();
-      expectTypeOf<{ type: "oauth2" }>().toExtend<OAuth2Security<string>>();
-      expectTypeOf<{
-        type: "openid";
-        url: string;
-      }>().toEqualTypeOf<OpenIdSecurity>();
-      expectTypeOf({ schema: z.string() }).toExtend<ApiResponse<z.ZodString>>();
     });
   });
 });

--- a/express-zod-api/tests/io-schema.spec.ts
+++ b/express-zod-api/tests/io-schema.spec.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import { ez, type IOSchema } from "../src";
-import { makeFinalInputSchema, ensureExtension } from "../src/io-schema";
+import { ez } from "../src";
+import {
+  makeFinalInputSchema,
+  ensureExtension,
+  type IOSchema,
+} from "../src/io-schema";
 
 describe("I/O Schema and related helpers", () => {
   describe("IOSchema", () => {

--- a/express-zod-api/tests/security.spec.ts
+++ b/express-zod-api/tests/security.spec.ts
@@ -1,6 +1,39 @@
-import { getSecurityNames } from "../src/security";
+import {
+  type BasicSecurity,
+  type BearerSecurity,
+  type CookieSecurity,
+  getSecurityNames,
+  type HeaderSecurity,
+  type InputSecurity,
+  type OAuth2Security,
+  type OpenIdSecurity,
+} from "../src/security";
 
 describe("Security", () => {
+  test("types should satisfy", () => {
+    expectTypeOf<{ type: "basic" }>().toEqualTypeOf<BasicSecurity>();
+    expectTypeOf<{
+      type: "bearer";
+      format?: string;
+    }>().toEqualTypeOf<BearerSecurity>();
+    expectTypeOf<{
+      type: "cookie";
+      name: string;
+    }>().toEqualTypeOf<CookieSecurity>();
+    expectTypeOf<{
+      type: "header";
+      name: string;
+    }>().toEqualTypeOf<HeaderSecurity>();
+    expectTypeOf<{ type: "input"; name: string }>().toEqualTypeOf<
+      InputSecurity<string>
+    >();
+    expectTypeOf<{ type: "oauth2" }>().toExtend<OAuth2Security<string>>();
+    expectTypeOf<{
+      type: "openid";
+      url: string;
+    }>().toEqualTypeOf<OpenIdSecurity>();
+  });
+
   describe("getSecurityNames", () => {
     test("should return empty set for empty containers", () => {
       expect(getSecurityNames([], "header")).toHaveProperty("size", 0);

--- a/express-zod-api/tests/server-helpers.spec.ts
+++ b/express-zod-api/tests/server-helpers.spec.ts
@@ -14,7 +14,8 @@ import {
   installTerminationListener,
   localsID,
 } from "../src/server-helpers";
-import { defaultResultHandler, ResultHandler, type CommonConfig } from "../src";
+import { defaultResultHandler, ResultHandler } from "../src";
+import type { CommonConfig } from "../src/config-type";
 import type { Request } from "express";
 import {
   makeLoggerMock,

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -21,9 +21,8 @@ import {
   createServer,
   defaultResultHandler,
   ez,
-  type AppConfig,
-  type ServerConfig,
 } from "../src";
+import type { AppConfig, ServerConfig } from "../src/config-type";
 import express from "express";
 
 describe("Server", () => {

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -6,8 +6,8 @@ import {
   testMiddleware,
   EventStreamFactory,
   EndpointsFactory,
-  type FlatObject,
 } from "../src";
+import type { FlatObject } from "../src/common-helpers";
 import {
   type Emitter,
   ensureStream,

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -5,8 +5,8 @@ import {
   ResultHandler,
   testEndpoint,
   testMiddleware,
-  type CommonConfig,
 } from "../src";
+import type { CommonConfig } from "../src/config-type";
 import type { Mock } from "vitest";
 
 describe("Testing", () => {


### PR DESCRIPTION
related to #952 , but due to the recent fix in #3541 (exposed DTS in dist), those are no longer needed.
Though, keeping Routing (certainly used) and Method (for conveniece).

This also adds `createApiResponse()` helper (it was removed in v9)