### PR TITLE
fix: rm type assertions from defaultIsHeader().

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -247,7 +247,7 @@ const enumerateExamples = (examples: unknown[]): ExamplesObject | undefined =>
 export const defaultIsHeader = (
   name: string,
   familiar?: Set<string>,
-): name is `x-${string}` =>
+): boolean =>
   familiar?.has(name) ||
   name.startsWith("x-") ||
   getWellKnownHeaders().has(name);


### PR DESCRIPTION
the return type asserting `x-` prefix is critically oudated.
it now checks both familiar and well-known headers 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal type declaration without changing runtime behavior or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->