### PR TITLE
fix(plugin): Bundling augmentation

### DIFF
--- a/compat-test/dts.spec.ts
+++ b/compat-test/dts.spec.ts
@@ -7,6 +7,6 @@ describe("DTS", () => {
       "./node_modules/express-zod-api/node_modules/@express-zod-api/zod-plugin/dist/index.d.ts",
       "utf-8",
     );
-    expect(pluginDts).toMatch(`declare module "zod"`);
+    expect(pluginDts).toContain(`declare module "zod"`);
   });
 });

--- a/compat-test/dts.spec.ts
+++ b/compat-test/dts.spec.ts
@@ -2,19 +2,11 @@ import { describe, test, expect } from "vitest";
 import { readFile } from "node:fs/promises";
 
 describe("DTS", () => {
-  test("Zod plugin must import augmentation", async () => {
+  test("Zod plugin must bundle augmentation into its DTS", async () => {
     const pluginDts = await readFile(
       "./node_modules/express-zod-api/node_modules/@express-zod-api/zod-plugin/dist/index.d.ts",
       "utf-8",
     );
-    expect(pluginDts).toMatch(`import "./augmentation.js";`);
-  });
-
-  test("Augmentation must extend Zod", async () => {
-    const augDts = await readFile(
-      "./node_modules/express-zod-api/node_modules/@express-zod-api/zod-plugin/dist/augmentation.d.ts",
-      "utf-8",
-    );
-    expect(augDts).toMatch(`declare module "zod"`);
+    expect(pluginDts).toMatch(`declare module "zod"`);
   });
 });

--- a/zod-plugin/CHANGELOG.md
+++ b/zod-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 6
 
+### v6.0.1
+
+- Simplified the bundle: Zod augmentation included into the `index.d.ts`.
+
 ### v6.0.0
 
 - Supported Node.js versions: `^22.19.0 || ^24.11.0 || ^26.0.0`.

--- a/zod-plugin/src/index.ts
+++ b/zod-plugin/src/index.ts
@@ -1,1 +1,2 @@
+import "./augmentation"; // types augmentation here
 import "./runtime"; // side effects here

--- a/zod-plugin/tsdown.config.ts
+++ b/zod-plugin/tsdown.config.ts
@@ -4,24 +4,13 @@ import { fixDtsPlugin } from "../tools/fixDts.ts";
 
 const plugins = [fixDtsPlugin()];
 
-export default defineConfig([
-  {
-    entry: "src/index.ts",
-    fixedExtension: false,
-    minify: true,
-    attw: { profile: "esm-only", level: "error" },
-    plugins,
-    banner: {
-      dts: "import './augmentation.js';",
-    },
-    define: {
-      "process.env.TSDOWN_SELF": `"${manifest.name}"`, // used by pluginFlag
-    },
+export default defineConfig({
+  entry: "src/index.ts",
+  fixedExtension: false,
+  minify: true,
+  attw: { profile: "esm-only", level: "error" },
+  plugins,
+  define: {
+    "process.env.TSDOWN_SELF": `"${manifest.name}"`, // used by pluginFlag
   },
-  {
-    entry: "src/augmentation.ts",
-    fixedExtension: false,
-    dts: { emitDtsOnly: true },
-    plugins,
-  },
-]);
+});


### PR DESCRIPTION
That didn't work before, but tsdown seems to fix that now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript declaration packaging so Zod module augmentation is included directly in the main plugin declaration file.
  * Removed the need for a separate augmentation declaration import when consuming the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->