### PR TITLE
br(export): rm `DocumentationError` from main entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Supported TypeScript versions (optional peer): `^6.0.3`:
   - Entirely `#private` props are now restored in the classes of the distributed `.d.ts` files.
+- `DocumentationError` removed from main entrypoint: import from `express-zod-api/documentation` instead.
 
 ## Version 29
 

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -20,7 +20,6 @@ export { createApiResponse } from "./api-response";
 export { ServeStatic } from "./serve-static";
 export { createServer, attachRouting } from "./server";
 export {
-  DocumentationError, // @todo remove in v30
   RoutingError,
   OutputValidationError,
   InputValidationError,

--- a/express-zod-api/tests/__snapshots__/index.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/index.spec.ts.snap
@@ -96,7 +96,6 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "ServeStatic",
   "createServer",
   "attachRouting",
-  "DocumentationError",
   "RoutingError",
   "OutputValidationError",
   "InputValidationError",

--- a/express-zod-api/tests/__snapshots__/index.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/index.spec.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`Index Entrypoint > exports > BuiltinLogger should have certain value 1`] = `[Function]`;
 
-exports[`Index Entrypoint > exports > DocumentationError should have certain value 1`] = `[Function]`;
-
 exports[`Index Entrypoint > exports > EndpointsFactory should have certain value 1`] = `[Function]`;
 
 exports[`Index Entrypoint > exports > EventStreamFactory should have certain value 1`] = `[Function]`;

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1,7 +1,6 @@
 import camelize from "camelize-ts";
 import snakify from "snakify-ts";
 import {
-  DocumentationError,
   EndpointsFactory,
   createConfig,
   Middleware,
@@ -11,7 +10,11 @@ import {
   type Method,
   type Routing,
 } from "../src";
-import { Documentation, type Depicter } from "../src/documentation";
+import {
+  Documentation,
+  DocumentationError,
+  type Depicter,
+} from "../src/documentation";
 import { contentTypes } from "../src/content-type";
 import type { IOSchema } from "../src/io-schema";
 import { z } from "zod";

--- a/express-zod-api/tests/errors.spec.ts
+++ b/express-zod-api/tests/errors.spec.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { DocumentationError, RoutingError } from "../src";
 import {
   IOSchemaError,
   InputValidationError,
@@ -7,6 +6,8 @@ import {
   OutputValidationError,
   ResultHandlerError,
   DeepCheckError,
+  DocumentationError,
+  RoutingError,
 } from "../src/errors";
 
 describe("Errors", () => {


### PR DESCRIPTION
available at `express-zod-api/documentation`