### PR TITLE
fix: Immutability of internal getters using `FrozenSet`

### DIFF
--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -13,6 +13,7 @@ import {
 import type { CommonConfig } from "./config-type";
 import { InputValidationError, OutputValidationError } from "./errors";
 import { ezFormBrand } from "./form-schema";
+import { FrozenSet } from "./frozen-set";
 import type { IOSchema } from "./io-schema";
 import type { ActualLogger } from "./logger-helpers";
 import type { LogicalContainer } from "./logical-container";
@@ -147,7 +148,7 @@ export class Endpoint<
 
   /** @internal */
   public override get methods() {
-    return Object.freeze(new Set(this.#def.methods));
+    return new FrozenSet(this.#def.methods);
   }
 
   /** @internal */

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -112,7 +112,7 @@ export class Endpoint<
     description?: string;
     summary?: string;
     getOperationId?: (method: ClientMethod) => string | undefined;
-    methods?: Method[];
+    methods: FrozenSet<Method>;
     scopes?: string[];
     tags?: string[];
     statusCodes: ReadonlySet<number>;
@@ -148,7 +148,7 @@ export class Endpoint<
 
   /** @internal */
   public override get methods() {
-    return new FrozenSet(this.#def.methods);
+    return this.#def.methods;
   }
 
   /** @internal */

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -13,7 +13,7 @@ import {
 import type { CommonConfig } from "./config-type";
 import { InputValidationError, OutputValidationError } from "./errors";
 import { ezFormBrand } from "./form-schema";
-import { FrozenSet } from "./frozen-set";
+import type { FrozenSet } from "./frozen-set";
 import type { IOSchema } from "./io-schema";
 import type { ActualLogger } from "./logger-helpers";
 import type { LogicalContainer } from "./logical-container";

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -26,6 +26,7 @@ import {
   arrayResultHandler,
   defaultResultHandler,
 } from "./result-handler";
+import { FrozenSet } from "./frozen-set";
 import { createCacheMiddleware } from "./cache-middleware";
 import { createCookieMiddleware } from "./cookie-middleware";
 import { createRateLimitMiddleware } from "./rate-limit-middleware";
@@ -199,7 +200,9 @@ export class EndpointsFactory<
     ...rest
   }: BuildProps<BIN, BOUT, IN, CTX, SCO>) {
     const { middlewares, resultHandler } = this;
-    const methods = typeof method === "string" ? [method] : method?.slice();
+    const methods = new FrozenSet(
+      typeof method === "string" ? [method] : method,
+    );
     const getOperationId =
       typeof operationId === "function"
         ? operationId

--- a/express-zod-api/src/frozen-set.ts
+++ b/express-zod-api/src/frozen-set.ts
@@ -1,5 +1,5 @@
 /** @class The Set that cannot be modified. */
-export class FrozenSet<T> extends Set<T> {
+export class FrozenSet<T> extends Set<T> implements ReadonlySet<T> {
   public constructor(values?: Iterable<T>) {
     super(); // because super(values) populates using this.add(value)
     if (values) for (const value of values) Set.prototype.add.call(this, value);

--- a/express-zod-api/src/frozen-set.ts
+++ b/express-zod-api/src/frozen-set.ts
@@ -1,4 +1,9 @@
-/** @class The Set that cannot be modified. */
+/**
+ * @class The Set that cannot be modified at runtime.
+ * @desc Use it for the values stored once internally and handed out through getters declared as `ReadonlySet`.
+ *       Use `Set` for mutable accumulators. TypeScript cannot distinguish `Set` from `FrozenSet` (structural typing),
+ *       so the immutability is enforced at runtime only: the mutation methods throw `TypeError`.
+ * */
 export class FrozenSet<T> extends Set<T> implements ReadonlySet<T> {
   public constructor(values?: Iterable<T>) {
     super(); // because super(values) populates using this.add(value)
@@ -18,5 +23,27 @@ export class FrozenSet<T> extends Set<T> implements ReadonlySet<T> {
   /** @throws TypeError */
   public override clear(): void {
     throw new TypeError("Can not clear the read only Set");
+  }
+
+  /** @desc The derived set is frozen as well. */
+  public override union<U>(other: ReadonlySetLike<U>): FrozenSet<T | U> {
+    return new FrozenSet(super.union(other));
+  }
+
+  /** @desc The derived set is frozen as well. */
+  public override intersection<U>(other: ReadonlySetLike<U>): FrozenSet<T & U> {
+    return new FrozenSet(super.intersection(other));
+  }
+
+  /** @desc The derived set is frozen as well. */
+  public override difference<U>(other: ReadonlySetLike<U>): FrozenSet<T> {
+    return new FrozenSet(super.difference(other));
+  }
+
+  /** @desc The derived set is frozen as well. */
+  public override symmetricDifference<U>(
+    other: ReadonlySetLike<U>,
+  ): FrozenSet<T | U> {
+    return new FrozenSet(super.symmetricDifference(other));
   }
 }

--- a/express-zod-api/src/frozen-set.ts
+++ b/express-zod-api/src/frozen-set.ts
@@ -1,0 +1,22 @@
+/** @class The Set that cannot be modified. */
+export class FrozenSet<T> extends Set<T> {
+  public constructor(values?: Iterable<T>) {
+    super(); // because super(values) populates using this.add(value)
+    if (values) for (const value of values) Set.prototype.add.call(this, value);
+  }
+
+  /** @throws TypeError */
+  public override add(_value: T): this {
+    throw new TypeError("Can not add to the read only Set");
+  }
+
+  /** @throws TypeError */
+  public override delete(_value: T): boolean {
+    throw new TypeError("Can not delete from the read only Set");
+  }
+
+  /** @throws TypeError */
+  public override clear(): void {
+    throw new TypeError("Can not clear the read only Set");
+  }
+}

--- a/express-zod-api/src/frozen-set.ts
+++ b/express-zod-api/src/frozen-set.ts
@@ -1,11 +1,14 @@
+const frozenSetBrand: unique symbol = Symbol("FrozenSet");
+
 /**
  * @class The Set that cannot be modified at runtime.
  * @desc Use it for the values stored once internally and handed out through getters declared as `ReadonlySet`.
- *       Use `Set` for mutable accumulators. TypeScript cannot distinguish `Set` from `FrozenSet` (structural typing),
- *       so the immutability is enforced at runtime only: the mutation methods throw `TypeError`.
+ *       Use `Set` for mutable accumulators. A nominal brand makes `Set` unassignable to `FrozenSet` at the type
+ *       level, while the immutability is enforced at runtime by the mutation methods throwing `TypeError`.
  * */
 export class FrozenSet<T> extends Set<T> implements ReadonlySet<T> {
-  public constructor(values?: Iterable<T>) {
+  declare readonly [frozenSetBrand]: true;
+  public constructor(values?: Iterable<T> | null) {
     super(); // because super(values) populates using this.add(value)
     if (values) for (const value of values) Set.prototype.add.call(this, value);
   }

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -56,7 +56,7 @@ export class Middleware<
   readonly #security?: LogicalContainer<
     Security<Extract<keyof z.input<IN>, string>, SCO>
   >;
-  readonly #statusCode?: number[];
+  readonly #statusCode: FrozenSet<number>;
   readonly #handler: Handler<z.output<IN>, CTX, RET>;
 
   constructor({
@@ -86,8 +86,9 @@ export class Middleware<
     super();
     this.#schema = input as IN;
     this.#security = security;
-    this.#statusCode =
-      typeof statusCode === "number" ? [statusCode] : statusCode?.slice();
+    this.#statusCode = new FrozenSet(
+      typeof statusCode === "number" ? [statusCode] : statusCode,
+    );
     this.#handler = handler;
   }
 
@@ -103,7 +104,7 @@ export class Middleware<
 
   /** @internal */
   public override get statusCodes() {
-    return new FrozenSet(this.#statusCode);
+    return this.#statusCode;
   }
 
   /** @throws InputValidationError */

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 import { z } from "zod";
 import { emptySchema, type FlatObject } from "./common-helpers";
 import { InputValidationError } from "./errors";
+import { FrozenSet } from "./frozen-set";
 import type { IOSchema } from "./io-schema";
 import type { LogicalContainer } from "./logical-container";
 import type { Security } from "./security";
@@ -102,7 +103,7 @@ export class Middleware<
 
   /** @internal */
   public override get statusCodes() {
-    return Object.freeze(new Set(this.#statusCode));
+    return new FrozenSet(this.#statusCode);
   }
 
   /** @throws InputValidationError */

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -11,6 +11,7 @@ import {
   type Method,
 } from "../src";
 import { Endpoint } from "../src/endpoint";
+import { FrozenSet } from "../src/frozen-set";
 
 describe("Endpoint", () => {
   describe(".methods", () => {
@@ -24,7 +25,7 @@ describe("Endpoint", () => {
         "query",
       ];
       const endpointMock = new Endpoint({
-        methods,
+        methods: new FrozenSet(methods),
         inputSchema: z.object({}),
         outputSchema: z.object({}),
         statusCodes: new Set(),
@@ -482,6 +483,7 @@ describe("Endpoint", () => {
     test("should return undefined if its not defined upon creation", () => {
       expect(
         new Endpoint({
+          methods: new FrozenSet(),
           inputSchema: z.object({}),
           outputSchema: z.object({}),
           statusCodes: new Set(),

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -36,9 +36,11 @@ describe("Endpoint", () => {
         }),
       });
       const { methods: actual } = endpointMock;
-      expect(actual).toEqual(new Set(methods));
-      actual.delete("get");
-      expect(endpointMock.methods).toEqual(new Set(methods));
+      expect(Array.from(actual)).toEqual(methods);
+      expect(() => (actual as Set<Method>).delete("get")).toThrow(
+        /read only/,
+      );
+      expect(Array.from(endpointMock.methods)).toEqual(methods);
     });
   });
 

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -37,9 +37,7 @@ describe("Endpoint", () => {
       });
       const { methods: actual } = endpointMock;
       expect(Array.from(actual)).toEqual(methods);
-      expect(() => (actual as Set<Method>).delete("get")).toThrow(
-        /read only/,
-      );
+      expect(() => actual.delete("get")).toThrow(/read only/);
       expect(Array.from(endpointMock.methods)).toEqual(methods);
     });
   });

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -413,7 +413,7 @@ describe("EndpointsFactory", () => {
         method: ["get", "post", "get"],
         handler: vi.fn(),
       });
-      expect(endpoint.methods).toEqual(new Set(["get", "post"]));
+      expect(Array.from(endpoint.methods)).toEqual(["get", "post"]);
     });
 
     test("should not mutate the supplied array of methods when building", () => {
@@ -424,7 +424,7 @@ describe("EndpointsFactory", () => {
       });
       expect(Object.isFrozen(methods)).toBe(false);
       methods.push("put");
-      expect(endpoint.methods).toEqual(new Set(["get", "post"]));
+      expect(Array.from(endpoint.methods)).toEqual(["get", "post"]);
     });
 
     test("should pass the single statusCode to the endpoint", () => {

--- a/express-zod-api/tests/frozen-set.spec.ts
+++ b/express-zod-api/tests/frozen-set.spec.ts
@@ -2,9 +2,11 @@ import { FrozenSet } from "../src/frozen-set";
 
 describe("FrozenSet", () => {
   test("types", () => {
-    expectTypeOf(Set).toExtend<typeof FrozenSet>();
-    expectTypeOf(FrozenSet).not.toExtend<typeof Set>();
-    expectTypeOf<Set<string>>().toExtend<FrozenSet<string>>();
+    expectTypeOf(Set).not.toExtend<typeof FrozenSet>();
+    expectTypeOf(FrozenSet).toExtend<typeof Set>();
+    expectTypeOf<FrozenSet<string>>().toExtend<Set<string>>();
+    expectTypeOf<FrozenSet<string>>().toExtend<ReadonlySet<string>>();
+    expectTypeOf<Set<string>>().not.toExtend<FrozenSet<string>>();
   });
 
   test("should construct an empty Set", () => {

--- a/express-zod-api/tests/frozen-set.spec.ts
+++ b/express-zod-api/tests/frozen-set.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { FrozenSet } from "../src/frozen-set";
 
 describe("FrozenSet", () => {

--- a/express-zod-api/tests/frozen-set.spec.ts
+++ b/express-zod-api/tests/frozen-set.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { FrozenSet } from "../src/frozen-set";
+
+describe("FrozenSet", () => {
+  test("should construct an empty Set", () => {
+    expect(new FrozenSet().size).toBe(0);
+    expect(new FrozenSet(undefined).size).toBe(0);
+  });
+
+  test("should construct a Set from an iterable", () => {
+    const set = new FrozenSet(["get", "post", "get"]);
+    expect(set).toBeInstanceOf(Set);
+    expect(Object.prototype.toString.call(set)).toBe("[object Set]");
+    expect(set.size).toBe(2);
+    expect(set.has("get")).toBe(true);
+    expect(Array.from(set)).toEqual(["get", "post"]);
+  });
+
+  test.each(["add", "delete", "clear"] as const)(
+    "should reject the mutation via %s",
+    (method) => {
+      const set = new FrozenSet(["get"]);
+      expect(() => set[method]("get")).toThrow(/read only/);
+      expect(set.size).toBe(1);
+    },
+  );
+});

--- a/express-zod-api/tests/frozen-set.spec.ts
+++ b/express-zod-api/tests/frozen-set.spec.ts
@@ -1,6 +1,12 @@
 import { FrozenSet } from "../src/frozen-set";
 
 describe("FrozenSet", () => {
+  test("types", () => {
+    expectTypeOf(Set).toExtend<typeof FrozenSet>();
+    expectTypeOf(FrozenSet).not.toExtend<typeof Set>();
+    expectTypeOf<Set<string>>().toExtend<FrozenSet<string>>();
+  });
+
   test("should construct an empty Set", () => {
     expect(new FrozenSet().size).toBe(0);
     expect(new FrozenSet(undefined).size).toBe(0);
@@ -23,4 +29,16 @@ describe("FrozenSet", () => {
       expect(set.size).toBe(1);
     },
   );
+
+  test.each([
+    "union",
+    "intersection",
+    "difference",
+    "symmetricDifference",
+  ] as const)("::%s() should return a new FrozenSet", (method) => {
+    const set = new FrozenSet(["get"]);
+    const result = set[method](new Set(["post"]));
+    expect(result).toBeInstanceOf(FrozenSet);
+    expect(result).not.toBe(set);
+  });
 });

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -29,15 +29,15 @@ describe("Middleware", () => {
       "should expose the declared statusCodes %#",
       (statusCode) => {
         const mw = new Middleware({ statusCode, handler: vi.fn() });
-        expect(mw.statusCodes).toEqual(
-          new Set(typeof statusCode === "number" ? [statusCode] : statusCode),
-        );
-        mw.statusCodes.delete(
-          typeof statusCode === "number" ? statusCode : statusCode[0],
-        );
-        expect(mw.statusCodes).toEqual(
-          new Set(typeof statusCode === "number" ? [statusCode] : statusCode),
-        );
+        const expected =
+          typeof statusCode === "number" ? [statusCode] : statusCode;
+        expect(Array.from(mw.statusCodes)).toEqual(expected);
+        expect(() =>
+          (mw.statusCodes as Set<number>).delete(
+            typeof statusCode === "number" ? statusCode : statusCode[0],
+          ),
+        ).toThrow(/read only/);
+        expect(Array.from(mw.statusCodes)).toEqual(expected);
       },
     );
 
@@ -46,7 +46,7 @@ describe("Middleware", () => {
       const mw = new Middleware({ statusCode, handler: vi.fn() });
       expect(Object.isFrozen(statusCode)).toBe(false);
       statusCode.push(500);
-      expect(mw.statusCodes).toEqual(new Set([429, 503]));
+      expect([...mw.statusCodes]).toEqual([429, 503]);
     });
 
     test("should allow to omit statusCode", () => {
@@ -120,6 +120,6 @@ describe("ExpressMiddleware", () => {
 
   test("should expose the declared statusCodes", () => {
     const mw = new ExpressMiddleware(vi.fn(), { statusCode: 429 });
-    expect(mw.statusCodes).toEqual(new Set([429]));
+    expect([...mw.statusCodes]).toEqual([429]);
   });
 });

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -33,7 +33,7 @@ describe("Middleware", () => {
           typeof statusCode === "number" ? [statusCode] : statusCode;
         expect(Array.from(mw.statusCodes)).toEqual(expected);
         expect(() =>
-          (mw.statusCodes as Set<number>).delete(
+          mw.statusCodes.delete(
             typeof statusCode === "number" ? statusCode : statusCode[0],
           ),
         ).toThrow(/read only/);

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -15,7 +15,9 @@ describe("Rate limit middleware", () => {
 
     test("should declare the status code it may throw when set explicitly", () => {
       expect(createRateLimitMiddleware().statusCodes.size).toBe(0);
-      expect(Array.from(createRateLimitMiddleware({ statusCode: 429 }).statusCodes)).toEqual([429]);
+      expect(
+        Array.from(createRateLimitMiddleware({ statusCode: 429 }).statusCodes),
+      ).toEqual([429]);
     });
 
     test("should forward config to rateLimit function", () => {

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -15,9 +15,7 @@ describe("Rate limit middleware", () => {
 
     test("should declare the status code it may throw when set explicitly", () => {
       expect(createRateLimitMiddleware().statusCodes.size).toBe(0);
-      expect(
-        createRateLimitMiddleware({ statusCode: 429 }).statusCodes,
-      ).toEqual(new Set([429]));
+      expect(Array.from(createRateLimitMiddleware({ statusCode: 429 }).statusCodes)).toEqual([429]);
     });
 
     test("should forward config to rateLimit function", () => {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -74,6 +74,24 @@ const performanceConcerns = [
   },
 ];
 
+const setTypeConcerns = [
+  {
+    selector:
+      "CallExpression[callee.object.name='Object'][callee.property.name='freeze'] " +
+      "> NewExpression[callee.name='Set']",
+    message: "Object.freeze() does not protect Set instances, use FrozenSet",
+  },
+  {
+    selector: "MethodDefinition[kind='get'] NewExpression[callee.name='Set']",
+    message: "getters must expose FrozenSet instead of the mutable Set",
+  },
+  {
+    selector:
+      "MethodDefinition[kind='get'] TSTypeReference[typeName.name='Set']",
+    message: "type the getters returning sets as ReadonlySet",
+  },
+];
+
 const tsFactoryConcerns = [
   {
     selector: "Identifier[name='createPropertySignature']",
@@ -233,6 +251,7 @@ export default defineConfig({
           "warn",
           ...importConcerns,
           ...performanceConcerns,
+          ...setTypeConcerns,
         ],
       },
     },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -82,12 +82,15 @@ const setTypeConcerns = [
     message: "Object.freeze() does not protect Set instances, use FrozenSet",
   },
   {
-    selector: "MethodDefinition[kind='get'] NewExpression[callee.name='Set']",
+    selector:
+      "MethodDefinition:matches([kind='get'], [key.name=/^get/]) " +
+      "NewExpression[callee.name='Set']",
     message: "getters must expose FrozenSet instead of the mutable Set",
   },
   {
     selector:
-      "MethodDefinition[kind='get'] TSTypeReference[typeName.name='Set']",
+      "MethodDefinition:matches([kind='get'], [key.name=/^get/]) " +
+      "TSTypeReference[typeName.name='Set']",
     message: "type the getters returning sets as ReadonlySet",
   },
 ];


### PR DESCRIPTION
`Object.freeze()` over `Set` is noop.
This is a better solution 
Related to https://github.com/RobinTail/express-zod-api/pull/3626#discussion_r3781552699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only collections for endpoint methods and middleware status codes.
  * Added set operations that create new read-only collections without changing the originals.

* **Bug Fixes**
  * Prevented accidental runtime changes to exposed method and status-code collections.

* **Tests**
  * Expanded coverage for collection immutability, set operations, endpoint method handling, and middleware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->