### PR TITLE
fix: document cookie-only inputs and QUERY query params

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -287,7 +287,8 @@ export const makeParamLocator = ({
       (isHeader?.(name, method, path) ?? defaultIsHeader(name, securityHeaders))
     )
       return "header";
-    if (isQueryEnabled && method !== "query") return "query";
+    if (isQueryEnabled) return "query";
+    if (areCookiesEnabled) return "cookie";
   };
   return { pathParams, getLocation, isQueryEnabled };
 };

--- a/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation.spec.ts.snap
@@ -949,26 +949,29 @@ paths:
   /v1/getSomething:
     query:
       operationId: QueryV1GetSomething
+      parameters:
+        - name: intersection
+          in: query
+          required: true
+          description: QUERY /v1/getSomething Parameter
+          schema:
+            type: object
+            properties:
+              one:
+                type: string
+              two:
+                type: string
+            required:
+              - one
+              - two
       requestBody:
         description: QUERY /v1/getSomething Request body
         content:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              properties:
-                intersection:
-                  type: object
-                  properties:
-                    one:
-                      type: string
-                    two:
-                      type: string
-                  required:
-                    - one
-                    - two
-              required:
-                - intersection
-        required: true
+              properties: {}
+              required: []
       responses:
         "200":
           description: QUERY /v1/getSomething Positive response

--- a/express-zod-api/tests/documentation-helpers.spec.ts
+++ b/express-zod-api/tests/documentation-helpers.spec.ts
@@ -446,6 +446,32 @@ describe("Documentation helpers", () => {
       expect(getLocation("test")).toBe("query");
       expect(getLocation("session")).toBe("cookie");
     });
+
+    test.each(["cookies", "signedCookies"] as const)(
+      "Issue #3660: should depict %s as cookie params without CookieSecurity",
+      (source) => {
+        const { pathParams, isQueryEnabled, getLocation } = makeParamLocator({
+          ...requestCtx,
+          inputSources: ["params", source],
+        });
+        expect(pathParams).toEqual(new Set(["id"]));
+        expect(isQueryEnabled).toBe(false);
+        expect(getLocation("id")).toBe("path");
+        expect(getLocation("session")).toBe("cookie");
+      },
+    );
+
+    test("Issue #3660: QUERY method should emit query params when query is enabled", () => {
+      const { pathParams, isQueryEnabled, getLocation } = makeParamLocator({
+        ...requestCtx,
+        method: "query",
+        inputSources: ["query", "body", "params"],
+      });
+      expect(pathParams).toEqual(new Set(["id"]));
+      expect(isQueryEnabled).toBe(true);
+      expect(getLocation("id")).toBe("path");
+      expect(getLocation("test")).toBe("query");
+    });
   });
 
   describe("depictRequestParams()", () => {

--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -1655,6 +1655,53 @@ describe("Documentation", () => {
     });
   });
 
+  describe("Issue #3660: Cookie-sourced input and QUERY query params", () => {
+    test("Should depict cookie params when cookies are in inputSources without CookieSecurity", () => {
+      const spec = new Documentation({
+        config: createConfig({
+          cors: false,
+          logger: { level: "silent" },
+          inputSources: { get: ["params", "cookies"] },
+        }),
+        routing: {
+          c: defaultEndpointsFactory.buildVoid({
+            input: z.object({ session: z.string() }),
+            handler: vi.fn(),
+          }),
+        },
+        info: { title: "Issue 3660", version: "1.0.0" },
+      }).getSpec();
+      expect(spec.paths!["/c"]!.get!.parameters).toEqual([
+        expect.objectContaining({
+          name: "session",
+          in: "cookie",
+          required: true,
+        }),
+      ]);
+    });
+
+    test("Should depict QUERY fields as query parameters when query is in inputSources", () => {
+      const spec = new Documentation({
+        config: sampleConfig,
+        routing: {
+          q: defaultEndpointsFactory.buildVoid({
+            method: "query",
+            input: z.object({ filter: z.string() }),
+            handler: vi.fn(),
+          }),
+        },
+        info: { title: "Issue 3660", version: "1.0.0" },
+      }).getSpec();
+      expect(spec.paths!["/q"]!.query!.parameters).toEqual([
+        expect.objectContaining({
+          name: "filter",
+          in: "query",
+          required: true,
+        }),
+      ]);
+    });
+  });
+
   describe("Issue #3601: shared input schema should not share the request body component", () => {
     const commons = {
       config: sampleConfig,


### PR DESCRIPTION
## Summary

`makeParamLocator` only emitted `in: cookie` for names listed in `CookieSecurity`. When `inputSources` included `cookies`/`signedCookies` but not `query`, remaining fields were omitted from the OpenAPI document even though runtime accepted them from cookies.

The same locator skipped the query fallback for HTTP `QUERY` (`method !== "query"`), so QUERY fields landed in the form body instead of `in: query` despite default sources including `query`.

## Changes

- When cookies are enabled and query is not, remaining fields are documented as `in: cookie` without requiring CookieSecurity.
- CookieSecurity still wins when both query and cookies are enabled.
- QUERY methods can emit `in: query` when query is among inputSources.

## Test plan

- [x] `vitest run tests/documentation-helpers.spec.ts tests/documentation.spec.ts` (151 passed)
- [x] Unit coverage for cookie-only sources and QUERY query params
- [x] Documentation integration expectations for both cases

Fixes #3660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API documentation for cookie-sourced parameters, including unsigned and signed cookies.
  * Query parameters are now correctly identified for query-based endpoints when query input is enabled.
  * Cookie parameters no longer require additional cookie security configuration to be documented accurately.

* **Tests**
  * Added coverage for cookie and query parameter documentation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->