### PR TITLE
feat(client): Uploads and DefaultContext with `override()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   - Removed `typescript` option from constructor — now imported statically;
   - Generated type for `ez.buffer()` is now `Blob` instead of `Buffer` (which didn't exist in browser environments);
   - The generated Client now excludes cookie-based security fields from input types (using `Omit`);
+  - The `Implementation` type requires `ctx` to be an object, the default one has `override` method for customizations;
   - The default `Client` Implementation got improved response parsing and now supports `Blob` in request and response;
   - Both `Client` and `Subscription` delegate cookies handling (credentials) to the browser when supported;
   - Added `hasCredentials` — an explicit declaration that the API supports credentialed CORS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   - The generated Client now excludes cookie-based security fields from input types (using `Omit`);
   - The `Implementation` type requires `ctx` to be an object, the default one has `override` method for customizations;
   - The default `Client` Implementation got improved response parsing and now supports `Blob` in request and response;
+  - The default `Client` Implementation now also supports uploads from the properties assigned with `File` or `Blob`;
   - Both `Client` and `Subscription` delegate cookies handling (credentials) to the browser when supported;
   - Added `hasCredentials` — an explicit declaration that the API supports credentialed CORS.
 - Consider using [the automated migration](https://www.npmjs.com/package/@express-zod-api/migration).

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -752,7 +752,7 @@ const substitute = (
   return [path, rest] as const;
 };
 
-export type Implementation<T = unknown> = (
+export type Implementation<T extends Record<string, unknown>> = (
   method: Method,
   path: string,
   params: Record<string, any>,
@@ -763,7 +763,9 @@ type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
 
-const defaultImplementation: Implementation = async (method, path, params) => {
+const defaultImplementation: Implementation<{
+  override?: (init: RequestInit) => RequestInit;
+}> = async (method, path, params, ctx) => {
   const isBlob = params instanceof Blob;
   const hasFiles =
     !isBlob &&
@@ -793,14 +795,16 @@ const defaultImplementation: Implementation = async (method, path, params) => {
       body = JSON.stringify(params);
     }
   }
+  let init: RequestInit = {
+    method: method.toUpperCase(),
+    credentials: undefined,
+    headers,
+    body,
+  };
+  if (ctx?.override) init = ctx.override(init);
   const response = await fetch(
     new URL(`${path}${searchParams}`, "http://localhost:8090"),
-    {
-      method: method.toUpperCase(),
-      credentials: undefined,
-      headers,
-      body,
-    },
+    init,
   );
   const contentType = response.headers.get("content-type");
   if (!contentType) return;
@@ -809,7 +813,11 @@ const defaultImplementation: Implementation = async (method, path, params) => {
   return response.blob();
 };
 
-export class Client<T> {
+export class Client<
+  T extends Record<string, unknown> = {
+    override?: (init: RequestInit) => RequestInit;
+  },
+> {
   public constructor(
     protected readonly implementation: Implementation<T> = defaultImplementation,
   ) {}

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -765,22 +765,41 @@ type Pagination =
 
 const defaultImplementation: Implementation = async (method, path, params) => {
   const isBlob = params instanceof Blob;
+  const hasFiles =
+    !isBlob &&
+    Object.values(params).some(
+      (one) => one instanceof Blob || one instanceof File,
+    );
   const hasBody = !["get", "head", "delete"].includes(method);
   const searchParams =
     isBlob || hasBody ? "" : `?${new URLSearchParams(params)}`;
+  const headers =
+    !hasBody || hasFiles
+      ? undefined
+      : {
+          "Content-Type": isBlob
+            ? "application/octet-stream"
+            : "application/json",
+        };
+  let body: RequestInit["body"] = undefined;
+  if (hasBody) {
+    if (isBlob) {
+      body = params;
+    } else if (hasFiles) {
+      body = new FormData();
+      for (const [key, value] of Object.entries(params))
+        body.append(key, value);
+    } else {
+      body = JSON.stringify(params);
+    }
+  }
   const response = await fetch(
     new URL(`${path}${searchParams}`, "http://localhost:8090"),
     {
       method: method.toUpperCase(),
-      headers: hasBody
-        ? {
-            "Content-Type": isBlob
-              ? "application/octet-stream"
-              : "application/json",
-          }
-        : undefined,
-      body: hasBody ? (isBlob ? params : JSON.stringify(params)) : undefined,
       credentials: undefined,
+      headers,
+      body,
     },
   );
   const contentType = response.headers.get("content-type");

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -795,7 +795,7 @@ const defaultImplementation: Implementation<DefaultContext> = async (
     } else if (hasFiles) {
       body = new FormData();
       for (const [key, value] of Object.entries(params))
-        body.append(key, value);
+        if (value !== undefined) body.append(key, value);
     } else {
       body = JSON.stringify(params);
     }

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -759,13 +759,18 @@ export type Implementation<T extends Record<string, unknown>> = (
   ctx?: T,
 ) => Promise<any>;
 
+export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
+
 type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
 
-const defaultImplementation: Implementation<{
-  override?: (init: RequestInit) => RequestInit;
-}> = async (method, path, params, ctx) => {
+const defaultImplementation: Implementation<DefaultContext> = async (
+  method,
+  path,
+  params,
+  ctx,
+) => {
   const isBlob = params instanceof Blob;
   const hasFiles =
     !isBlob &&
@@ -813,11 +818,7 @@ const defaultImplementation: Implementation<{
   return response.blob();
 };
 
-export class Client<
-  T extends Record<string, unknown> = {
-    override?: (init: RequestInit) => RequestInit;
-  },
-> {
+export class Client<T extends Record<string, unknown> = DefaultContext> {
   public constructor(
     protected readonly implementation: Implementation<T> = defaultImplementation,
   ) {}

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -759,11 +759,11 @@ export type Implementation<T extends Record<string, unknown>> = (
   ctx?: T,
 ) => Promise<any>;
 
-export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
-
 type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
+
+export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
 
 const defaultImplementation: Implementation<DefaultContext> = async (
   method,

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -724,9 +724,21 @@ describe("Example", async () => {
     });
 
     test("can upload a file", async () => {
-      const response = await client.provide("post /v1/avatar/upload", {
-        avatar: new File(["test"], "test.svg", { type: "image/svg+xml" }),
-      });
+      const response = await client.provide(
+        "post /v1/avatar/upload",
+        { avatar: new File(["test"], "test.svg", { type: "image/svg+xml" }) },
+        {
+          override: ({ headers, ...rest }) => ({
+            ...rest,
+            headers: {
+              ...headers,
+              Cookie:
+                "session=j%3A%7B%22token%22%3A%22553280ce-ab20-4481-a9dc-fd3fc4f6759c%22%7D; " +
+                "Path=/; HttpOnly; SameSite=Lax",
+            },
+          }),
+        },
+      );
       expect(response.status).toBe("success");
     });
   });

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -284,8 +284,7 @@ describe("Example", async () => {
           body: data,
           headers: {
             Cookie:
-              "session=j%3A%7B%22token%22%3A%22553280ce-ab20-4481-a9dc-fd3fc4f6759c%22%7D; " +
-              "Path=/; HttpOnly; SameSite=Lax",
+              "session=j%3A%7B%22token%22%3A%22553280ce-ab20-4481-a9dc-fd3fc4f6759c%22%7D;",
           },
         },
       );
@@ -303,8 +302,6 @@ describe("Example", async () => {
             num: "123",
             obj: { some: "thing" },
             str: "test string value",
-            Path: "/", // from cookie
-            SameSite: "Lax",
             session: { token: "553280ce-ab20-4481-a9dc-fd3fc4f6759c" },
           },
           size: 48687,
@@ -733,8 +730,7 @@ describe("Example", async () => {
             headers: {
               ...headers,
               Cookie:
-                "session=j%3A%7B%22token%22%3A%22553280ce-ab20-4481-a9dc-fd3fc4f6759c%22%7D; " +
-                "Path=/; HttpOnly; SameSite=Lax",
+                "session=j%3A%7B%22token%22%3A%22553280ce-ab20-4481-a9dc-fd3fc4f6759c%22%7D;",
             },
           }),
         },

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -722,6 +722,13 @@ describe("Example", async () => {
       });
       expect(response instanceof Blob).toBe(true);
     });
+
+    test("can upload a file", async () => {
+      const response = await client.provide("post /v1/avatar/upload", {
+        avatar: new File(["test"], "test.svg", { type: "image/svg+xml" }),
+      });
+      expect(response.status).toBe("success");
+    });
   });
 
   describe("Rate limiting", () => {

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -35,6 +35,12 @@ const ids = {
   rest: "rest",
   searchParams: "searchParams",
   defaultImplementation: "defaultImplementation",
+  hasFiles: "hasFiles",
+  value: "value",
+  File: "File",
+  FormData: "FormData",
+  headers: "headers",
+  body: "body",
   client: "client",
   contentType: "contentType",
   isBlob: "isBlob",
@@ -246,22 +252,38 @@ export abstract class IntegrationBase {
       "head",
       "delete",
     ] satisfies ClientMethod[]).join(", ");
-    const headers = `${ids.hasBody} ? { "Content-Type": ${ids.isBlob} ? "${contentTypes.raw}" : "${contentTypes.json}" } : ${ids.undefined}`;
-    const body = `${ids.hasBody} ? ${ids.isBlob} ? ${ids.params} : JSON.${propOf<JSON>("stringify")}(${ids.params}) : ${ids.undefined}`;
+    const headers =
+      `!${ids.hasBody} || ${ids.hasFiles} ? ${ids.undefined} : ` +
+      `{ "Content-Type": ${ids.isBlob} ? "${contentTypes.raw}" : "${contentTypes.json}" };`;
     const contentType = `${ids.response}.${propOf<Response>("headers")}.${propOf<Headers>("get")}("content-type")`;
     const searchParams = `\`?\${new ${URLSearchParams.name}(${ids.params})}\``;
     return [
       `const ${ids.defaultImplementation}: ${ids.Implementation} = async (${args}) => {`,
       `  const ${ids.isBlob} = ${ids.params} instanceof Blob;`,
+      `  const ${ids.hasFiles} = !${ids.isBlob} && Object.${propOf<ObjectConstructor>("values")}(` +
+        `${ids.params}).${propOf<unknown[]>("some")}((one) => one instanceof Blob || one instanceof ${ids.File});`,
       `  const ${ids.hasBody} = ![${noBodyMethods}].includes(${ids.method});`,
       `  const ${ids.searchParams} = ${ids.isBlob} || ${ids.hasBody} ? "" : ${searchParams};`,
+      `  const ${ids.headers} = ${headers}`,
+      `  let ${ids.body}: RequestInit["${ids.body}"] = ${ids.undefined};`,
+      `  if (${ids.hasBody}) {`,
+      `    if (${ids.isBlob}) {`,
+      `      ${ids.body} = ${ids.params};`,
+      `    } else if (${ids.hasFiles}) {`,
+      `      ${ids.body} = new ${FormData.name}();`,
+      `      for (const [${ids.key}, ${ids.value}] of Object.${propOf<ObjectConstructor>("entries")}(${ids.params}))`,
+      `        ${ids.body}.${propOf<FormData>("append")}(${ids.key}, ${ids.value});`,
+      `    } else {`,
+      `      ${ids.body} = JSON.${propOf<JSON>("stringify")}(${ids.params});`,
+      `    }`,
+      `  }`,
       `  const ${ids.response} = await ${fetch.name}(`,
       `    new ${URL.name}(\`\${${ids.path}}\${${ids.searchParams}}\`, "${this.serverUrl}"),`,
       `    {`,
       `      ${propOf<RequestInit>("method")}: ${ids.method}.${propOf<string>("toUpperCase")}(),`,
-      `      ${propOf<RequestInit>("headers")}: ${headers},`,
-      `      ${propOf<RequestInit>("body")}: ${body},`,
       `      ${propOf<RequestInit>("credentials")}: ${hasCredentials ? `"include"` : ids.undefined},`,
+      `      ${ids.headers},`,
+      `      ${ids.body},`,
       `    },`,
       `  );`,
       `  const ${ids.contentType} = ${contentType};`,

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -143,7 +143,8 @@ export abstract class IntegrationBase {
   };
 
   /**
-   * @example export type Implementation = (method: Method, path: string, params: Record<string, any>) => Promise<any>;
+   * @example export type Implementation<T extends Record<string, unknown>> =
+   *          (method: Method, path: string, params: Record<string, any>, ctx?: T) => Promise<any>;
    * @internal
    * */
   protected makeImplementationType = () => {
@@ -153,7 +154,7 @@ export abstract class IntegrationBase {
       `${ids.params}: Record<string, any>`,
       `${ids.ctx}?: T`,
     ].join(",");
-    return `export type ${ids.Implementation}<T = unknown> = (${args}) => Promise<any>;`;
+    return `export type ${ids.Implementation}<T extends Record<string, unknown>> = (${args}) => Promise<any>;`;
   };
 
   /**
@@ -221,7 +222,7 @@ export abstract class IntegrationBase {
     const totalProp = propOf<OffsetPaginatedResult["output"]["shape"]>("total");
     const callArgs = `${ids.method}, ...${ids.substitute}(${ids.path}, ${ids.params}), ${ids.ctx}`;
     return [
-      `export class ${name}<T> {`,
+      `export class ${name}<T extends Record<string, unknown> = { override?: (init: RequestInit) => RequestInit }> {`,
       `  public constructor(`,
       `    protected readonly ${ids.implementation}: ${ids.Implementation}<T> = ${ids.defaultImplementation},`,
       `  ) {}`,
@@ -242,11 +243,11 @@ export abstract class IntegrationBase {
   };
 
   /**
-   * @example export const defaultImplementation: Implementation = async (method,path,params) => { ___ };
+   * @example const defaultImplementation = async (method, path, params, ctx) => { ___ };
    * @internal
    * */
   protected makeDefaultImplementation = (hasCredentials: boolean) => {
-    const args = `${ids.method}, ${ids.path}, ${ids.params}`;
+    const args = `${ids.method}, ${ids.path}, ${ids.params}, ${ids.ctx}`;
     const noBodyMethods = quot([
       "get",
       "head",
@@ -258,7 +259,7 @@ export abstract class IntegrationBase {
     const contentType = `${ids.response}.${propOf<Response>("headers")}.${propOf<Headers>("get")}("content-type")`;
     const searchParams = `\`?\${new ${URLSearchParams.name}(${ids.params})}\``;
     return [
-      `const ${ids.defaultImplementation}: ${ids.Implementation} = async (${args}) => {`,
+      `const ${ids.defaultImplementation}: ${ids.Implementation}<{ override?: (init: RequestInit) => RequestInit }> = async (${args}) => {`,
       `  const ${ids.isBlob} = ${ids.params} instanceof Blob;`,
       `  const ${ids.hasFiles} = !${ids.isBlob} && Object.${propOf<ObjectConstructor>("values")}(` +
         `${ids.params}).${propOf<unknown[]>("some")}((one) => one instanceof Blob || one instanceof ${ids.File});`,
@@ -277,14 +278,16 @@ export abstract class IntegrationBase {
       `      ${ids.body} = JSON.${propOf<JSON>("stringify")}(${ids.params});`,
       `    }`,
       `  }`,
+      `  let init: RequestInit = {`,
+      `    ${propOf<RequestInit>("method")}: ${ids.method}.${propOf<string>("toUpperCase")}(),`,
+      `    ${propOf<RequestInit>("credentials")}: ${hasCredentials ? `"include"` : ids.undefined},`,
+      `    ${ids.headers},`,
+      `    ${ids.body},`,
+      `  };`,
+      `  if (${ids.ctx}?.override) init = ${ids.ctx}.override(init);`,
       `  const ${ids.response} = await ${fetch.name}(`,
       `    new ${URL.name}(\`\${${ids.path}}\${${ids.searchParams}}\`, "${this.serverUrl}"),`,
-      `    {`,
-      `      ${propOf<RequestInit>("method")}: ${ids.method}.${propOf<string>("toUpperCase")}(),`,
-      `      ${propOf<RequestInit>("credentials")}: ${hasCredentials ? `"include"` : ids.undefined},`,
-      `      ${ids.headers},`,
-      `      ${ids.body},`,
-      `    },`,
+      `    init,`,
       `  );`,
       `  const ${ids.contentType} = ${contentType};`,
       `  if (!${ids.contentType}) return;`,

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -282,7 +282,7 @@ export abstract class IntegrationBase {
       `    } else if (${ids.hasFiles}) {`,
       `      ${ids.body} = new ${FormData.name}();`,
       `      for (const [${ids.key}, ${ids.value}] of Object.${propOf<ObjectConstructor>("entries")}(${ids.params}))`,
-      `        ${ids.body}.${propOf<FormData>("append")}(${ids.key}, ${ids.value});`,
+      `        if (${ids.value} !== undefined) ${ids.body}.${propOf<FormData>("append")}(${ids.key}, ${ids.value});`,
       `    } else {`,
       `      ${ids.body} = JSON.${propOf<JSON>("stringify")}(${ids.params});`,
       `    }`,

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -14,6 +14,7 @@ type Store = Record<IOKind, string>;
 const ids = {
   Path: "Path",
   Implementation: "Implementation",
+  DefaultContext: "DefaultContext",
   key: "key",
   path: "path",
   params: "params",
@@ -158,6 +159,13 @@ export abstract class IntegrationBase {
   };
 
   /**
+   * @example export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
+   * @internal
+   * */
+  protected makeDefaultContextType = () =>
+    `export type ${ids.DefaultContext} = { override?: (init: RequestInit) => RequestInit };`;
+
+  /**
    * @example const parseRequest = (request: string) => request.split(/ (.+)/, 2) as [Method, Path];
    * @internal
    * @desc split once, excludes the third empty element
@@ -222,7 +230,7 @@ export abstract class IntegrationBase {
     const totalProp = propOf<OffsetPaginatedResult["output"]["shape"]>("total");
     const callArgs = `${ids.method}, ...${ids.substitute}(${ids.path}, ${ids.params}), ${ids.ctx}`;
     return [
-      `export class ${name}<T extends Record<string, unknown> = { override?: (init: RequestInit) => RequestInit }> {`,
+      `export class ${name}<T extends Record<string, unknown> = ${ids.DefaultContext}> {`,
       `  public constructor(`,
       `    protected readonly ${ids.implementation}: ${ids.Implementation}<T> = ${ids.defaultImplementation},`,
       `  ) {}`,
@@ -259,7 +267,7 @@ export abstract class IntegrationBase {
     const contentType = `${ids.response}.${propOf<Response>("headers")}.${propOf<Headers>("get")}("content-type")`;
     const searchParams = `\`?\${new ${URLSearchParams.name}(${ids.params})}\``;
     return [
-      `const ${ids.defaultImplementation}: ${ids.Implementation}<{ override?: (init: RequestInit) => RequestInit }> = async (${args}) => {`,
+      `const ${ids.defaultImplementation}: ${ids.Implementation}<${ids.DefaultContext}> = async (${args}) => {`,
       `  const ${ids.isBlob} = ${ids.params} instanceof Blob;`,
       `  const ${ids.hasFiles} = !${ids.isBlob} && Object.${propOf<ObjectConstructor>("values")}(` +
         `${ids.params}).${propOf<unknown[]>("some")}((one) => one instanceof Blob || one instanceof ${ids.File});`,

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -50,6 +50,7 @@ const ids = {
   SomeOf: "SomeOf",
   Request: "Request",
   Pagination: "Pagination",
+  override: "override",
 } satisfies Record<string, string>;
 
 export const interfaces: Record<IOKind, string> = {
@@ -163,7 +164,7 @@ export abstract class IntegrationBase {
    * @internal
    * */
   protected makeDefaultContextType = () =>
-    `export type ${ids.DefaultContext} = { override?: (init: RequestInit) => RequestInit };`;
+    `export type ${ids.DefaultContext} = { ${ids.override}?: (init: RequestInit) => RequestInit };`;
 
   /**
    * @example const parseRequest = (request: string) => request.split(/ (.+)/, 2) as [Method, Path];
@@ -292,7 +293,7 @@ export abstract class IntegrationBase {
       `    ${ids.headers},`,
       `    ${ids.body},`,
       `  };`,
-      `  if (${ids.ctx}?.override) init = ${ids.ctx}.override(init);`,
+      `  if (${ids.ctx}?.${ids.override}) init = ${ids.ctx}.${ids.override}(init);`,
       `  const ${ids.response} = await ${fetch.name}(`,
       `    new ${URL.name}(\`\${${ids.path}}\${${ids.searchParams}}\`, "${this.serverUrl}"),`,
       `    init,`,

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -189,6 +189,7 @@ export class Integration extends IntegrationBase {
       this.makeParseRequestFn(),
       this.makeSubstituteFn(),
       this.makeImplementationType(),
+      this.makeDefaultContextType(),
       this.makePaginationType(),
       this.makeDefaultImplementation(hasCredentials && hasCookies),
       this.makeClientClass(clientClassName),

--- a/express-zod-api/src/integration.ts
+++ b/express-zod-api/src/integration.ts
@@ -189,8 +189,8 @@ export class Integration extends IntegrationBase {
       this.makeParseRequestFn(),
       this.makeSubstituteFn(),
       this.makeImplementationType(),
-      this.makeDefaultContextType(),
       this.makePaginationType(),
+      this.makeDefaultContextType(),
       this.makeDefaultImplementation(hasCredentials && hasCookies),
       this.makeClientClass(clientClassName),
       this.makeSubscriptionClass(

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -539,11 +539,11 @@ export type Implementation<T extends Record<string, unknown>> = (
   ctx?: T,
 ) => Promise<any>;
 
-export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
-
 type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
+
+export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
 
 const defaultImplementation: Implementation<DefaultContext> = async (
   method,

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -532,7 +532,7 @@ const substitute = (
   return [path, rest] as const;
 };
 
-export type Implementation<T = unknown> = (
+export type Implementation<T extends Record<string, unknown>> = (
   method: Method,
   path: string,
   params: Record<string, any>,
@@ -543,7 +543,9 @@ type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
 
-const defaultImplementation: Implementation = async (method, path, params) => {
+const defaultImplementation: Implementation<{
+  override?: (init: RequestInit) => RequestInit;
+}> = async (method, path, params, ctx) => {
   const isBlob = params instanceof Blob;
   const hasFiles =
     !isBlob &&
@@ -573,14 +575,16 @@ const defaultImplementation: Implementation = async (method, path, params) => {
       body = JSON.stringify(params);
     }
   }
+  let init: RequestInit = {
+    method: method.toUpperCase(),
+    credentials: undefined,
+    headers,
+    body,
+  };
+  if (ctx?.override) init = ctx.override(init);
   const response = await fetch(
     new URL(\`\${path}\${searchParams}\`, "https://example.com"),
-    {
-      method: method.toUpperCase(),
-      credentials: undefined,
-      headers,
-      body,
-    },
+    init,
   );
   const contentType = response.headers.get("content-type");
   if (!contentType) return;
@@ -589,7 +593,11 @@ const defaultImplementation: Implementation = async (method, path, params) => {
   return response.blob();
 };
 
-export class Client<T> {
+export class Client<
+  T extends Record<string, unknown> = {
+    override?: (init: RequestInit) => RequestInit;
+  },
+> {
   public constructor(
     protected readonly implementation: Implementation<T> = defaultImplementation,
   ) {}

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -545,22 +545,41 @@ type Pagination =
 
 const defaultImplementation: Implementation = async (method, path, params) => {
   const isBlob = params instanceof Blob;
+  const hasFiles =
+    !isBlob &&
+    Object.values(params).some(
+      (one) => one instanceof Blob || one instanceof File,
+    );
   const hasBody = !["get", "head", "delete"].includes(method);
   const searchParams =
     isBlob || hasBody ? "" : \`?\${new URLSearchParams(params)}\`;
+  const headers =
+    !hasBody || hasFiles
+      ? undefined
+      : {
+          "Content-Type": isBlob
+            ? "application/octet-stream"
+            : "application/json",
+        };
+  let body: RequestInit["body"] = undefined;
+  if (hasBody) {
+    if (isBlob) {
+      body = params;
+    } else if (hasFiles) {
+      body = new FormData();
+      for (const [key, value] of Object.entries(params))
+        body.append(key, value);
+    } else {
+      body = JSON.stringify(params);
+    }
+  }
   const response = await fetch(
     new URL(\`\${path}\${searchParams}\`, "https://example.com"),
     {
       method: method.toUpperCase(),
-      headers: hasBody
-        ? {
-            "Content-Type": isBlob
-              ? "application/octet-stream"
-              : "application/json",
-          }
-        : undefined,
-      body: hasBody ? (isBlob ? params : JSON.stringify(params)) : undefined,
       credentials: undefined,
+      headers,
+      body,
     },
   );
   const contentType = response.headers.get("content-type");

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -539,13 +539,18 @@ export type Implementation<T extends Record<string, unknown>> = (
   ctx?: T,
 ) => Promise<any>;
 
+export type DefaultContext = { override?: (init: RequestInit) => RequestInit };
+
 type Pagination =
   | { nextCursor: string | null }
   | { total: number; limit: number; offset: number };
 
-const defaultImplementation: Implementation<{
-  override?: (init: RequestInit) => RequestInit;
-}> = async (method, path, params, ctx) => {
+const defaultImplementation: Implementation<DefaultContext> = async (
+  method,
+  path,
+  params,
+  ctx,
+) => {
   const isBlob = params instanceof Blob;
   const hasFiles =
     !isBlob &&
@@ -593,11 +598,7 @@ const defaultImplementation: Implementation<{
   return response.blob();
 };
 
-export class Client<
-  T extends Record<string, unknown> = {
-    override?: (init: RequestInit) => RequestInit;
-  },
-> {
+export class Client<T extends Record<string, unknown> = DefaultContext> {
   public constructor(
     protected readonly implementation: Implementation<T> = defaultImplementation,
   ) {}

--- a/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/integration.spec.ts.snap
@@ -575,7 +575,7 @@ const defaultImplementation: Implementation<DefaultContext> = async (
     } else if (hasFiles) {
       body = new FormData();
       for (const [key, value] of Object.entries(params))
-        body.append(key, value);
+        if (value !== undefined) body.append(key, value);
     } else {
       body = JSON.stringify(params);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * When providing `ctx` to `Implementation`, it must now be an object (the default context includes an optional request customization hook).

* **New Features**
  * Improved response parsing now supports `Blob` in both requests and responses.
  * Uploads are supported from `File`/`Blob` values and multipart form data is applied automatically.
  * Content-Type handling is applied more appropriately for JSON and file-based requests.

* **Tests**
  * Updated upload-related assertions and added coverage for `File` uploads and request header customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->