### PR TITLE
fix(docs): Removing status discriminator from examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,18 +1400,18 @@ response schemas and their corresponding status codes.
 import { ResultHandler } from "express-zod-api";
 
 const resultHandler = new ResultHandler({
-  positive: (data) => ({
+  positive: (output) => ({
     statusCode: [201, 202], // created or will be created
-    schema: z.object({ status: z.literal("created"), data }),
+    schema: output,
   }),
   negative: [
     {
       statusCode: 409, // conflict: entity already exists
-      schema: z.object({ status: z.literal("exists"), id: z.int() }),
+      schema: z.object({ id: z.int().describe("id of the existing entity") }),
     },
     {
       statusCode: [400, 500], // validation or internal error
-      schema: z.object({ status: z.literal("error"), reason: z.string() }),
+      schema: z.object({ reason: z.string() }),
     },
   ],
 });

--- a/example/example.client.ts
+++ b/example/example.client.ts
@@ -75,21 +75,17 @@ type PostV1UserCreateInput = {
 
 /** post /v1/user/create */
 type PostV1UserCreatePositiveVariant1 = {
-  status: "created";
-  data: {
-    id: number;
-  };
+  id: number;
 };
 
 /** post /v1/user/create */
 type PostV1UserCreateNegativeVariant1 = {
-  status: "exists";
+  /** id of the existing entity */
   id: number;
 };
 
 /** post /v1/user/create */
 type PostV1UserCreateNegativeVariant2 = {
-  status: "error";
   reason: string;
 };
 

--- a/example/example.documentation.yaml
+++ b/example/example.documentation.yaml
@@ -295,22 +295,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    const: created
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        exclusiveMinimum: 0
-                        maximum: 9007199254740991
-                    required:
-                      - id
-                    additionalProperties: false
+                  id:
+                    type: integer
+                    exclusiveMinimum: 0
+                    maximum: 9007199254740991
                 required:
-                  - status
-                  - data
+                  - id
                 additionalProperties: false
         "400":
           description: POST /v1/user/create Negative response 400
@@ -319,13 +309,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    const: error
                   reason:
                     type: string
                 required:
-                  - status
                   - reason
                 additionalProperties: false
         "409":
@@ -335,15 +321,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    const: exists
                   id:
                     type: integer
                     minimum: -9007199254740991
                     maximum: 9007199254740991
+                    description: id of the existing entity
                 required:
-                  - status
                   - id
                 additionalProperties: false
         "500":
@@ -353,13 +336,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    const: error
                   reason:
                     type: string
                 required:
-                  - status
                   - reason
                 additionalProperties: false
   /v1/user/list:

--- a/example/factories.ts
+++ b/example/factories.ts
@@ -75,18 +75,18 @@ export const arrayRespondingFactory = new EndpointsFactory(arrayResultHandler);
 /** @desc The factory demonstrates slightly different response schemas depending on the negative status code */
 export const statusDependingFactory = new EndpointsFactory(
   new ResultHandler({
-    positive: (data) => ({
-      statusCode: [201, 202],
-      schema: z.object({ status: z.literal("created"), data }),
+    positive: (output) => ({
+      statusCode: [201, 202], // created or will be created
+      schema: output,
     }),
     negative: [
       {
-        statusCode: 409,
-        schema: z.object({ status: z.literal("exists"), id: z.int() }),
+        statusCode: 409, // conflict: entity already exists
+        schema: z.object({ id: z.int().describe("id of the existing entity") }),
       },
       {
-        statusCode: [400, 500],
-        schema: z.object({ status: z.literal("error"), reason: z.string() }),
+        statusCode: [400, 500], // validation or internal error
+        schema: z.object({ reason: z.string() }),
       },
     ],
     handler: ({ error, response, output }) => {
@@ -99,12 +99,10 @@ export const statusDependingFactory = new EndpointsFactory(
         return void response
           .status(httpError.statusCode)
           .json(
-            doesExist
-              ? { status: "exists", id: httpError.id }
-              : { status: "error", reason: httpError.message },
+            doesExist ? { id: httpError.id } : { reason: httpError.message },
           );
       }
-      response.status(201).json({ status: "created", data: output });
+      response.status(201).json(output);
     },
   }),
 );

--- a/example/index.spec.ts
+++ b/example/index.spec.ts
@@ -58,10 +58,7 @@ describe("Example", async () => {
       });
       expect(response.status).toBe(201);
       const json = await response.json();
-      expect(json).toMatchObject({
-        status: "created",
-        data: { id: 16 },
-      });
+      expect(json).toMatchObject({ id: 16 });
     });
 
     test("Should handle valid PATCH request with rate limit headers", async ({
@@ -438,7 +435,7 @@ describe("Example", async () => {
       });
       expect(response.status).toBe(409);
       const json = await response.json();
-      expect(json).toEqual({ status: "exists", id: 16 });
+      expect(json).toEqual({ id: 16 });
     });
 
     test("POST request should fail on demand", async ({ signal }) => {
@@ -450,7 +447,7 @@ describe("Example", async () => {
       });
       expect(response.status).toBe(500);
       const json = await response.json();
-      expect(json).toEqual({ status: "error", reason: "That went wrong" });
+      expect(json).toEqual({ reason: "That went wrong" });
     });
 
     test("PATCH request should fail on auth middleware key check", async ({


### PR DESCRIPTION
Since after #3647 we use the HTTP status code to convey the status. Removing it from payload.