### PR TITLE
fix(perf): Collect security headers and cookies only when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 29
 
+### v29.0.1
+
+- Minor performance tuning for `Documentation` generator:
+  - Collecting security headers and cookie names only when the corresponding input sources are enabled.
+
 ### v29.0.0
 
 - Supported Node.js versions: `^22.19.0 || ^24.11.0 || ^26.0.0`;

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -37,13 +37,13 @@ import { ezDateOutBrand } from "./date-out-schema";
 import { DocumentationError } from "./errors";
 import type { IOSchema } from "./io-schema";
 import { flattenIO } from "./json-schema-helpers";
-import type { Alternatives } from "./logical-container";
+import type { Alternatives, LogicalContainer } from "./logical-container";
 import { getBrand } from "./metadata";
 import type { ClientMethod } from "./method";
 import type { ProprietaryBrand } from "./proprietary-schemas";
 import { ezRawBrand } from "./raw-schema";
 import type { FirstPartyKind } from "./schema-walker";
-import type { Security } from "./security";
+import { getSecurityNames, type Security } from "./security";
 import { ezUploadBrand } from "./upload-schema";
 import { getWellKnownHeaders } from "./well-known-headers";
 
@@ -257,8 +257,7 @@ export const depictRequestParams = ({
   makeRef,
   composition,
   isHeader,
-  securityHeaders,
-  securityCookies,
+  security,
   description = `${method.toUpperCase()} ${path} Parameter`,
 }: ReqResCommons & {
   composition: "inline" | "components";
@@ -266,8 +265,7 @@ export const depictRequestParams = ({
   request: z.core.JSONSchema.BaseSchema;
   inputSources: InputSource[];
   isHeader?: IsHeader;
-  securityHeaders?: Set<string>;
-  securityCookies?: Set<string>;
+  security?: LogicalContainer<Security>[];
 }) => {
   const flat = flattenIO(request);
   const pathParams = new Set(getRoutePathParams(path));
@@ -276,6 +274,12 @@ export const depictRequestParams = ({
   const areHeadersEnabled = inputSources.includes("headers");
   const areCookiesEnabled =
     inputSources.includes("cookies") || inputSources.includes("signedCookies");
+  let securityHeaders: Set<string> | undefined;
+  if (areHeadersEnabled && security)
+    securityHeaders = getSecurityNames(security, "header");
+  let securityCookies: Set<string> | undefined;
+  if (areCookiesEnabled && security)
+    securityCookies = getSecurityNames(security, "cookie");
 
   const getLocation = (name: string) => {
     if (areParamsEnabled && pathParams.has(name) && pathParams.delete(name))

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -23,7 +23,6 @@ import {
 import type { CommonConfig } from "./config-type";
 import { processContainers } from "./logical-container";
 import type { ClientMethod } from "./method";
-import { getSecurityNames } from "./security";
 import {
   depictBody,
   depictRequestParams,
@@ -224,7 +223,7 @@ export class Documentation extends OpenApiBuilder {
     return (method, path, endpoint) => {
       this.#checkDuplicate(method, path);
       const commons = { ...shared, path, method, endpoint };
-      const { description, summary, scopes, inputSchema } = endpoint;
+      const { description, summary, scopes, inputSchema, security } = endpoint;
       const inputSources = getInputSources(method, config.inputSources);
       const operationId = this.#ensureUniqOperationId(
         path,
@@ -237,9 +236,8 @@ export class Documentation extends OpenApiBuilder {
         ...commons,
         inputSources,
         isHeader,
-        securityHeaders: getSecurityNames(endpoint.security, "header"),
-        securityCookies: getSecurityNames(endpoint.security, "cookie"),
         request,
+        security,
         description: descriptions?.requestParameter?.({
           method,
           path,
@@ -287,7 +285,7 @@ export class Documentation extends OpenApiBuilder {
         : undefined;
 
       const securityRefs = depictSecurityRefs(
-        depictSecurity(processContainers(endpoint.security), inputSources),
+        depictSecurity(processContainers(security), inputSources),
         scopes,
         (securitySchema) => {
           const name = this.#ensureUniqSecuritySchemaName(securitySchema);

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -20,7 +20,7 @@ export { createApiResponse } from "./api-response";
 export { ServeStatic } from "./serve-static";
 export { createServer, attachRouting } from "./server";
 export {
-  DocumentationError,
+  DocumentationError, // @todo perhaps should be moved to /documentation subpath (breaking?)
   RoutingError,
   OutputValidationError,
   InputValidationError,

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -1,8 +1,7 @@
 import type { SchemaObjectValue } from "openapi3-ts/oas32";
 import * as R from "ramda";
 import { z } from "zod";
-import { ez } from "../src";
-import { DocumentationError } from "../src/errors";
+import { ez, DocumentationError } from "../src";
 import {
   type OpenAPIContext,
   depictRequestParams,
@@ -473,7 +472,7 @@ describe("Documentation helpers", () => {
           },
           inputSources: ["query", "headers", "params"],
           composition: "inline",
-          securityHeaders: new Set(["secure"]),
+          security: [{ type: "header", name: "secure" }],
           ...requestCtx,
         }),
       ).toMatchSnapshot();
@@ -493,7 +492,7 @@ describe("Documentation helpers", () => {
           },
           inputSources: ["query", "cookies", "params"],
           composition: "inline",
-          securityCookies: new Set(["session"]),
+          security: [{ type: "cookie", name: "session" }],
           ...requestCtx,
         }),
       ).toMatchSnapshot();


### PR DESCRIPTION
Minor adjustment. Moving the collecting of security measures into the `depictRequestParams` under condition.

This also avoids running calculated property `Endpoint::security` three times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved API documentation generation for endpoints using header- or cookie-based authentication.
* Unified security information handling for more accurate request parameter and operation documentation.
* Security details are now collected only when relevant input sources are enabled, improving documentation generation efficiency.
* Updated documentation tests to reflect streamlined security configuration.

## Chores

* Added release notes for the documentation generator improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->