### PR TITLE
fix: Avoid duplicate status code in ResultHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed the bug where multiple response schemas could share the same status code in `ResultHandler` definition:
   - Either when multiple entries omit the `statusCode` and fall back to defaults or when the codes explicitly overlap;
   - That silently overwrote schemas in the generated `Documentation` and duplicated keys in the generated `Integration`;
-  - Now throws a `ResultHandlerError` when using the mentioned generators.
+  - Now throws a `ResultHandlerError` when using the mentioned generators and at startup in development mode.
 
 ### v29.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v29.2.2
 
-- Fixed the bug where multiple response schemas shared the same status code in `ResultHandler` definition:
+- Fixed the bug where multiple response schemas could share the same status code in `ResultHandler` definition:
   - Either when multiple entries omit the `statusCode` and fall back to defaults or when the codes explicitly overlap;
   - That silently overwrote schemas in the generated `Documentation` and duplicated keys in the generated `Integration`;
   - Now throws a `ResultHandlerError` when using the mentioned generators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 29
 
+### v29.2.2
+
+- Fixed the bug where multiple response schemas shared the same status code in `ResultHandler` definition:
+  - Either when multiple entries omit the `statusCode` and fall back to defaults or when the codes explicitly overlap;
+  - That silently overwrote schemas in the generated `Documentation` and duplicated keys in the generated `Integration`;
+  - Now throws a `ResultHandlerError` when using the mentioned generators.
+
 ### v29.2.1
 
 - Tiny performance tuning for self-diagnostics at startup (development mode only).

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -45,21 +45,35 @@ export const normalize = <A extends unknown[]>(
     const err = new Error(`At least one ${variant} response schema required.`);
     throw new ResultHandlerError(err);
   }
-  return (Array.isArray(subject) ? subject : [subject]).map(
-    ({ schema, statusCode, mimeType }) => ({
-      schema,
-      statusCodes:
-        typeof statusCode === "number"
-          ? [statusCode]
-          : statusCode || fallback.statusCodes,
-      mimeTypes:
-        typeof mimeType === "string"
-          ? [mimeType]
-          : mimeType === undefined
-            ? fallback.mimeTypes
-            : mimeType,
-    }),
-  );
+  const normalized = (
+    Array.isArray(subject) ? subject : [subject]
+  ).map<NormalizedResponse>(({ schema, statusCode, mimeType }) => ({
+    schema,
+    statusCodes:
+      typeof statusCode === "number"
+        ? [statusCode]
+        : statusCode || fallback.statusCodes,
+    mimeTypes:
+      typeof mimeType === "string"
+        ? [mimeType]
+        : mimeType === undefined
+          ? fallback.mimeTypes
+          : mimeType,
+  }));
+  if (normalized.length > 1) {
+    const statusCodes = R.chain(R.prop("statusCodes"), normalized);
+    const duplicated = R.find(
+      (code) => statusCodes.indexOf(code) !== statusCodes.lastIndexOf(code),
+      statusCodes,
+    );
+    if (duplicated !== undefined) {
+      const err = new Error(
+        `The status code ${duplicated} is used by more than one schema.`,
+      );
+      throw new ResultHandlerError(err);
+    }
+  }
+  return normalized;
 };
 
 export const logServerError = (

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -68,7 +68,7 @@ export const normalize = <A extends unknown[]>(
     );
     if (duplicated !== undefined) {
       const err = new Error(
-        `The status code ${duplicated} is used by more than one schema.`,
+        `The status code ${duplicated} is used by multiple response schemas.`,
       );
       throw new ResultHandlerError(err);
     }

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -27,7 +27,7 @@ export type DiscriminatedResult =
       error: Error;
     };
 
-/** @throws ResultHandlerError when Result is an empty array */
+/** @throws ResultHandlerError when Result is an empty array or contains duplicate status codes */
 export const normalize = <A extends unknown[]>(
   subject: Result | LazyResult<Result, A>,
   {

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/result-helpers";
 import { makeLoggerMock, makeRequestMock } from "../src/testing";
 import { runtime } from "../src/common-helpers";
-import type { ApiResponse } from "../src/api-response.ts";
+import type { ApiResponse } from "../src/api-response";
 
 describe("Result helpers", () => {
   describe("normalize()", () => {

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -1,6 +1,7 @@
 import createHttpError from "http-errors";
 import { z } from "zod";
 import { InputValidationError, OutputValidationError } from "../src";
+import { ResultHandlerError } from "../src/errors";
 import {
   ensureHttpError,
   getPublicErrorMessage,
@@ -10,6 +11,7 @@ import {
 } from "../src/result-helpers";
 import { makeLoggerMock, makeRequestMock } from "../src/testing";
 import { runtime } from "../src/common-helpers";
+import type { ApiResponse } from "../src/api-response.ts";
 
 describe("Result helpers", () => {
   describe("normalize()", () => {
@@ -67,6 +69,26 @@ describe("Result helpers", () => {
       });
       expect(typeof subject).toBe("function");
     });
+
+    test.each<ApiResponse<z.ZodType>[]>([
+      [{ schema: z.string() }, { schema: z.number() }], // both fall back to defaults
+      [
+        { schema: z.string(), statusCode: 200 },
+        { schema: z.number(), statusCode: [204, 200] }, // 200 is duplicated explicitly
+      ],
+    ])(
+      "should throw when same status code used by different schemas %#",
+      (...subject) => {
+        expect(() =>
+          normalize(subject, {
+            variant: "positive",
+            args: [],
+            statusCodes: [200],
+            mimeTypes: ["text/plain"],
+          }),
+        ).toThrow(ResultHandlerError);
+      },
+    );
   });
 
   describe("logServerError()", () => {

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -86,7 +86,11 @@ describe("Result helpers", () => {
             statusCodes: [200],
             mimeTypes: ["text/plain"],
           }),
-        ).toThrow(ResultHandlerError);
+        ).toThrow(
+          new ResultHandlerError(
+            new Error("The status code 200 is used by multiple response schemas."),
+          ),
+        );
       },
     );
   });

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -88,7 +88,9 @@ describe("Result helpers", () => {
           }),
         ).toThrow(
           new ResultHandlerError(
-            new Error("The status code 200 is used by multiple response schemas."),
+            new Error(
+              "The status code 200 is used by multiple response schemas.",
+            ),
           ),
         );
       },


### PR DESCRIPTION
Found during #3621 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conflicting response status codes no longer silently overwrite schemas.
  * Documentation and integration generation now report errors when duplicate status codes are configured.
  * Validation covers both default and explicitly duplicated status codes.
  * Clearer errors help identify invalid response configurations before output is generated.

* **Documentation**
  * Added a changelog entry for version 29.2.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->