### PR TITLE
fix: `makeLoggerMock()` compatibility with `isLoggerInstance()`

### DIFF
--- a/express-zod-api/src/testing.ts
+++ b/express-zod-api/src/testing.ts
@@ -44,6 +44,10 @@ export const makeLoggerMock = <LOG extends FlatObject>(loggerProps?: LOG) => {
           return (...args: unknown[]) => logs[prop].push(args);
         return Reflect.get(target, prop, recv);
       },
+      has(target, prop) {
+        if (isSeverity(prop) || prop === "_getLogs") return true;
+        return Reflect.has(target, prop);
+      },
     },
   );
 };

--- a/express-zod-api/tests/logger-helpers.spec.ts
+++ b/express-zod-api/tests/logger-helpers.spec.ts
@@ -8,7 +8,7 @@ import {
   formatDuration,
   type AbstractLogger,
 } from "../src/logger-helpers";
-import { makeLoggerMock } from "../src/testing.ts";
+import { makeLoggerMock } from "../src/testing";
 
 describe("Logger helpers", () => {
   describe("isSeverity()", () => {

--- a/express-zod-api/tests/logger-helpers.spec.ts
+++ b/express-zod-api/tests/logger-helpers.spec.ts
@@ -8,6 +8,7 @@ import {
   formatDuration,
   type AbstractLogger,
 } from "../src/logger-helpers";
+import { makeLoggerMock } from "../src/testing.ts";
 
 describe("Logger helpers", () => {
   describe("isSeverity()", () => {
@@ -74,6 +75,7 @@ describe("Logger helpers", () => {
       })(),
       Object.setPrototypeOf({ level: "debug" }, { debug: () => {} }),
       new BuiltinLogger({ level: "debug" }),
+      makeLoggerMock(),
     ])("should validate logger instances %#", (sample) => {
       expect(isLoggerInstance(sample)).toBeTruthy();
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger test utilities so mocked loggers correctly recognize supported severity methods and log retrieval.
  * Expanded logger validation coverage to include mocked logger instances.
  * This improves reliability for applications and integrations that use logger testing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->