### PR TITLE
ref: using `Set` for asserting target type in `depictPipeline()`

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -192,6 +192,11 @@ const makeNullableType = (
   );
 };
 
+const typeofCompatible = new Set<ReturnType<typeof getTransformedType>>([
+  "number",
+  "string",
+  "boolean",
+] satisfies SchemaObjectType[]);
 export const depictPipeline: Depicter = ({ zodSchema, jsonSchema }, ctx) => {
   const target = (zodSchema as z.core.$ZodPipe)._zod.def[
     ctx.isResponse ? "out" : "in"
@@ -213,12 +218,8 @@ export const depictPipeline: Depicter = ({ zodSchema, jsonSchema }, ctx) => {
         target,
         makeSample(opposingDepiction),
       );
-      if (targetType && ["number", "string", "boolean"].includes(targetType)) {
-        return {
-          ...jsonSchema,
-          type: targetType as "number" | "string" | "boolean",
-        };
-      }
+      if (targetType && typeofCompatible.has(targetType))
+        return { ...jsonSchema, type: targetType as SchemaObjectType };
     }
   }
   return jsonSchema;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved handling of transformed output types in generated API documentation.
  * Continued support for transformed `number`, `string`, and `boolean` schemas with no behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->