### PR TITLE
fix(mw): Respecting custom status code for rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 29
 
+### v29.2.4
+
+- Fixed: `createRateLimitMiddleware` and `EndpointsFactory::useRateLimit` respect the custom `statusCode`:
+  - The feature introduced in v28.7.0 and the default code remains `429`.
+
 ### v29.2.3
 
 - This version prevents the HTTP status code misuse within `ResultHandler` API response definition:

--- a/express-zod-api/src/rate-limit-middleware.ts
+++ b/express-zod-api/src/rate-limit-middleware.ts
@@ -18,9 +18,10 @@ import { loadPeer } from "./peer-helpers";
 export const createRateLimitMiddleware = (options?: Partial<Options>) => {
   const rateLimit = loadPeer<typeof RateLimitFn>("express-rate-limit");
   const limiter = rateLimit({
+    statusCode: 429,
     ...options,
     handler: (_req, _res, next, optionsUsed) => {
-      next(createHttpError(429, optionsUsed.message));
+      next(createHttpError(optionsUsed.statusCode, optionsUsed.message));
     },
   });
   const { getKey, resetKey } = limiter;

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -35,7 +35,7 @@ describe("Rate limit middleware", () => {
     });
 
     test.each([{}, { statusCode: 444 }])(
-      "should reject when the limit exceeded",
+      "should reject when the limit exceeded %#",
       async (cfg) => {
         rateLimitMock.mockImplementationOnce((options: any) =>
           Object.assign((req: any, res: any, next: any) => {

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -34,17 +34,23 @@ describe("Rate limit middleware", () => {
       expect(output).toEqual({ rateLimit: limiterApiMock });
     });
 
-    test("should reject with 429 when limit exceeded", async () => {
-      rateLimitMock.mockImplementation((options: any) =>
-        Object.assign((req: any, res: any, next: any) => {
-          options.handler(req, res, next, options);
-        }, limiterApiMock),
-      );
-      const { responseMock } = await testMiddleware({
-        middleware: createRateLimitMiddleware({ message: "too fast" }),
-      });
-      expect(responseMock._getStatusCode()).toBe(429);
-    });
+    test.each([{}, { statusCode: 444 }])(
+      "should reject when the limit exceeded",
+      async (cfg) => {
+        rateLimitMock.mockImplementationOnce((options: any) =>
+          Object.assign((req: any, res: any, next: any) => {
+            options.handler(req, res, next, options);
+          }, limiterApiMock),
+        );
+        const { responseMock } = await testMiddleware({
+          middleware: createRateLimitMiddleware({
+            ...cfg,
+            message: "too fast",
+          }),
+        });
+        expect(responseMock._getStatusCode()).toBe(cfg.statusCode ?? 429);
+      },
+    );
 
     test("should populate ctx.rateLimit from request", async () => {
       const rateLimitInfo = {


### PR DESCRIPTION
related to #3621 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limiting responses now honor configured custom HTTP status codes.
  * The default rate-limit status remains HTTP 429 when no custom code is provided.
  * Existing rate-limit messages and options continue to be preserved.

* **Documentation**
  * Added a changelog entry describing the updated rate-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->