### PR TITLE
br(mw): rate limiter overrides or narrows the status code to `429`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Supported TypeScript versions (optional peer): `^6.0.3`:
   - Entirely `#private` props are now restored in the classes of the distributed `.d.ts` files.
 - `DocumentationError` removed from main entrypoint: import from `express-zod-api/documentation` instead.
+- The rate-limiting Middleware now explicitly declares the `statusCode` that it may interrupt the request handling:
+  - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;
+  - This will override or narrow the negative status codes declared in ResultHandler when generating Documentation;
+  - The Endpoints using this Middleware should declare its other negative status codes explicitly to preserve them.
 
 ## Version 29
 

--- a/README.md
+++ b/README.md
@@ -911,11 +911,7 @@ Install `express-rate-limit`. Consider the `createRateLimitMiddleware()` to enab
 
 ```ts
 const endpoint = factory
-  .useRateLimit({
-    windowMs: 60000,
-    max: 100,
-    statusCode: 429, // when set explicitly, it will be reflected in the Documentation
-  }) // shorthand, or .addMiddleware(createRateLimitMiddleware())
+  .useRateLimit({ windowMs: 60000, max: 100 }) // shorthand, or .addMiddleware(createRateLimitMiddleware())
   .buildVoid({
     handler: async ({ ctx: { rateLimit, logger } }) => {
       logger.debug("Features", rateLimit); // { limit, used, remaining, resetTime, getKey, resetKey }

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -18,11 +18,7 @@ import { stat } from "node:fs/promises";
 
 /** @desc This factory extends the default one by enforcing rate limiting and authentication */
 export const keyAndTokenAuthenticatedEndpointsFactory = defaultEndpointsFactory
-  .useRateLimit({
-    windowMs: 60000,
-    max: 10,
-    statusCode: 429, // forces this response code in Documentation, @todo remove in v30
-  })
+  .useRateLimit({ windowMs: 60000, max: 10 })
   .addMiddleware(authMiddleware);
 
 /** @desc This factory adds session read from cookie into context */

--- a/express-zod-api/src/rate-limit-middleware.ts
+++ b/express-zod-api/src/rate-limit-middleware.ts
@@ -17,17 +17,9 @@ const defaultStatusCode = 429;
  * @requires express-rate-limit
  * @param options — Partial options passed to the express-rate-limit constructor.
  * @example createRateLimitMiddleware({ windowMs: 60000, max: 100 })
+ * @modifies ResultHandler.negative.statusCode — overrides or narrows down to 429
  */
-export const createRateLimitMiddleware = (
-  options?: Partial<Options> & {
-    /**
-     * @desc The HTTP status code to send back when a client is rate-limited.
-     * @default 429
-     * @modifies ResultHandler.negative.statusCode — overrides when specified explicitly (opt-in, no breaking changes).
-     */
-    statusCode?: number;
-  },
-) => {
+export const createRateLimitMiddleware = (options?: Partial<Options>) => {
   const rateLimit = loadPeer<typeof RateLimitFn>("express-rate-limit");
   const limiter = rateLimit({
     statusCode: defaultStatusCode,
@@ -42,8 +34,7 @@ export const createRateLimitMiddleware = (
     resetKey,
   };
   return new ExpressMiddleware(limiter, {
-    /** @todo add ?? defaultStatusCode in next major */
-    statusCode: options?.statusCode, // only when specified explicitly to avoid breaking changes
+    statusCode: options?.statusCode ?? defaultStatusCode,
     provider: (req: AugmentedRequest) => ({
       rateLimit: {
         ...limiterApi,

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -13,11 +13,10 @@ describe("Rate limit middleware", () => {
       expect(constructor.name).toBe("ExpressMiddleware");
     });
 
-    test("should declare the status code it may throw when set explicitly", () => {
-      expect(createRateLimitMiddleware().statusCodes.size).toBe(0);
-      expect(
-        Array.from(createRateLimitMiddleware({ statusCode: 429 }).statusCodes),
-      ).toEqual([429]);
+    test("should declare the status code it may throw", () => {
+      expect(Array.from(createRateLimitMiddleware().statusCodes)).toEqual([
+        429,
+      ]);
     });
 
     test("should forward config to rateLimit function", () => {

--- a/express-zod-api/tests/rate-limit-middleware.spec.ts
+++ b/express-zod-api/tests/rate-limit-middleware.spec.ts
@@ -13,11 +13,14 @@ describe("Rate limit middleware", () => {
       expect(constructor.name).toBe("ExpressMiddleware");
     });
 
-    test("should declare the status code it may throw", () => {
-      expect(Array.from(createRateLimitMiddleware().statusCodes)).toEqual([
-        429,
-      ]);
-    });
+    test.each([undefined, 444])(
+      "should declare the status code it may throw %#",
+      (statusCode) => {
+        expect(
+          Array.from(createRateLimitMiddleware({ statusCode }).statusCodes),
+        ).toEqual([statusCode ?? 429]);
+      },
+    );
 
     test("should forward config to rateLimit function", () => {
       createRateLimitMiddleware({ windowMs: 60000, max: 10 });


### PR DESCRIPTION
Implements the postponed changes related to #3621 