### PR TITLE
fix: Ensure scopes and tags are deduplicated and immutable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v29.3.2
 
 - The tags and scopes given to `EndpointsFactory::build()` are now deduplicated and immutable:
-  - The generated `Documentation` and `Integration` no longer contain duplicate entries in such cases.
+  - The generated `Documentation` and `Integration` would no longer contain duplicate entries of that kind.
 
 ### v29.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 29
 
+### v29.3.2
+
+- The tags and scopes given to `EndpointsFactory::build()` are now deduplicated and immutable:
+  - The generated `Documentation` and `Integration` no longer contain duplicate entries in such cases.
+
 ### v29.3.1
 
 - Fixed the `Endpoint` methods duplication issue:

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -11,6 +11,7 @@ import {
   type SchemaObjectValue,
   type SecurityRequirementObject,
   type SecuritySchemeObject,
+  type SecuritySchemeType,
   type TagObject,
   isReferenceObject,
   isSchemaObject,
@@ -594,20 +595,25 @@ export const depictSecurity = (
   );
 };
 
+const scopedSecurities = new Set<SecuritySchemeType>([
+  "oauth2",
+  "openIdConnect",
+]);
 export const depictSecurityRefs = (
   alternatives: Alternatives<SecuritySchemeObject>,
-  scopes: string[] | ReadonlyArray<string>,
+  scopes: ReadonlySet<string>,
   entitle: (subject: SecuritySchemeObject) => string,
-): SecurityRequirementObject[] =>
-  alternatives.map((alternative) =>
+): SecurityRequirementObject[] => {
+  const list = Array.from(scopes);
+  return alternatives.map((alternative) =>
     alternative.reduce<SecurityRequirementObject>((refs, securitySchema) => {
       const name = entitle(securitySchema);
-      const hasScopes = ["oauth2", "openIdConnect"].includes(
-        securitySchema.type,
-      );
-      return Object.assign(refs, { [name]: hasScopes ? scopes : [] });
+      return Object.assign(refs, {
+        [name]: scopedSecurities.has(securitySchema.type) ? list : [],
+      });
     }, {}),
   );
+};
 
 export const depictRequest = ({
   schema,
@@ -700,5 +706,7 @@ export const trimSummary = (summary?: string, limit = 50) =>
     ? summary
     : summary.slice(0, Math.max(1, limit || 0) - 1) + "…";
 
-export const nonEmpty = <T>(subject: T[] | ReadonlyArray<T>) =>
-  subject.length ? subject.slice() : undefined;
+export const nonEmpty = <T>(subject: Iterable<T>) => {
+  const copy = Array.from(subject);
+  return copy.length ? copy : undefined;
+};

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -595,10 +595,9 @@ export const depictSecurity = (
   );
 };
 
-const scopedSecurities = new Set<SecuritySchemeType>([
-  "oauth2",
-  "openIdConnect",
-]);
+const hasScopes = Set.prototype.has.bind(
+  new Set<SecuritySchemeType>(["oauth2", "openIdConnect"]),
+);
 export const depictSecurityRefs = (
   alternatives: Alternatives<SecuritySchemeObject>,
   scopes: ReadonlySet<string>,
@@ -609,7 +608,7 @@ export const depictSecurityRefs = (
     alternative.reduce<SecurityRequirementObject>((refs, securitySchema) => {
       const name = entitle(securitySchema);
       return Object.assign(refs, {
-        [name]: scopedSecurities.has(securitySchema.type) ? list : [],
+        [name]: hasScopes(securitySchema.type) ? list : [],
       });
     }, {}),
   );

--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -604,14 +604,14 @@ export const depictSecurityRefs = (
   entitle: (subject: SecuritySchemeObject) => string,
 ): SecurityRequirementObject[] => {
   const list = Array.from(scopes);
-  return alternatives.map((alternative) =>
-    alternative.reduce<SecurityRequirementObject>((refs, securitySchema) => {
+  return alternatives.map((alternative) => {
+    const refs: SecurityRequirementObject = {};
+    for (const securitySchema of alternative) {
       const name = entitle(securitySchema);
-      return Object.assign(refs, {
-        [name]: hasScopes(securitySchema.type) ? list : [],
-      });
-    }, {}),
-  );
+      refs[name] = hasScopes(securitySchema.type) ? list : [];
+    }
+    return refs;
+  });
 };
 
 export const depictRequest = ({

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -73,9 +73,9 @@ export abstract class AbstractEndpoint {
   /** @internal */
   public abstract get security(): LogicalContainer<Security>[];
   /** @internal */
-  public abstract get scopes(): ReadonlyArray<string>;
+  public abstract get scopes(): ReadonlySet<string>;
   /** @internal */
-  public abstract get tags(): ReadonlyArray<string>;
+  public abstract get tags(): ReadonlySet<string>;
   /** @internal */
   public abstract getProbableRequestType(method?: ClientMethod): ContentType;
   /** @internal */
@@ -113,8 +113,8 @@ export class Endpoint<
     summary?: string;
     getOperationId?: (method: ClientMethod) => string | undefined;
     methods: FrozenSet<Method>;
-    scopes?: string[];
-    tags?: string[];
+    scopes: FrozenSet<string>;
+    tags: FrozenSet<string>;
     statusCodes: ReadonlySet<number>;
   }) {
     super();
@@ -198,12 +198,12 @@ export class Endpoint<
 
   /** @internal */
   public override get scopes() {
-    return Object.freeze(this.#def.scopes || []);
+    return this.#def.scopes;
   }
 
   /** @internal */
   public override get tags() {
-    return Object.freeze(this.#def.tags || []);
+    return this.#def.tags;
   }
 
   /** @internal */

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -208,8 +208,8 @@ export class EndpointsFactory<
         ? operationId
         : (mtd: ClientMethod) =>
             operationId && `${operationId}${mtd === "head" ? "__HEAD" : ""}`; // ensure non-breaking change
-    const scopes = typeof scope === "string" ? [scope] : scope || [];
-    const tags = typeof tag === "string" ? [tag] : tag || [];
+    const scopes = new FrozenSet(typeof scope === "string" ? [scope] : scope);
+    const tags = new FrozenSet(typeof tag === "string" ? [tag] : tag);
     return new Endpoint({
       ...rest,
       middlewares,

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -69,7 +69,7 @@ export abstract class IntegrationBase {
   /** @internal */
   protected paths = new Set<string>();
   /** @internal */
-  protected tags = new Map<string, ReadonlyArray<string>>();
+  protected tags = new Map<string, ReadonlySet<string>>();
   /** @internal */
   protected registry = new Map<
     string,

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -740,7 +740,7 @@ describe("Documentation helpers", () => {
       expect(
         depictSecurityRefs(
           [[{ type: "apiKey" }, { type: "oauth2" }, { type: "openIdConnect" }]],
-          [],
+          new Set(),
           R.prop("type"),
         ),
       ).toMatchSnapshot();
@@ -750,7 +750,7 @@ describe("Documentation helpers", () => {
             [{ type: "apiKey" }, { type: "oauth2" }],
             [{ type: "apiKey" }, { type: "openIdConnect" }],
           ],
-          [],
+          new Set(),
           R.prop("type"),
         ),
       ).toMatchSnapshot();
@@ -761,7 +761,7 @@ describe("Documentation helpers", () => {
             [{ type: "oauth2" }],
             [{ type: "openIdConnect" }],
           ],
-          [],
+          new Set(),
           R.prop("type"),
         ),
       ).toMatchSnapshot();
@@ -775,7 +775,7 @@ describe("Documentation helpers", () => {
             [{ type: "oauth2" }],
             [{ type: "openIdConnect" }],
           ],
-          ["read", "write"],
+          new Set(["read", "write"]),
           R.prop("type"),
         ),
       ).toMatchSnapshot();

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -26,6 +26,8 @@ describe("Endpoint", () => {
       ];
       const endpointMock = new Endpoint({
         methods: new FrozenSet(methods),
+        scopes: new FrozenSet(),
+        tags: new FrozenSet(),
         inputSchema: z.object({}),
         outputSchema: z.object({}),
         statusCodes: new Set(),
@@ -405,8 +407,10 @@ describe("Endpoint", () => {
           scope,
         });
         const { scopes } = endpoint;
-        expect(scopes).toEqual(typeof scope === "string" ? [scope] : scope);
-        expect(() => (scopes as any[]).push()).toThrowError(/read only/);
+        expect(Array.from(scopes)).toEqual(
+          typeof scope === "string" ? [scope] : scope,
+        );
+        expect(() => scopes.add("something")).toThrow(/read only/);
       },
     );
   });
@@ -422,8 +426,8 @@ describe("Endpoint", () => {
           tag,
         });
         const { tags } = endpoint;
-        expect(tags).toEqual(typeof tag === "string" ? [tag] : tag);
-        expect(() => (tags as any[]).push()).toThrowError(/read only/);
+        expect(Array.from(tags)).toEqual(typeof tag === "string" ? [tag] : tag);
+        expect(() => tags.add("something")).toThrow(/read only/);
       },
     );
   });
@@ -484,6 +488,8 @@ describe("Endpoint", () => {
       expect(
         new Endpoint({
           methods: new FrozenSet(),
+          scopes: new FrozenSet(),
+          tags: new FrozenSet(),
           inputSchema: z.object({}),
           outputSchema: z.object({}),
           statusCodes: new Set(),

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -427,6 +427,44 @@ describe("EndpointsFactory", () => {
       expect(Array.from(endpoint.methods)).toEqual(["get", "post"]);
     });
 
+    test("should deduplicate the tags declared in the tuple", () => {
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        tag: ["users", "users", "files"],
+        handler: vi.fn(),
+      });
+      expect(Array.from(endpoint.tags)).toEqual(["users", "files"]);
+    });
+
+    test("should not mutate the supplied array of tags when building", () => {
+      const tags = ["users", "files"];
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        tag: tags,
+        handler: vi.fn(),
+      });
+      expect(Object.isFrozen(tags)).toBe(false);
+      tags.push("extra");
+      expect(Array.from(endpoint.tags)).toEqual(["users", "files"]);
+    });
+
+    test("should deduplicate the scopes declared in the tuple", () => {
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        scope: ["admin", "admin", "read"],
+        handler: vi.fn(),
+      });
+      expect(Array.from(endpoint.scopes)).toEqual(["admin", "read"]);
+    });
+
+    test("should not mutate the supplied array of scopes when building", () => {
+      const scopes = ["admin", "read"];
+      const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
+        scope: scopes,
+        handler: vi.fn(),
+      });
+      expect(Object.isFrozen(scopes)).toBe(false);
+      scopes.push("write");
+      expect(Array.from(endpoint.scopes)).toEqual(["admin", "read"]);
+    });
+
     test("should pass the single statusCode to the endpoint", () => {
       const endpoint = new EndpointsFactory(resultHandlerMock).buildVoid({
         handler: vi.fn(),


### PR DESCRIPTION
addition to #3627 and #3626 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint tags and scopes are now deduplicated while preserving their original order.
  * Endpoint metadata is protected from changes to the original input collections.
  * Generated documentation and integrations no longer contain duplicate tags or scopes.
  * Security scopes are applied only to supported OAuth2 and OpenID Connect schemes.
* **Improvements**
  * Endpoint metadata collections are now read-only, preventing accidental modification after creation.
* **Changelog**
  * Documented these improvements in version 29.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->