### PR TITLE
feat(rh): `legacyResultHandler` and `legacyEndpointsFactory` with migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
   - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;
   - This will override or narrow the negative status codes declared in ResultHandler when generating Documentation;
   - The Endpoints using this Middleware should declare its other negative status codes explicitly to preserve them.
-- The `defaultResultHandler` changed both positive and negative schemas:
+- The `defaultResultHandler` (and `defaultEndpointsFactory`) changed both positive and negative reponse schemas:
   - The positive response is now the Endpoint output as is: the `{ status: "success", data: {...} }` wrapper removed;
-  - The negative response is now the `{ message }`: the `{ status: "error", error: {...} }` wrapper removed.
+  - The negative response is now the `{ message }`: the `{ status: "error", error: {...} }` wrapper removed;
+  - Existing APIs can migrate to `legacyResultHandler` and `legacyEndpointsFactory` for preserving those wrappers.
 - The `Integration` generator changed to discriminate responses by HTTP status code or legacy `success|error` fallback:
   - New `EncodedResponse` interface holding payloads along with `status: number, discriminator: "success" | "error"`;
   - New public static method `Client::discriminate(status: number): "success" | "error"`;
@@ -33,6 +34,16 @@ if (status === 200)
   console.log(data.name); // success
 else if (status === 400 || discriminator === "error")
   console.error(data.message); // error
