### PR TITLE
fix(28): Redundant components for schemas with `id` meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 28
 
+### v28.7.8
+
+- Fixes component duplication in the generated Documentation:
+  - When a schema with `.meta({ id })` is reused across endpoints with `composition: "components"`;
+  - Found and reported by [@marco-carvalho](https://github.com/marco-carvalho).
+
 ### v28.7.7
 
 - Fixes an issue where an empty path could be emitted for the root route by Documentation instead of `/`:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -356,8 +356,10 @@ const fixReferences = (
         const actualName = entry.$ref.split("/").pop()!;
         const depiction = defs[actualName];
         if (depiction) {
+          const cacheKey = // avoiding serialization because changing $ref
+            depiction.id || filterNaming(actualName) || depiction;
           entry.$ref = ctx.makeRef(
-            depiction.id || depiction, // avoiding serialization, because changing $ref
+            cacheKey,
             asOAS(depiction),
             depiction.id || filterNaming(actualName),
           ).$ref;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -356,12 +356,11 @@ const fixReferences = (
         const actualName = entry.$ref.split("/").pop()!;
         const depiction = defs[actualName];
         if (depiction) {
-          const cacheKey = // avoiding serialization because changing $ref
-            depiction.id || filterNaming(actualName) || depiction;
+          const cacheKey = depiction.id || filterNaming(actualName);
           entry.$ref = ctx.makeRef(
-            cacheKey,
+            cacheKey || depiction, // avoiding serialization because changing $ref
             asOAS(depiction),
-            depiction.id || filterNaming(actualName),
+            cacheKey,
           ).$ref;
         }
         continue;

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1305,4 +1305,101 @@ describe("Documentation", () => {
       expect(spec).toMatchSnapshot();
     });
   });
+
+  describe("Issue #3570: component deduplication with meta id", () => {
+    const commons = {
+      config: sampleConfig,
+      title: "Issue 3570",
+      version: "1.0.0",
+      serverUrl: "http://localhost:8090",
+      composition: "components" as const,
+    };
+
+    test("same schema reused as output across two endpoints should produce one component", () => {
+      const item = z
+        .object({ id: z.uuid(), name: z.string() })
+        .meta({ id: "Item" });
+      const spec = new Documentation({
+        routing: {
+          "get /a": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: item,
+            handler: vi.fn(),
+          }),
+          "get /b": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: item,
+            handler: vi.fn(),
+          }),
+        },
+        ...commons,
+      }).getSpec();
+      const schemas = spec.components?.schemas ?? {};
+      const itemKeys = Object.keys(schemas).filter((name) =>
+        name.startsWith("Item"),
+      );
+      expect(itemKeys).toEqual(["Item"]);
+    });
+
+    test("same schema as input and output of one endpoint should produce one component", () => {
+      const item = z
+        .object({ id: z.uuid(), name: z.string() })
+        .meta({ id: "Item" });
+      const spec = new Documentation({
+        routing: {
+          "post /a": defaultEndpointsFactory.build({
+            method: "post",
+            input: item,
+            output: item,
+            handler: vi.fn(),
+          }),
+        },
+        ...commons,
+      }).getSpec();
+      const schemas = spec.components?.schemas ?? {};
+      const itemKeys = Object.keys(schemas).filter((name) =>
+        name.startsWith("Item"),
+      );
+      expect(itemKeys).toEqual(["Item"]);
+    });
+
+    test("multiple distinct meta ids should each appear once when reused", () => {
+      const itemA = z
+        .object({ id: z.uuid(), name: z.string() })
+        .meta({ id: "ItemA" });
+      const itemB = z
+        .object({ id: z.uuid(), name: z.string() })
+        .meta({ id: "ItemB" });
+      const spec = new Documentation({
+        routing: {
+          "get /a": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: itemA,
+            handler: vi.fn(),
+          }),
+          "get /b": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: itemA,
+            handler: vi.fn(),
+          }),
+          "get /c": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: itemB,
+            handler: vi.fn(),
+          }),
+          "get /d": defaultEndpointsFactory.build({
+            input: z.object({}),
+            output: itemB,
+            handler: vi.fn(),
+          }),
+        },
+        ...commons,
+      }).getSpec();
+      const schemas = spec.components?.schemas ?? {};
+      const itemKeys = Object.keys(schemas).filter((name) =>
+        name.startsWith("Item"),
+      );
+      expect(itemKeys).toEqual(["ItemA", "ItemB"]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3570 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI component schema deduplication when schemas share the same metadata identifier.
  * Prevented duplicate component entries when schemas are reused across endpoints or as both input and output.
  * Improved naming and reuse of generated schema references when metadata identifiers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->