### PR TITLE
fix: Prevent HTTP status code misuse in ResultHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 29
 
+### v29.2.3
+
+- This version prevents the HTTP status code misuse within `ResultHandler` API response definition:
+  - The `ResultHandler::positive` expects status codes less than `400`;
+  - The `ResultHandler::negative` expects status codes greater than or equal to `400`;
+  - Otherwise, throws a `ResultHandlerError` when using `Documentation` or `Integration` or at startup (dev. mode).
+
 ### v29.2.2
 
 - Fixed the bug where multiple response schemas could share the same status code in `ResultHandler` definition:

--- a/express-zod-api/src/api-response.ts
+++ b/express-zod-api/src/api-response.ts
@@ -10,6 +10,9 @@ export const responseVariants = Object.keys(
   defaultStatusCodes,
 ) as ResponseVariant[];
 
+/** @internal An internal helper to distinguish positive (success) status codes from the negative ones. */
+export const isPositiveStatusCode = (statusCode: number) => statusCode < 400;
+
 /**
  * @desc A container for describing an API response: its schema, status code(s) and MIME type(s).
  * @see ResultHandler

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -6,7 +6,6 @@ import {
   type NormalizedResponse,
 } from "./api-response";
 import { ensureError, isObject, type FlatObject } from "./common-helpers";
-import { contentTypes } from "./content-type";
 import createHttpError, { isHttpError } from "http-errors";
 import { ResultHandlerError } from "./errors";
 import type { IOSchema } from "./io-schema";
@@ -119,22 +118,12 @@ export class ResultHandler<
 
   /** @internal */
   public override getPositiveResponse(output: IOSchema) {
-    return normalize(this.#positive, {
-      variant: "positive",
-      args: [output],
-      statusCodes: [defaultStatusCodes.positive],
-      mimeTypes: [contentTypes.json],
-    });
+    return normalize(this.#positive, { variant: "positive", args: [output] });
   }
 
   /** @internal */
   public override getNegativeResponse() {
-    return normalize(this.#negative, {
-      variant: "negative",
-      args: [],
-      statusCodes: [defaultStatusCodes.negative],
-      mimeTypes: [contentTypes.json],
-    });
+    return normalize(this.#negative, { variant: "negative", args: [] });
   }
 }
 

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -64,11 +64,8 @@ export const normalize = <A extends unknown[]>(
           : mimeType,
   }));
   const statusCodes = R.chain(R.prop("statusCodes"), normalized);
