### PR TITLE
fix: Deduplicating `Endpoint::methods()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Version 29
 
+### v29.3.1
+
+- Fixed the `Endpoint` methods duplication issue:
+  - `Endpoint::methods()` now returns a `ReadonlySet` instead of a `ReadonlyArray`;
+  - `EndpointsFactory::build()` copies the array of declared methods to prevent its further mutation;
+  - Declared methods are now deduplicated, so assigning the same method multiple times no longer causes
+    a misleading "Route has a duplicate" error and duplicate entries in the generated `Integration` and `Documentation`.
+
 ### v29.3.0
 
 - Featuring Endpoint-specific status codes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 ### v29.3.1
 
 - Fixed the `Endpoint` methods duplication issue:
-  - `Endpoint::methods()` now returns a `ReadonlySet` instead of a `ReadonlyArray`;
-  - `EndpointsFactory::build()` copies the array of declared methods to prevent its further mutation;
-  - Declared methods are now deduplicated, so assigning the same method multiple times no longer causes
-    a misleading "Route has a duplicate" error and duplicate entries in the generated `Integration` and `Documentation`.
+  - The methods given to `EndpointsFactory::build()` are now deduplicated;
+  - No more confusing "Route has a duplicate" error in that case and duplicate entries in the generated `Integration`.
 
 ### v29.3.0
 

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -64,7 +64,7 @@ export abstract class AbstractEndpoint {
   /** @internal */
   public abstract get summary(): string | undefined;
   /** @internal */
-  public abstract get methods(): ReadonlyArray<Method> | undefined;
+  public abstract get methods(): ReadonlySet<Method>;
   /** @internal */
   public abstract get inputSchema(): IOSchema;
   /** @internal */
@@ -147,7 +147,7 @@ export class Endpoint<
 
   /** @internal */
   public override get methods() {
-    return Object.freeze(this.#def.methods);
+    return Object.freeze(new Set(this.#def.methods));
   }
 
   /** @internal */

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -199,7 +199,7 @@ export class EndpointsFactory<
     ...rest
   }: BuildProps<BIN, BOUT, IN, CTX, SCO>) {
     const { middlewares, resultHandler } = this;
-    const methods = typeof method === "string" ? [method] : method;
+    const methods = typeof method === "string" ? [method] : method?.slice();
     const getOperationId =
       typeof operationId === "function"
         ? operationId

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -55,7 +55,7 @@ export class Middleware<
   readonly #security?: LogicalContainer<
     Security<Extract<keyof z.input<IN>, string>, SCO>
   >;
-  readonly #statusCode: number[];
+  readonly #statusCode?: number[];
   readonly #handler: Handler<z.output<IN>, CTX, RET>;
 
   constructor({
@@ -86,9 +86,7 @@ export class Middleware<
     this.#schema = input as IN;
     this.#security = security;
     this.#statusCode =
-      typeof statusCode === "number"
-        ? [statusCode]
-        : (statusCode?.slice() ?? []);
+      typeof statusCode === "number" ? [statusCode] : statusCode?.slice();
     this.#handler = handler;
   }
 

--- a/express-zod-api/src/routing-walker.ts
+++ b/express-zod-api/src/routing-walker.ts
@@ -107,8 +107,7 @@ export const walkRouting = ({
         onEndpoint(explicitMethod, path, element);
       } else {
         const { methods } = element;
-        const effective = methods.size ? methods : new Set<Method>(["get"]);
-        for (const method of effective) {
+        for (const method of methods.size ? methods : ["get" as const]) {
           checkDuplicate(method, path, visited);
           onEndpoint(method, path, element);
         }

--- a/express-zod-api/src/routing-walker.ts
+++ b/express-zod-api/src/routing-walker.ts
@@ -67,9 +67,9 @@ const prohibit = (method: Method, path: string) => {
 const checkMethodSupported = (
   method: Method,
   path: string,
-  methods?: ReadonlyArray<Method>,
+  methods: ReadonlySet<Method>,
 ) => {
-  if (!methods || methods.includes(method)) return;
+  if (!methods.size || methods.has(method)) return;
   throw new RoutingError(
     `Method ${method} is not supported by the assigned Endpoint.`,
     method,
@@ -106,8 +106,9 @@ export const walkRouting = ({
         checkMethodSupported(explicitMethod, path, element.methods);
         onEndpoint(explicitMethod, path, element);
       } else {
-        const { methods = ["get"] } = element;
-        for (const method of methods) {
+        const { methods } = element;
+        const effective = methods.size ? methods : new Set<Method>(["get"]);
+        for (const method of effective) {
           checkDuplicate(method, path, visited);
           onEndpoint(method, path, element);
         }

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -8,14 +8,23 @@ import {
   ez,
   testEndpoint,
   ResultHandler,
+  type Method,
 } from "../src";
 import { Endpoint } from "../src/endpoint";
 
 describe("Endpoint", () => {
   describe(".methods", () => {
-    test("Should return the correct set of methods (readonly)", () => {
+    test("Should return the correct set of methods", () => {
+      const methods: Method[] = [
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "query",
+      ];
       const endpointMock = new Endpoint({
-        methods: ["get", "post", "put", "delete", "patch", "query"],
+        methods,
         inputSchema: z.object({}),
         outputSchema: z.object({}),
         statusCodes: new Set(),
@@ -26,16 +35,10 @@ describe("Endpoint", () => {
           handler: vi.fn(),
         }),
       });
-      const { methods } = endpointMock;
-      expect(methods).toEqual([
-        "get",
-        "post",
-        "put",
-        "delete",
-        "patch",
-        "query",
-      ]);
-      expect(() => (methods as any[]).push()).toThrowError(/read only/);
+      const { methods: actual } = endpointMock;
+      expect(actual).toEqual(new Set(methods));
+      actual.delete("get");
+      expect(endpointMock.methods).toEqual(new Set(methods));
     });
   });
 

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -8,6 +8,7 @@ import {
   defaultEndpointsFactory,
   ResultHandler,
   testMiddleware,
+  type Method,
 } from "../src";
 import * as cookieMw from "../src/cookie-middleware";
 import * as cacheMw from "../src/cache-middleware";
@@ -309,7 +310,7 @@ describe("EndpointsFactory", () => {
         handler: handlerMock,
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
-      expect(endpoint.methods).toBeUndefined();
+      expect(endpoint.methods.size).toBe(0);
       expect(endpoint.inputSchema).toMatchSnapshot();
       expect(endpoint.outputSchema).toMatchSnapshot();
       expectTypeOf(endpoint.inputSchema._zod.output).toEqualTypeOf<
@@ -359,7 +360,7 @@ describe("EndpointsFactory", () => {
         handler: handlerMock,
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
-      expect(endpoint.methods).toBeUndefined();
+      expect(endpoint.methods.size).toBe(0);
       expect(endpoint.inputSchema).toMatchSnapshot();
       expect(endpoint.outputSchema).toMatchSnapshot();
       expectTypeOf(endpoint.inputSchema._zod.output).toEqualTypeOf<
@@ -385,7 +386,7 @@ describe("EndpointsFactory", () => {
         handler: handlerMock,
       });
       expect(endpoint).toBeInstanceOf(Endpoint);
-      expect(endpoint.methods).toBeUndefined();
+      expect(endpoint.methods.size).toBe(0);
       expect(endpoint.inputSchema).toMatchSnapshot();
       expect(endpoint.outputSchema).toMatchSnapshot();
       expectTypeOf(endpoint.inputSchema._zod.output).toEqualTypeOf<
@@ -405,6 +406,25 @@ describe("EndpointsFactory", () => {
         endpoint.inputSchema._zod.output,
       ).toEqualTypeOf<EmptyObject>();
       expect(endpoint.isDeprecated).toBe(true);
+    });
+
+    test("should deduplicate the methods declared in the tuple", () => {
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        method: ["get", "post", "get"],
+        handler: vi.fn(),
+      });
+      expect(endpoint.methods).toEqual(new Set(["get", "post"]));
+    });
+
+    test("should not mutate the supplied array of methods when building", () => {
+      const methods = ["get", "post"] as [Method, ...Method[]];
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        method: methods,
+        handler: vi.fn(),
+      });
+      expect(Object.isFrozen(methods)).toBe(false);
+      methods.push("put");
+      expect(endpoint.methods).toEqual(new Set(["get", "post"]));
     });
 
     test("should pass the single statusCode to the endpoint", () => {

--- a/express-zod-api/tests/routing-walker.spec.ts
+++ b/express-zod-api/tests/routing-walker.spec.ts
@@ -67,4 +67,20 @@ describe("walkRouting()", () => {
       walkRouting({ routing, config: { cors: false }, onEndpoint }),
     ).not.toThrow();
   });
+
+  test("Should deduplicate the methods declared by the endpoint", () => {
+    const dupEndpoint = defaultEndpointsFactory.buildVoid({
+      method: ["get", "get"],
+      handler: vi.fn(),
+    });
+    expect(() =>
+      walkRouting({
+        routing: { "/x": dupEndpoint },
+        config: { cors: false },
+        onEndpoint,
+      }),
+    ).not.toThrow();
+    expect(onEndpoint).toHaveBeenCalledTimes(1);
+    expect(onEndpoint).toHaveBeenCalledWith("get", "/x", dupEndpoint);
+  });
 });


### PR DESCRIPTION
Found while working on #3621 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate HTTP methods from creating duplicate routes or misleading errors.
  * Preserved configured method lists without mutating the original settings.
  * Improved default handling for endpoints without explicitly configured methods.
  * Protected endpoint method definitions from unintended external changes.

* **Documentation**
  * Added changelog details for the routing and method-handling fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->