+```
+
+```diff
+@@ Keeping the response wrappers: @@
+- import { defaultEndpointsFactory } from "express-zod-api";
++ import { legacyEndpointsFactory } from "express-zod-api";
+  const factory = new EndpointsFactory(
+-   defaultResultHandler
++   legacyResultHandler
+  );
 ```
 
 ## Version 29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;
   - This will override or narrow the negative status codes declared in ResultHandler when generating Documentation;
   - The Endpoints using this Middleware should declare its other negative status codes explicitly to preserve them.
-- The `defaultResultHandler` (and `defaultEndpointsFactory`) changed both positive and negative reponse schemas:
+- The `defaultResultHandler` (and `defaultEndpointsFactory`) changed both positive and negative response schemas:
   - The positive response is now the Endpoint output as is: the `{ status: "success", data: {...} }` wrapper removed;
   - The negative response is now the `{ message }`: the `{ status: "error", error: {...} }` wrapper removed;
   - Existing APIs can migrate to `legacyResultHandler` and `legacyEndpointsFactory` for preserving those wrappers.

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -257,11 +257,10 @@ export const defaultEndpointsFactory = new EndpointsFactory(
 );
 
 /**
- * @deprecated This factory is designed only to simplify the migration of APIs from v29.
- * @since v30.0.0
+ * @deprecated Use defaultEndpointsFactory for new APIs.
+ * @desc For migration purposes only: preserves the response wrappers.
+ * @see legacyResultHandler
  * @todo remove in v31
- * @desc Preserves the v29 response shapes using legacyResultHandler.
- * @desc Use defaultEndpointsFactory for new APIs.
  * */
 export const legacyEndpointsFactory = new EndpointsFactory(legacyResultHandler);
 

--- a/express-zod-api/src/endpoints-factory.ts
+++ b/express-zod-api/src/endpoints-factory.ts
@@ -25,6 +25,7 @@ import {
   AbstractResultHandler,
   arrayResultHandler,
   defaultResultHandler,
+  legacyResultHandler,
 } from "./result-handler";
 import { FrozenSet } from "./frozen-set";
 import { createCacheMiddleware } from "./cache-middleware";
@@ -254,6 +255,15 @@ export class EndpointsFactory<
 export const defaultEndpointsFactory = new EndpointsFactory(
   defaultResultHandler,
 );
+
+/**
+ * @deprecated This factory is designed only to simplify the migration of APIs from v29.
+ * @since v30.0.0
+ * @todo remove in v31
+ * @desc Preserves the v29 response shapes using legacyResultHandler.
+ * @desc Use defaultEndpointsFactory for new APIs.
+ * */
+export const legacyEndpointsFactory = new EndpointsFactory(legacyResultHandler);
 
 /**
  * @deprecated Resist the urge of using it: this factory is designed only to simplify the migration of legacy APIs.

--- a/express-zod-api/src/index.ts
+++ b/express-zod-api/src/index.ts
@@ -2,6 +2,7 @@ export { createConfig } from "./config-type";
 export {
   EndpointsFactory,
   defaultEndpointsFactory,
+  legacyEndpointsFactory,
   arrayEndpointsFactory,
 } from "./endpoints-factory";
 export { getMessageFromError } from "./common-helpers";
@@ -14,6 +15,7 @@ export { createRateLimitMiddleware } from "./rate-limit-middleware";
 export {
   ResultHandler,
   defaultResultHandler,
+  legacyResultHandler,
   arrayResultHandler,
 } from "./result-handler";
 export { createApiResponse } from "./api-response";

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -170,7 +170,7 @@ globalRegistry.add(legacyNegativeSchema, {
 
 /**
  * @deprecated Use defaultResultHandler for new APIs.
- * @desc For migration purposes: preserves the response shapes of v0–v29:
+ * @desc For migration purposes: preserves the response shapes of v0–v29.
  * @example `{ status: "success", data: {...} }` and `{ status: "error", error: {...} }`.
  * @todo remove in v31
  * */

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -155,6 +155,51 @@ export const defaultResultHandler = new ResultHandler({
   },
 });
 
+const legacyNegativeSchema = z.object({
+  status: z.literal("error"),
+  error: z.object({ message: z.string() }),
+});
+globalRegistry.add(legacyNegativeSchema, {
+  examples: [
+    {
+      status: "error",
+      error: { message: "Sample error message" },
+    },
+  ] satisfies z.output<typeof legacyNegativeSchema>[],
+});
+
+/**
+ * @deprecated This handler is designed only to simplify the migration of APIs from v29.
+ * @since v30.0.0
+ * @todo remove in v31
+ * @desc Preserves the v29 response shapes: `{ status: "success", data: {...} }` and `{ status: "error", error: {...} }`.
+ * @desc Use defaultResultHandler for new APIs — the old envelope is removed in v30.
+ * */
+export const legacyResultHandler = new ResultHandler({
+  positive: (output) =>
+    z.object({
+      status: z.literal("success"),
+      data: output,
+    }),
+  negative: legacyNegativeSchema,
+  handler: ({ error, input, output, request, response, logger }) => {
+    if (error) {
+      const httpError = ensureHttpError(error);
+      logServerError(httpError, logger, request, input);
+      return void response
+        .status(httpError.statusCode)
+        .set(httpError.headers)
+        .json({
+          status: "error",
+          error: { message: getPublicErrorMessage(httpError) },
+        });
+    }
+    response
+      .status(defaultStatusCodes.positive)
+      .json({ status: "success", data: output });
+  },
+});
+
 const arrayNegativeSchema = z.string();
 globalRegistry.add(arrayNegativeSchema, {
   examples: ["Sample error message"] satisfies z.output<

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -169,11 +169,10 @@ globalRegistry.add(legacyNegativeSchema, {
 });
 
 /**
- * @deprecated This handler is designed only to simplify the migration of APIs from v29.
- * @since v30.0.0
+ * @deprecated Use defaultResultHandler for new APIs.
+ * @desc For migration purposes: preserves the response shapes of v0–v29:
+ * @example `{ status: "success", data: {...} }` and `{ status: "error", error: {...} }`.
  * @todo remove in v31
- * @desc Preserves the v29 response shapes: `{ status: "success", data: {...} }` and `{ status: "error", error: {...} }`.
- * @desc Use defaultResultHandler for new APIs — the old envelope is removed in v30.
  * */
 export const legacyResultHandler = new ResultHandler({
   positive: (output) =>

--- a/express-zod-api/src/result-handler.ts
+++ b/express-zod-api/src/result-handler.ts
@@ -175,11 +175,22 @@ globalRegistry.add(legacyNegativeSchema, {
  * @todo remove in v31
  * */
 export const legacyResultHandler = new ResultHandler({
-  positive: (output) =>
-    z.object({
+  positive: (output) => {
+    const responseSchema = z.object({
       status: z.literal("success"),
       data: output,
-    }),
+    });
+    const examples = getExamples(output); // pulling up:
+    if (examples.length) {
+      globalRegistry.add(responseSchema, {
+        examples: examples.map((data) => ({
+          status: "success" as const,
+          data,
+        })),
+      });
+    }
+    return responseSchema;
+  },
   negative: legacyNegativeSchema,
   handler: ({ error, input, output, request, response, logger }) => {
     if (error) {

--- a/express-zod-api/tests/__snapshots__/index.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/index.spec.ts.snap
@@ -74,11 +74,24 @@ exports[`Index Entrypoint > exports > ez should have certain value 1`] = `
 
 exports[`Index Entrypoint > exports > getMessageFromError should have certain value 1`] = `[Function]`;
 