-  const invalid = R.find(
-    variant === "positive"
-      ? R.complement(isPositiveStatusCode)
-      : isPositiveStatusCode,
-    statusCodes,
+  const invalid = statusCodes.find(
+    (one) => isPositiveStatusCode(one) === (variant === "negative"),
   );
   if (invalid !== undefined) {
     const err = new Error(

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -3,6 +3,7 @@ import createHttpError, { HttpError, isHttpError } from "http-errors";
 import * as R from "ramda";
 import { z } from "zod";
 import {
+  defaultStatusCodes,
   isPositiveStatusCode,
   type NormalizedResponse,
   type ResponseVariant,
@@ -17,6 +18,7 @@ import { InputValidationError, ResultHandlerError } from "./errors";
 import type { ActualLogger } from "./logger-helpers";
 import type { LazyResult, Result } from "./result-handler";
 import { getExamples } from "./metadata";
+import { contentTypes } from "./content-type.ts";
 
 export type ResultSchema<R extends Result> =
   R extends Result<infer S> ? S : never;
@@ -37,13 +39,16 @@ export const normalize = <A extends unknown[]>(
   {
     variant,
     args,
-    ...fallback
-  }: Omit<NormalizedResponse, "schema"> & {
+  }: {
     variant: ResponseVariant;
     args: A;
   },
 ): NormalizedResponse[] => {
   if (typeof subject === "function") subject = subject(...args);
+  const fallback: Pick<NormalizedResponse, "statusCodes" | "mimeTypes"> = {
+    statusCodes: [defaultStatusCodes[variant]],
+    mimeTypes: [contentTypes.json],
+  };
   if (subject instanceof z.ZodType) return [{ schema: subject, ...fallback }];
   if (Array.isArray(subject) && !subject.length) {
     const err = new Error(`At least one ${variant} response schema required.`);

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -36,13 +36,7 @@ export type DiscriminatedResult =
 /** @throws ResultHandlerError when Result is an empty array or contains duplicate status codes */
 export const normalize = <A extends unknown[]>(
   subject: Result | LazyResult<Result, A>,
-  {
-    variant,
-    args,
-  }: {
-    variant: ResponseVariant;
-    args: A;
-  },
+  { variant, args }: { variant: ResponseVariant; args: A },
 ): NormalizedResponse[] => {
   if (typeof subject === "function") subject = subject(...args);
   const fallback: Pick<NormalizedResponse, "statusCodes" | "mimeTypes"> = {

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -18,7 +18,7 @@ import { InputValidationError, ResultHandlerError } from "./errors";
 import type { ActualLogger } from "./logger-helpers";
 import type { LazyResult, Result } from "./result-handler";
 import { getExamples } from "./metadata";
-import { contentTypes } from "./content-type.ts";
+import { contentTypes } from "./content-type";
 
 export type ResultSchema<R extends Result> =
   R extends Result<infer S> ? S : never;

--- a/express-zod-api/src/result-helpers.ts
+++ b/express-zod-api/src/result-helpers.ts
@@ -2,7 +2,11 @@ import type { Request } from "express";
 import createHttpError, { HttpError, isHttpError } from "http-errors";
 import * as R from "ramda";
 import { z } from "zod";
-import type { NormalizedResponse, ResponseVariant } from "./api-response";
+import {
+  isPositiveStatusCode,
+  type NormalizedResponse,
+  type ResponseVariant,
+} from "./api-response";
 import {
   combinations,
   getMessageFromError,
@@ -60,8 +64,20 @@ export const normalize = <A extends unknown[]>(
           ? fallback.mimeTypes
           : mimeType,
   }));
+  const statusCodes = R.chain(R.prop("statusCodes"), normalized);
+  const invalid = R.find(
+    variant === "positive"
+      ? R.complement(isPositiveStatusCode)
+      : isPositiveStatusCode,
+    statusCodes,
+  );
+  if (invalid !== undefined) {
+    const err = new Error(
+      `The status code ${invalid} is not valid for a ${variant} API response.`,
+    );
+    throw new ResultHandlerError(err);
+  }
   if (normalized.length > 1) {
-    const statusCodes = R.chain(R.prop("statusCodes"), normalized);
     const duplicated = R.find(
       (code) => statusCodes.indexOf(code) !== statusCodes.lastIndexOf(code),
       statusCodes,

--- a/express-zod-api/tests/api-response.spec.ts
+++ b/express-zod-api/tests/api-response.spec.ts
@@ -2,9 +2,11 @@ import {
   type ApiResponse,
   createApiResponse,
   defaultStatusCodes,
+  isPositiveStatusCode,
   responseVariants,
 } from "../src/api-response";
 import { z } from "zod";
+import * as R from "ramda";
 
 describe("ApiResponse", () => {
   test("type should satisfy", () => {
@@ -38,5 +40,20 @@ describe("ApiResponse", () => {
         ApiResponse<z.ZodString>
       >();
     });
+  });
+
+  describe("isPositiveStatusCode", () => {
+    test.each(R.range(100, 400))(
+      "should consider %s as positive",
+      (statusCode) => {
+        expect(isPositiveStatusCode(statusCode)).toBe(true);
+      },
+    );
+    test.each(R.range(400, 600))(
+      "should consider %s as negative",
+      (statusCode) => {
+        expect(isPositiveStatusCode(statusCode)).toBe(false);
+      },
+    );
   });
 });

--- a/express-zod-api/tests/api-response.spec.ts
+++ b/express-zod-api/tests/api-response.spec.ts
@@ -16,6 +16,8 @@ describe("ApiResponse", () => {
   describe("defaultStatusCodes", () => {
     test("should be 200 and 400", () => {
       expect(defaultStatusCodes).toMatchSnapshot();
+      expect(isPositiveStatusCode(defaultStatusCodes.positive)).toBe(true);
+      expect(isPositiveStatusCode(defaultStatusCodes.negative)).toBe(false);
     });
   });
 

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -20,53 +20,33 @@ describe("Result helpers", () => {
     test.each([schema, () => schema])(
       "should handle a plain schema %#",
       (subject) => {
-        expect(
-          normalize(subject, {
-            variant: "positive",
-            args: [],
-            statusCodes: [200],
-            mimeTypes: ["text/plain"],
-          }),
-        ).toEqual([{ schema, statusCodes: [200], mimeTypes: ["text/plain"] }]);
+        expect(normalize(subject, { variant: "positive", args: [] })).toEqual([
+          { schema, statusCodes: [200], mimeTypes: ["application/json"] },
+        ]);
       },
     );
 
     test.each([{ schema }, () => ({ schema })])(
       "should handle an object %#",
       (subject) => {
-        expect(
-          normalize(subject, {
-            variant: "positive",
-            args: [],
-            statusCodes: [200],
-            mimeTypes: ["text/plain"],
-          }),
-        ).toEqual([{ schema, statusCodes: [200], mimeTypes: ["text/plain"] }]);
+        expect(normalize(subject, { variant: "positive", args: [] })).toEqual([
+          { schema, statusCodes: [200], mimeTypes: ["application/json"] },
+        ]);
       },
     );
 
     test.each([[{ schema }], () => [{ schema }]])(
       "should handle an array of objects %#",
       (subject) => {
-        expect(
-          normalize(subject, {
-            variant: "positive",
-            args: [],
-            statusCodes: [200],
-            mimeTypes: ["text/plain"],
-          }),
-        ).toEqual([{ schema, statusCodes: [200], mimeTypes: ["text/plain"] }]);
+        expect(normalize(subject, { variant: "positive", args: [] })).toEqual([
+          { schema, statusCodes: [200], mimeTypes: ["application/json"] },
+        ]);
       },
     );
 
     test("should not mutate the subject when it's a function", () => {
       const subject = () => schema;
-      normalize(subject, {
-        variant: "positive",
-        args: [],
-        statusCodes: [200],
-        mimeTypes: ["text/plain"],
-      });
+      normalize(subject, { variant: "positive", args: [] });
       expect(typeof subject).toBe("function");
     });
 
@@ -80,12 +60,7 @@ describe("Result helpers", () => {
       "should throw when same status code used by different schemas %#",
       (...subject) => {
         expect(() =>
-          normalize(subject, {
-            variant: "positive",
-            args: [],
-            statusCodes: [200],
-            mimeTypes: ["text/plain"],
-          }),
+          normalize(subject, { variant: "positive", args: [] }),
         ).toThrow(
           new ResultHandlerError(
             new Error(
@@ -105,15 +80,7 @@ describe("Result helpers", () => {
       "should throw when status code %s does not match the %s response variant",
       (statusCode, variant) => {
         expect(() =>
-          normalize(
-            { schema: z.string(), statusCode },
-            {
-              variant,
-              args: [],
-              statusCodes: [200],
-              mimeTypes: ["text/plain"],
-            },
-          ),
+          normalize({ schema: z.string(), statusCode }, { variant, args: [] }),
         ).toThrow(
           new ResultHandlerError(
             new Error(

--- a/express-zod-api/tests/result-helpers.spec.ts
+++ b/express-zod-api/tests/result-helpers.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/result-helpers";
 import { makeLoggerMock, makeRequestMock } from "../src/testing";
 import { runtime } from "../src/common-helpers";
-import type { ApiResponse } from "../src/api-response";
+import type { ApiResponse, ResponseVariant } from "../src/api-response";
 
 describe("Result helpers", () => {
   describe("normalize()", () => {
@@ -90,6 +90,34 @@ describe("Result helpers", () => {
           new ResultHandlerError(
             new Error(
               "The status code 200 is used by multiple response schemas.",
+            ),
+          ),
+        );
+      },
+    );
+
+    test.each<[number, ResponseVariant]>([
+      [200, "negative"],
+      [399, "negative"],
+      [400, "positive"],
+      [599, "positive"],
+    ])(
+      "should throw when status code %s does not match the %s response variant",
+      (statusCode, variant) => {
+        expect(() =>
+          normalize(
+            { schema: z.string(), statusCode },
+            {
+              variant,
+              args: [],
+              statusCodes: [200],
+              mimeTypes: ["text/plain"],
+            },
+          ),
+        ).toThrow(
+          new ResultHandlerError(
+            new Error(
+              `The status code ${statusCode} is not valid for a ${variant} API response.`,
             ),
           ),
         );


### PR DESCRIPTION
- Addition to #3622 — covers the potential gap for cross-variant status code duplication:
  - revealed by pullfrog at https://github.com/RobinTail/express-zod-api/pull/3622#pullrequestreview-4911143267
- Prepends #3621 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure response status codes match their declared positive or negative response types.
  * Invalid status-code definitions now produce clear errors during documentation and integration generation, as well as development startup diagnostics.
  * Status codes from 100–399 are treated as positive; codes from 400–599 are treated as negative.
  * Response defaults are applied consistently when status codes and content types are not specified.

* **Documentation**
  * Added changelog entry for version 29.2.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->