### PR TITLE
fix(documentation): Prevent using same meta `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixes the issue where the same `.meta({ id })` could be used on different schemas:
   - Zod 4.3 removed the `id` unique constraint, but the `Documentation` generator relies on it for making references;
+  - The Documentation generator will now throw a `DocumentationError` if it meets the same `id` on different schemas;
   - Found and reported by [@marco-carvalho](https://github.com/marco-carvalho).
 
 ### v28.7.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 28
 
+### v28.7.9
+
+- Fixes the issue where the same `.meta({ id })` could be used on different schemas:
+  - Zod 4.3 removed the `id` unique constraint, but the `Documentation` generator relies on it for making references;
+  - Found and reported by [@marco-carvalho](https://github.com/marco-carvalho).
+
 ### v28.7.8
 
 - Fixes component duplication in the generated Documentation:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -55,6 +55,7 @@ interface ReqResCommons {
   ) => ReferenceObject;
   path: string;
   method: ClientMethod;
+  seenIds: Map<string, z.core.$ZodType>;
 }
 
 export interface OpenAPIContext extends ReqResCommons {
@@ -382,6 +383,21 @@ const depict = (
       unrepresentable: "any",
       io: ctx.isResponse ? "output" : "input",
       override: (zodCtx) => {
+        const id = z.globalRegistry.get(zodCtx.zodSchema)?.id;
+        if (id) {
+          const familiar = ctx.seenIds.get(id);
+          if (familiar) {
+            if (familiar !== zodCtx.zodSchema) {
+              throw new DocumentationError(
+                `The meta id "${id}" is used by two different schemas. ` +
+                  "Please make the ids unique or reuse the same schema instance.",
+                ctx,
+              );
+            }
+          } else {
+            ctx.seenIds.set(id, zodCtx.zodSchema);
+          }
+        }
         const brand = getBrand(zodCtx.zodSchema);
         const depicter =
           rules[
@@ -437,6 +453,7 @@ export const depictResponse = ({
   hasMultipleStatusCodes,
   statusCode,
   brandHandling,
+  seenIds,
   description = `${method.toUpperCase()} ${path} ${ucFirst(variant)} response ${
     hasMultipleStatusCodes ? statusCode : ""
   }`.trim(),
@@ -454,7 +471,7 @@ export const depictResponse = ({
   const response = asOAS(
     depict(schema, {
       rules: { ...brandHandling, ...depicters },
-      ctx: { isResponse: true, makeRef, path, method },
+      ctx: { isResponse: true, makeRef, path, method, seenIds },
     }),
   );
   const examples = [];
@@ -570,13 +587,14 @@ export const depictRequest = ({
   makeRef,
   path,
   method,
+  seenIds,
 }: ReqResCommons & {
   schema: IOSchema;
   brandHandling?: BrandHandling;
 }) =>
   depict(schema, {
     rules: { ...brandHandling, ...depicters },
-    ctx: { isResponse: false, makeRef, path, method },
+    ctx: { isResponse: false, makeRef, path, method, seenIds },
   });
 
 export const depictBody = ({

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -386,17 +386,14 @@ const depict = (
         const id = z.globalRegistry.get(zodCtx.zodSchema)?.id;
         if (id) {
           const familiar = ctx.seenIds.get(id);
-          if (familiar) {
-            if (familiar !== zodCtx.zodSchema) {
-              throw new DocumentationError(
-                `The meta id "${id}" is used by two different schemas. ` +
-                  "Please make the ids unique or reuse the same schema instance.",
-                ctx,
-              );
-            }
-          } else {
-            ctx.seenIds.set(id, zodCtx.zodSchema);
+          if (familiar && familiar !== zodCtx.zodSchema) {
+            throw new DocumentationError(
+              `The meta id "${id}" is used by two different schemas. ` +
+                "Please make the ids unique or reuse the same schema instance.",
+              ctx,
+            );
           }
+          ctx.seenIds.set(id, zodCtx.zodSchema);
         }
         const brand = getBrand(zodCtx.zodSchema);
         const depicter =

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -32,6 +32,7 @@ import {
 } from "./documentation-helpers";
 import type { Routing } from "./routing";
 import { walkRouting, withHead, type OnEndpoint } from "./routing-walker";
+import { z } from "zod";
 
 type Component =
   `${ResponseVariant}Response` | "requestParameter" | "requestBody";
@@ -179,6 +180,8 @@ export class Documentation extends OpenApiBuilder {
     summarizer = defaultSummarizer,
     composition = "inline",
   }: DocumentationParams): OnEndpoint<ClientMethod> {
+    const makeRef = this.#makeRef.bind(this);
+    const seenIds = new Map<string, z.core.$ZodType>();
     return (method, path, endpoint) => {
       const commons = {
         path,
@@ -186,7 +189,8 @@ export class Documentation extends OpenApiBuilder {
         endpoint,
         composition,
         brandHandling,
-        makeRef: this.#makeRef.bind(this),
+        makeRef,
+        seenIds,
       };
       const { description, summary, scopes, inputSchema } = endpoint;
       const inputSources = getInputSources(method, config.inputSources);

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -180,18 +180,14 @@ export class Documentation extends OpenApiBuilder {
     summarizer = defaultSummarizer,
     composition = "inline",
   }: DocumentationParams): OnEndpoint<ClientMethod> {
-    const makeRef = this.#makeRef.bind(this);
-    const seenIds = new Map<string, z.core.$ZodType>();
+    const shared = {
+      composition,
+      brandHandling,
+      makeRef: this.#makeRef.bind(this),
+      seenIds: new Map<string, z.core.$ZodType>(),
+    };
     return (method, path, endpoint) => {
-      const commons = {
-        path,
-        method,
-        endpoint,
-        composition,
-        brandHandling,
-        makeRef,
-        seenIds,
-      };
+      const commons = { ...shared, path, method, endpoint };
       const { description, summary, scopes, inputSchema } = endpoint;
       const inputSources = getInputSources(method, config.inputSources);
       const operationId = this.#ensureUniqOperationId(

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -29,17 +29,20 @@ import {
 
 describe("Documentation helpers", () => {
   const makeRefMock = vi.fn();
+  const seenIds = new Map<string, z.core.$ZodType>();
   const requestCtx: OpenAPIContext = {
     path: "/v1/user/:id",
     method: "get",
     isResponse: false,
     makeRef: makeRefMock,
+    seenIds,
   };
   const responseCtx: OpenAPIContext = {
     path: "/v1/user/:id",
     method: "get",
     isResponse: true,
     makeRef: makeRefMock,
+    seenIds,
   };
 
   beforeEach(() => {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1402,4 +1402,105 @@ describe("Documentation", () => {
       expect(itemKeys).toEqual(["ItemA", "ItemB"]);
     });
   });
+
+  describe("Issue #3576: meta id uniqueness guard", () => {
+    const commons = {
+      config: sampleConfig,
+      title: "Issue 3576",
+      version: "1.0.0",
+      serverUrl: "http://localhost:8090",
+      composition: "components" as const,
+    };
+
+    test("two different schemas sharing an id across endpoints should throw", () => {
+      const alpha = z
+        .object({ kind: z.literal("alpha") })
+        .meta({ id: "Shared" });
+      const beta = z.object({ kind: z.literal("beta") }).meta({ id: "Shared" });
+      expect(
+        () =>
+          new Documentation({
+            routing: {
+              "get /a": defaultEndpointsFactory.build({
+                input: z.object({}),
+                output: alpha,
+                handler: vi.fn(),
+              }),
+              "get /b": defaultEndpointsFactory.build({
+                input: z.object({}),
+                output: beta,
+                handler: vi.fn(),
+              }),
+            },
+            ...commons,
+          }),
+      ).toThrow(/Shared/);
+    });
+
+    test("an id reused for a transformation should throw", () => {
+      const obj = z.object({ a: z.number() }).meta({ id: "Shared" });
+      const objToObj = obj
+        .transform(({ a }) => ({ b: String(a) }))
+        .meta({ id: "Shared" });
+      expect(
+        () =>
+          new Documentation({
+            routing: {
+              "post /a": defaultEndpointsFactory.build({
+                method: "post",
+                input: obj,
+                output: objToObj,
+                handler: vi.fn(),
+              }),
+            },
+            ...commons,
+          }),
+      ).toThrow(/Shared/);
+    });
+
+    test("same instance depicted differently as input and output should not throw", () => {
+      const pipe = z
+        .object({ a: z.number() })
+        .transform(({ a }) => ({ b: String(a) }))
+        .meta({ id: "Shared" });
+      expect(
+        () =>
+          new Documentation({
+            routing: {
+              "post /a": defaultEndpointsFactory.build({
+                method: "post",
+                input: pipe,
+                output: pipe,
+                handler: vi.fn(),
+              }),
+            },
+            ...commons,
+          }),
+      ).not.toThrow();
+    });
+
+    test("same schema reused with the same id should not throw", () => {
+      const item = z
+        .object({ id: z.uuid(), name: z.string() })
+        .meta({ id: "Item" });
+      expect(
+        () =>
+          new Documentation({
+            routing: {
+              "get /a": defaultEndpointsFactory.build({
+                input: item,
+                output: item,
+                handler: vi.fn(),
+              }),
+              "get /b": defaultEndpointsFactory.build({
+                input: item,
+                output: item,
+                handler: vi.fn(),
+              }),
+            },
+            ...commons,
+          }),
+      ).not.toThrow();
+    });
+  });
 });

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -1,6 +1,6 @@
 import createHttpError from "http-errors";
 import * as R from "ramda";
-import { globalRegistry, z } from "zod";
+import { z } from "zod";
 import { createRequire } from "node:module";
 
 describe("Environment checks", () => {
@@ -224,8 +224,8 @@ describe("Environment checks", () => {
       expect(() => {
         beta = z.number().meta({ id });
       }).not.toThrow();
-      const metaAlpha = globalRegistry.get(alpha)!;
-      const metaBeta = globalRegistry.get(beta!)!;
+      const metaAlpha = z.globalRegistry.get(alpha)!;
+      const metaBeta = z.globalRegistry.get(beta!)!;
       expect(metaAlpha).toBeTruthy();
       expect(metaBeta).toBeTruthy();
       expect(metaAlpha.id).toBe(metaBeta.id);

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -1,6 +1,6 @@
 import createHttpError from "http-errors";
 import * as R from "ramda";
-import { z } from "zod";
+import { globalRegistry, z } from "zod";
 import { createRequire } from "node:module";
 
 describe("Environment checks", () => {
@@ -211,6 +211,24 @@ describe("Environment checks", () => {
       expect(
         z.toJSONSchema(z.string().meta({ id: "uniq" })),
       ).not.toHaveProperty("id");
+    });
+
+    /**
+     * @link https://github.com/colinhacks/zod/commit/adf65cdef4d8de10b788293808e8d52807adb7c0
+     * @since zod v4.3.0, 29.12.2025
+     * */
+    test("meta id uniqueness is NOT checked", () => {
+      const id = "Shared";
+      const alpha = z.string().meta({ id });
+      let beta: z.ZodType;
+      expect(() => {
+        beta = z.number().meta({ id });
+      }).not.toThrow();
+      const metaAlpha = globalRegistry.get(alpha)!;
+      const metaBeta = globalRegistry.get(beta!)!;
+      expect(metaAlpha).toBeTruthy();
+      expect(metaBeta).toBeTruthy();
+      expect(metaAlpha.id).toBe(metaBeta.id);
     });
   });
 


### PR DESCRIPTION
Fixes #3576 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation generation now detects and reports duplicate metadata IDs used by different schemas.
  - Reusing the same schema instance across requests, responses, or endpoints remains supported.
  - Transformations with conflicting metadata IDs now produce a clear documentation error.

- **Documentation**
  - Added a changelog entry describing the metadata ID validation improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->