+exports[`Index Entrypoint > exports > legacyEndpointsFactory should have certain value 1`] = `
+EndpointsFactory {
+  "middlewares": [],
+  "resultHandler": ResultHandler {},
+  "schema": undefined,
+  "statusCodes": Set {},
+  "use": [Function],
+}
+`;
+
+exports[`Index Entrypoint > exports > legacyResultHandler should have certain value 1`] = `ResultHandler {}`;
+
 exports[`Index Entrypoint > exports > should have certain entities exposed 1`] = `
 [
   "createConfig",
   "EndpointsFactory",
   "defaultEndpointsFactory",
+  "legacyEndpointsFactory",
   "arrayEndpointsFactory",
   "getMessageFromError",
   "ensureHttpError",
@@ -89,6 +102,7 @@ exports[`Index Entrypoint > exports > should have certain entities exposed 1`] =
   "createRateLimitMiddleware",
   "ResultHandler",
   "defaultResultHandler",
+  "legacyResultHandler",
   "arrayResultHandler",
   "createApiResponse",
   "ServeStatic",

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -189,7 +189,23 @@ exports[`ResultHandler > 'legacyResultHandler' > Should handle schema error 1`] 
 }
 `;
 
-exports[`ResultHandler > 'legacyResultHandler' > should forward output schema examples 1`] = `undefined`;
+exports[`ResultHandler > 'legacyResultHandler' > should forward output schema examples 1`] = `
+{
+  "examples": [
+    {
+      "data": {
+        "items": [
+          "One",
+          "Two",
+          "Three",
+        ],
+        "str": "test",
+      },
+      "status": "success",
+    },
+  ],
+}
+`;
 
 exports[`ResultHandler > 'legacyResultHandler' > should generate negative response example 1`] = `
 {

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -128,6 +128,82 @@ exports[`ResultHandler > 'defaultResultHandler' > should generate negative respo
 }
 `;
 
+exports[`ResultHandler > 'legacyResultHandler' > Should handle HTTP error 1`] = `
+{
+  "error": {
+    "message": "Something not found",
+  },
+  "status": "error",
+}
+`;
+
+exports[`ResultHandler > 'legacyResultHandler' > Should handle generic error 1`] = `
+[
+  [
+    "Server side error",
+    {
+      "error": InternalServerError({
+        "cause": Error({
+          "message": "Some error",
+        }),
+        "message": "Some error",
+      }),
+      "payload": {
+        "something": 453,
+      },
+      "url": "http://something/v1/anything",
+    },
+  ],
+]
+`;
+
+exports[`ResultHandler > 'legacyResultHandler' > Should handle generic error 2`] = `
+{
+  "error": {
+    "message": "Some error",
+  },
+  "status": "error",
+}
+`;
+
+exports[`ResultHandler > 'legacyResultHandler' > Should handle regular response 1`] = `
+{
+  "data": {
+    "anything": 118,
+    "items": [
+      "One",
+      "Two",
+      "Three",
+    ],
+  },
+  "status": "success",
+}
+`;
+
+exports[`ResultHandler > 'legacyResultHandler' > Should handle schema error 1`] = `
+{
+  "error": {
+    "message": "something: Expected string, got number",
+  },
+  "status": "error",
+}
+`;
+
+exports[`ResultHandler > 'legacyResultHandler' > should forward output schema examples 1`] = `undefined`;
+
+exports[`ResultHandler > 'legacyResultHandler' > should generate negative response example 1`] = `
+{
+  "examples": [
+    {
+      "error": {
+        "message": "Sample error message",
+      },
+      "status": "error",
+    },
+  ],
+}
+`;
+
 exports[`ResultHandler > arrayResultHandler should attempt to take examples from the items prop 1`] = `
 {
   "examples": [

--- a/express-zod-api/tests/result-handler.spec.ts
+++ b/express-zod-api/tests/result-handler.spec.ts
@@ -5,6 +5,7 @@ import {
   InputValidationError,
   arrayResultHandler,
   defaultResultHandler,
+  legacyResultHandler,
   ResultHandler,
 } from "../src";
 import { ResultHandlerError } from "../src/errors";
@@ -76,6 +77,10 @@ describe("ResultHandler", () => {
     {
       subject: defaultResultHandler,
       name: "defaultResultHandler",
+    },
+    {
+      subject: legacyResultHandler,
+      name: "legacyResultHandler",
     },
     {
       subject: arrayResultHandler,

--- a/migration/index.spec.ts
+++ b/migration/index.spec.ts
@@ -24,6 +24,10 @@ describe("Migration", async () => {
     valid: [
       // expressZodApiImport
       `import { Documentation } from "express-zod-api/documentation"`,
+      // defaultId
+      `import { legacyResultHandler, legacyEndpointsFactory } from "express-zod-api"`,
+      `const foo = new EndpointsFactory(legacyResultHandler)`,
+      `const bar = legacyEndpointsFactory.build({})`,
     ],
     invalid: [
       {
@@ -50,6 +54,153 @@ describe("Migration", async () => {
             data: {
               subject: "DocumentationError",
               to: "express-zod-api/documentation",
+            },
+          },
+        ],
+      },
+      {
+        name: "change defaultResultHandler import",
+        code: `import { defaultResultHandler } from "express-zod-api"`,
+        output: `import { legacyResultHandler } from "express-zod-api"`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+        ],
+      },
+      {
+        name: "change defaultEndpointsFactory import",
+        code: `import { defaultEndpointsFactory } from "express-zod-api"`,
+        output: `import { legacyEndpointsFactory } from "express-zod-api"`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+        ],
+      },
+      {
+        name: "change both in mixed import",
+        code: `import { defaultResultHandler, defaultEndpointsFactory } from "express-zod-api"`,
+        output: `import { legacyResultHandler, legacyEndpointsFactory } from "express-zod-api"`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+        ],
+      },
+      {
+        name: "change defaultResultHandler in code usage",
+        code: `import { defaultResultHandler } from "express-zod-api"; const f = new EndpointsFactory(defaultResultHandler)`,
+        output: `import { legacyResultHandler } from "express-zod-api"; const f = new EndpointsFactory(legacyResultHandler)`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultResultHandler",
+              to: "legacyResultHandler",
+            },
+          },
+        ],
+      },
+      {
+        name: "change defaultEndpointsFactory in code usage",
+        code: `import { defaultEndpointsFactory } from "express-zod-api"; const f = defaultEndpointsFactory.build({})`,
+        output: `import { legacyEndpointsFactory } from "express-zod-api"; const f = legacyEndpointsFactory.build({})`,
+        errors: [
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
+            },
+          },
+          {
+            messageId: "change",
+            data: {
+              subject: "entity",
+              from: "defaultEndpointsFactory",
+              to: "legacyEndpointsFactory",
             },
           },
         ],

--- a/migration/index.ts
+++ b/migration/index.ts
@@ -7,12 +7,14 @@ import {
 
 interface Queries {
   expressZodApiImport: ESTree.ImportDeclaration;
+  defaultId: ESTree.IdentifierName;
 }
 
 type Listener = keyof Queries;
 
 const queries: Record<Listener, string> = {
   expressZodApiImport: `ImportDeclaration[source.value="express-zod-api"]`,
+  defaultId: `Identifier[name]`,
 };
 
 const listen = <S extends { [K in Listener]: (node: Queries[K]) => void }>(
@@ -28,6 +30,11 @@ const listen = <S extends { [K in Listener]: (node: Queries[K]) => void }>(
 
 const moveTargets = new Map<string, string[]>([
   ["express-zod-api/documentation", ["DocumentationError"]],
+]);
+
+const renameTargets = new Map([
+  ["defaultResultHandler", "legacyResultHandler"],
+  ["defaultEndpointsFactory", "legacyEndpointsFactory"],
 ]);
 
 const ruleName = `v${import.meta.TSDOWN_VERSION.split(".")[0]}`;
@@ -101,6 +108,16 @@ const theRule: Rule = {
             }
             return fixer.replaceText(node, parts.join("\n"));
           },
+        });
+      },
+      defaultId: (node) => {
+        const replacement = renameTargets.get(node.name);
+        if (!replacement) return;
+        ctx.report({
+          node,
+          messageId: "change",
+          data: { subject: "entity", from: node.name, to: replacement },
+          fix: (fixer) => fixer.replaceText(node, replacement),
         });
       },
     }),


### PR DESCRIPTION
this is to preserve wrappers for existing APIs while being able to migrate