### PR TITLE
fix: Warn about using BuiltinLogger on prod.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v29.3.3
 
-- Added a warning about using the built-in logger in productionЖ
+- Added a warning about using the built-in logger in production:
   - The `BuiltinLogger` is intended for development purposes only because it prints messages synchronously;
   - That may degrade the performance of your API in production mode (`NODE_ENV=production`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 29
 
+### v29.3.3
+
+- Added a warning about using the built-in logger in productionЖ
+  - The `BuiltinLogger` is intended for development purposes only because it prints messages synchronously;
+  - That may degrade the performance of your API in production mode (`NODE_ENV=production`).
+
 ### v29.3.2
 
 - The tags and scopes given to `EndpointsFactory::build()` are now deduplicated and immutable:

--- a/README.md
+++ b/README.md
@@ -729,12 +729,7 @@ To receive a compressed response, the client should include the following header
 
 ## Customizing logger
 
-A simple built-in console logger is used by default with the following options that you can configure:
-
-The built-in logger is intended for development purposes only: it prints messages synchronously, which may degrade the
-performance of your API in production mode. When running in production, the framework warns you about this and
-recommends installing a professional logging solution instead, such as [Pino](https://github.com/pinojs/pino) or
-[Winston](https://github.com/winstonjs/winston). Installing one will also suppress the warning.
+The built-in logger is used by default (for development only) with the following options that you can configure:
 
 ```ts
 import { createConfig } from "express-zod-api";
@@ -747,8 +742,10 @@ const config = createConfig({
 });
 ```
 
-You can also replace it with a one having at least the following methods: `info()`, `debug()`, `error()` and `warn()`.
-Winston and Pino support is well-known. Here is an example configuring `pino` logger with `pino-pretty` extension:
+However, it prints messages to the console synchronously, which may degrade the performance of your API in
+[production mode](#production-mode). Consider installing a professional logging solution instead, such as
+[Pino](https://github.com/pinojs/pino) or [Winston](https://github.com/winstonjs/winston). You can use any logger
+having at least the following methods: `info()`, `debug()`, `error()` and `warn()`. Here is how to use `pino`:
 
 ```ts
 import pino, { Logger } from "pino";

--- a/README.md
+++ b/README.md
@@ -731,6 +731,11 @@ To receive a compressed response, the client should include the following header
 
 A simple built-in console logger is used by default with the following options that you can configure:
 
+The built-in logger is intended for development purposes only: it prints messages synchronously, which may degrade the
+performance of your API in production mode. When running in production, the framework warns you about this and
+recommends installing a professional logging solution instead, such as [Pino](https://github.com/pinojs/pino) or
+[Winston](https://github.com/winstonjs/winston). Installing one will also suppress the warning.
+
 ```ts
 import { createConfig } from "express-zod-api";
 const config = createConfig({
@@ -1459,9 +1464,9 @@ const rawAcceptingEndpoint = defaultEndpointsFactory.build({
 
 ## Profiling
 
-For debugging and performance testing purposes the framework offers a simple `.profile()` method on the built-in logger.
-It starts a timer when you call it and measures the duration in adaptive units (from picoseconds to minutes) until you
-invoke the returned callback. The default severity of those measurements is `debug`.
+During development, for debugging and performance testing purposes, the framework offers a simple `.profile()` method
+on the built-in logger. It starts a timer when you call it and measures the duration in adaptive units (from
+picoseconds to minutes) until you invoke the returned callback. The default severity of those measurements is `debug`.
 
 ```ts
 import { createConfig, BuiltinLogger } from "express-zod-api";

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ To receive a compressed response, the client should include the following header
 
 ## Customizing logger
 
-The built-in logger is used by default (for development only) with the following options that you can configure:
+The built-in logger is used by default with the following options that you can configure:
 
 ```ts
 import { createConfig } from "express-zod-api";
@@ -742,10 +742,10 @@ const config = createConfig({
 });
 ```
 
-However, it prints messages to the console synchronously, which may degrade the performance of your API in
-[production mode](#production-mode). Consider installing a professional logging solution instead, such as
-[Pino](https://github.com/pinojs/pino) or [Winston](https://github.com/winstonjs/winston). You can use any logger
-having at least the following methods: `info()`, `debug()`, `error()` and `warn()`. Here is how to use `pino`:
+However, it's for development purposes only: it prints messages to the console synchronously, which may degrade the
+performance of your API in [production mode](#production-mode). Consider installing a professional logging solution
+instead, such as [Pino](https://github.com/pinojs/pino) or [Winston](https://github.com/winstonjs/winston). You can use
+any logger having at least these methods: `info()`, `debug()`, `error()` and `warn()`. Here is how to use `pino`:
 
 ```ts
 import pino, { Logger } from "pino";

--- a/express-zod-api/src/builtin-logger.ts
+++ b/express-zod-api/src/builtin-logger.ts
@@ -43,7 +43,7 @@ interface ProfilerOptions {
   formatter?: (ms: number) => string | number;
 }
 
-/** @desc Built-in console logger with optional colorful inspections */
+/** @desc Built-in console logger for development with optional colorful inspections */
 export class BuiltinLogger implements AbstractLogger {
   protected readonly config: BuiltinLoggerConfig;
 

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -61,7 +61,7 @@ export interface CommonConfig {
    */
   errorHandler?: AbstractResultHandler;
   /**
-   * @desc Built-in logger configuration or an instance of any compatible logger.
+   * @desc Built-in logger configuration (for development only) or any compatible logger instance.
    * @example { level: "debug", color: true }
    * @default { level: NODE_ENV === "production" ? "warn" : "debug", color: isSupported(), depth: 2 }
    * */

--- a/express-zod-api/src/server.ts
+++ b/express-zod-api/src/server.ts
@@ -38,6 +38,12 @@ const makeCommonEntities = (config: CommonConfig) => {
     build: import.meta.TSDOWN_BUILD || "from sources",
     env: runtime.env,
   });
+  if (runtime.isProduction && logger instanceof BuiltinLogger) {
+    logger.warn(
+      "Using the built-in logger in production may degrade performance due to synchronous printing. " +
+        "Consider installing a professional logging solution, such as Pino or Winston.",
+    );
+  }
   installDeprecationListener(logger);
   const loggingMiddleware = createLoggingMiddleware({ logger, config });
   const getLogger = makeGetLogger(logger);

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -492,6 +492,8 @@ describe("Server", () => {
     });
 
     test("Should NOT warn in non-production mode", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      runtime._cache = undefined;
       const warnSpy = vi.spyOn(BuiltinLogger.prototype, "warn");
       createServer(
         { http: { listen: givePort() }, startupLogo: false, cors: false },

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -23,6 +23,7 @@ import {
   ez,
 } from "../src";
 import type { AppConfig, ServerConfig } from "../src/config-type";
+import { runtime } from "../src/common-helpers";
 import express from "express";
 
 describe("Server", () => {
@@ -435,6 +436,68 @@ describe("Server", () => {
       expect(appMock.post.mock.calls[0]![0]).toBe("/v1/test");
       expect(appMock.options).toHaveBeenCalledTimes(1);
       expect(appMock.options.mock.calls[0]![0]).toBe("/v1/test");
+    });
+  });
+
+  describe("Production mode", () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      runtime._cache = undefined;
+    });
+
+    test.each([
+      undefined,
+      { level: "info" as const },
+      new BuiltinLogger({ level: "silent" }),
+    ])(
+      "Should warn when using the built-in logger in production %#",
+      (logger) => {
+        vi.stubEnv("NODE_ENV", "production");
+        runtime._cache = undefined;
+        const warnSpy = vi.spyOn(BuiltinLogger.prototype, "warn");
+        createServer(
+          {
+            http: { listen: givePort() },
+            startupLogo: false,
+            logger,
+            cors: false,
+          },
+          {},
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Using the built-in logger in production"),
+        );
+      },
+    );
+
+    test("Should NOT warn when a custom logger is used in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      runtime._cache = undefined;
+      const customLogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      createServer(
+        {
+          http: { listen: givePort() },
+          startupLogo: false,
+          logger: customLogger,
+          cors: false,
+        },
+        {},
+      );
+      expect(customLogger.warn).not.toHaveBeenCalled();
+    });
+
+    test("Should NOT warn in non-production mode", () => {
+      const warnSpy = vi.spyOn(BuiltinLogger.prototype, "warn");
+      createServer(
+        { http: { listen: givePort() }, startupLogo: false, cors: false },
+        {},
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -186,6 +186,9 @@ describe("App in production mode", () => {
       "DeprecationError (express): Sample deprecation message",
       expect.any(Array), // stack
     );
+    expect(warnMethod).toHaveBeenCalledWith(
+      expect.stringContaining("Using the built-in logger in production"),
+    );
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Instead of #2495 and #2497 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the built-in logger is intended for development only.
  - Documented potential production performance impact from synchronous logging.
  - Added guidance on alternative production logging solutions and clarified profiling usage.

- **Bug Fixes**
  - Added a production startup warning when the built-in logger is configured, recommending a production-ready alternative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->