### PR TITLE
fix(export): Exposing `DocumentationError` from the corresponding subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Minor performance tuning for `Documentation` generator:
   - Collecting security headers and cookie names only when the corresponding input sources are enabled;
   - Reduced some calculations required to depict request body and parameters.
+- Deprecating the `DocumentationError` export from `express-zod-api`:
+  - This export will be removed in the next major version;
+  - Import it from `express-zod-api/documentation` subpath instead.
 
 ### v29.0.0
 

--- a/express-zod-api/src/documentation.ts
+++ b/express-zod-api/src/documentation.ts
@@ -45,6 +45,8 @@ import type { Routing } from "./routing";
 import { walkRouting, withHead, type OnEndpoint } from "./routing-walker";
 import { z } from "zod";
 
+export { DocumentationError };
+
 type Component =
   `${ResponseVariant}Response` | "requestParameter" | "requestBody";
 

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -20,7 +20,7 @@ export { createApiResponse } from "./api-response";
 export { ServeStatic } from "./serve-static";
 export { createServer, attachRouting } from "./server";
 export {
-  DocumentationError, // @todo perhaps should be moved to /documentation subpath (breaking?)
+  DocumentationError, // @todo remove in v30
   RoutingError,
   OutputValidationError,
   InputValidationError,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deprecated importing `DocumentationError` from the package root.
  * Added support for importing `DocumentationError` from the documentation module.
  * The package-root export will be removed in the next major release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->