### PR TITLE
feat(endpoint): Try parsing sync first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 - Added the `trySyncValidation` option to the configuration (opt-in, disabled by default):
   - When enabled, the framework attempts a synchronous I/O `parse()` first, falling back to `parseAsync()` only for
-    schemas containing async refinements or transforms;
+    schemas containing async refinements or transformations;
   - This benefits [compiled](https://zod.dev/compile) schemas (Zod 4.5+) by keeping them on the fast parsing path;
   - Even without schema compilation it gives a ~1.3x performance boost for synchronous I/O validation, but when hitting
-    an async schema, the performance decrease is ~14x, so it's an opt-in feature now:
+    an async schema, the performance decrease is ~14x, so it will only attempt sync parsing once per schema:
     - Also, async refinements and transformations execute twice in that case, so avoid side effects in them;
   - The flag is applied to the I/O schemas of `Endpoint` and the input schema of `Middleware`.
 - The `Middleware::execute()` now accepts optional `config` property on its argument:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Version 29
 
+### v29.5.0
+
+- Added the `trySyncValidation` option to the configuration (opt-in, disabled by default):
+  - When enabled, the framework attempts a synchronous I/O `parse()` first, falling back to `parseAsync()` only for
+    schemas containing async refinements or transforms;
+  - This benefits [compiled](https://zod.dev/compile) schemas (Zod 4.5+) by keeping them on the fast parsing path;
+  - Even without schema compilation it gives a ~1.3x performance boost for synchronous I/O validation, but when hitting
+    an async schema, the performance decrease is ~14x, so it's an opt-in feature now;
+  - The flag is applied to the I/O schemas of `Endpoint` and the input schema of `Middleware`.
+- The `Middleware::execute()` now accepts optional `config` property on its argument:
+  - It might become required in v30;
+  - `testMiddleware()` now forwards the mocked configuration into the `Middleware::execute()`.
+
 ### v29.4.1
 
 - Compatibility fix for Zod 4.5:
@@ -5247,7 +5260,8 @@ const config = createConfig({
 ### v5.3.1
 
 - Fixed issue #269: async refinements in I/O schemas of endpoints and middlewares.
-  - There was an error `Async refinement encountered during synchronous parse operation. Use .parseAsync instead.`
+  - There was an error `Async refinement encountered during synchronous parse operation. Use .parseAsync instead.`;
+  - Found and reported by [@BlessedRaccoon](https://github.com/BlessedRaccoon).
 
 ### v5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
     schemas containing async refinements or transforms;
   - This benefits [compiled](https://zod.dev/compile) schemas (Zod 4.5+) by keeping them on the fast parsing path;
   - Even without schema compilation it gives a ~1.3x performance boost for synchronous I/O validation, but when hitting
-    an async schema, the performance decrease is ~14x, so it's an opt-in feature now;
+    an async schema, the performance decrease is ~14x, so it's an opt-in feature now:
+    - Also, async refinements and transformations execute twice in that case, so avoid side effects in them;
   - The flag is applied to the I/O schemas of `Endpoint` and the input schema of `Middleware`.
 - The `Middleware::execute()` now accepts optional `config` property on its argument:
   - It might become required in v30;

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ These people contributed to the improvement of the framework by reporting bugs, 
 [<img src="https://github.com/foxfirecodes.png" alt="@foxfirecodes" width="50" />](https://github.com/foxfirecodes)
 [<img src="https://github.com/HardCoreQual.png" alt="@HardCoreQual" width="50" />](https://github.com/HardCoreQual)
 [<img src="https://github.com/hellovai.png" alt="@hellovai" width="50" />](https://github.com/hellovai)
+[<img src="https://github.com/BlessedRaccoon.png" alt="@BlessedRaccoon" width="50" />](https://github.com/BlessedRaccoon)
 [<img src="https://github.com/Isaac-Leonard.png" alt="@Isaac-Leonard" width="50" />](https://github.com/Isaac-Leonard)
 [<img src="https://github.com/digimuza.png" alt="@digimuza" width="50" />](https://github.com/digimuza)
 [<img src="https://github.com/glitch452.png" alt="@glitch452" width="50" />](https://github.com/glitch452)

--- a/express-zod-api/bench/parse-maybe-async.bench.ts
+++ b/express-zod-api/bench/parse-maybe-async.bench.ts
@@ -11,6 +11,6 @@ describe.each([
   });
 
   bench("parseMaybeAsync()", async () => {
-    await parseMaybeAsync(schema, "", true);
+    await parseMaybeAsync(schema, "", { trySyncValidation: true, cors: false });
   });
 });

--- a/express-zod-api/bench/parse-maybe-async.bench.ts
+++ b/express-zod-api/bench/parse-maybe-async.bench.ts
@@ -11,6 +11,6 @@ describe.each([
   });
 
   bench("parseMaybeAsync()", async () => {
-    await parseMaybeAsync(schema, "");
+    await parseMaybeAsync(schema, "", true);
   });
 });

--- a/express-zod-api/bench/parse-maybe-async.bench.ts
+++ b/express-zod-api/bench/parse-maybe-async.bench.ts
@@ -7,10 +7,10 @@ describe.each([
   [z.string().refine(async () => true), "async"],
 ])("Parsing $1 schemas", (schema) => {
   bench(".parseAsync()", async () => {
-    return void schema.parseAsync("");
+    await schema.parseAsync("");
   });
 
   bench("parseMaybeAsync()", async () => {
-    return void parseMaybeAsync(schema, "");
+    await parseMaybeAsync(schema, "");
   });
 });

--- a/express-zod-api/bench/parse-maybe-async.bench.ts
+++ b/express-zod-api/bench/parse-maybe-async.bench.ts
@@ -1,0 +1,16 @@
+import { bench } from "vitest";
+import { z } from "zod";
+import { parseMaybeAsync } from "../src/common-helpers.ts";
+
+describe.each([
+  [z.string(), "sync"],
+  [z.string().refine(async () => true), "async"],
+])("Parsing $1 schemas", (schema) => {
+  bench(".parseAsync()", async () => {
+    return void schema.parseAsync("");
+  });
+
+  bench("parseMaybeAsync()", async () => {
+    return void parseMaybeAsync(schema, "");
+  });
+});

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -98,17 +98,17 @@ export const ensureError = (subject: unknown): Error =>
  * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
-  input: unknown,
+  value: unknown,
   { trySyncValidation = false }: CommonConfig,
   prev?: { isAsync: boolean }, // when already found to be async
 ): Promise<z.output<T>> => {
-  if (!trySyncValidation || prev?.isAsync) return schema.parseAsync(input);
+  if (!trySyncValidation || prev?.isAsync) return schema.parseAsync(value);
   try {
-    return schema.parse(input);
+    return schema.parse(value);
   } catch (err) {
     if (err instanceof z.core.$ZodAsyncError) {
       if (prev) prev.isAsync = true;
-      return schema.parseAsync(input);
+      return schema.parseAsync(value);
     }
     throw err;
   }

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -92,15 +92,24 @@ export const ensureError = (subject: unknown): Error =>
       ? new z.ZodRealError(subject.issues)
       : new Error(String(subject));
 
-/** @desc Attempts to parse the schema synchronously first. Made for parsing compiled schemas */
+/**
+ * @desc Attempts to parse the schema synchronously first. Made for parsing compiled schemas
+ * @param state Tracks whether a synchronous parsing attempt is viable for the schema between requests
+ * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,
+  state?: { syncImpossible: boolean },
 ): Promise<z.output<T>> => {
+  // Skip the futile attempt when a schema was already found to be async
+  if (state?.syncImpossible) return schema.parseAsync(input);
   try {
     return schema.parse(input);
   } catch (e) {
-    if (e instanceof z.core.$ZodAsyncError) return schema.parseAsync(input);
+    if (e instanceof z.core.$ZodAsyncError) {
+      if (state) state.syncImpossible = true;
+      return schema.parseAsync(input);
+    }
     throw e;
   }
 };

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -92,6 +92,23 @@ export const ensureError = (subject: unknown): Error =>
       ? new z.ZodRealError(subject.issues)
       : new Error(String(subject));
 
+/**
+ * @desc Parses the schema synchronously via `.parse()` when possible, falling back to `.parseAsync()` for schemas
+ *       containing async refinements (which throw `$ZodAsyncError` on a synchronous parse). This keeps compiled
+ *       schemas on the fast path while covering schemas with async logic.
+ * */
+export const parseMaybeAsync = async <T extends z.ZodType>(
+  schema: T,
+  input: unknown,
+): Promise<z.output<T>> => {
+  try {
+    return schema.parse(input);
+  } catch (e) {
+    if (e instanceof z.core.$ZodAsyncError) return schema.parseAsync(input);
+    throw e;
+  }
+};
+
 export const getMessageFromError = (error: Error): string => {
   if (error instanceof z.ZodError) {
     return error.issues

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -99,7 +99,7 @@ export const ensureError = (subject: unknown): Error =>
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   value: unknown,
-  { trySyncValidation = false }: CommonConfig,
+  { trySyncValidation = false }: Partial<CommonConfig>, // @todo rm Partial in v30
   prev?: { isAsync: boolean }, // when already found to be async
 ): Promise<z.output<T>> => {
   if (!trySyncValidation || prev?.isAsync) return schema.parseAsync(value);

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -94,26 +94,23 @@ export const ensureError = (subject: unknown): Error =>
 
 /**
  * @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements.
- * @param config The config, only `trySyncValidation` is being used
- * @param state Tracks when the schema is discovered to be async, to skip futile sync attempts on subsequent requests
  * @todo enable trySyncValidation by default in v30
  * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,
   { trySyncValidation = false }: CommonConfig,
-  state?: { isAsync: boolean },
+  prev?: { isAsync: boolean }, // when already found to be async
 ): Promise<z.output<T>> => {
-  // Skip the futile attempt when the feature is disabled or the schema was already found to be async
-  if (!trySyncValidation || state?.isAsync) return schema.parseAsync(input);
+  if (!trySyncValidation || prev?.isAsync) return schema.parseAsync(input);
   try {
     return schema.parse(input);
-  } catch (e) {
-    if (e instanceof z.core.$ZodAsyncError) {
-      if (state) state.isAsync = true;
+  } catch (err) {
+    if (err instanceof z.core.$ZodAsyncError) {
+      if (prev) prev.isAsync = true;
       return schema.parseAsync(input);
     }
-    throw e;
+    throw err;
   }
 };
 

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -93,16 +93,19 @@ export const ensureError = (subject: unknown): Error =>
       : new Error(String(subject));
 
 /**
- * @desc Attempts to parse the schema synchronously first. Made for parsing compiled schemas
+ * @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements.
+ * @param trySyncValidation Enables sync attempts (per the `trySyncValidation` config option)
  * @param state Tracks whether a synchronous parsing attempt is viable for the schema between requests
  * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,
+  trySyncValidation: boolean | undefined,
   state?: { syncImpossible: boolean },
 ): Promise<z.output<T>> => {
-  // Skip the futile attempt when a schema was already found to be async
-  if (state?.syncImpossible) return schema.parseAsync(input);
+  // Skip the futile attempt when the feature is disabled or the schema was already found to be async
+  if (!trySyncValidation || state?.syncImpossible)
+    return schema.parseAsync(input);
   try {
     return schema.parse(input);
   } catch (e) {

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -95,22 +95,21 @@ export const ensureError = (subject: unknown): Error =>
 /**
  * @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements.
  * @param trySyncValidation Enables sync attempts (per the `trySyncValidation` config option)
- * @param state Tracks whether a synchronous parsing attempt is viable for the schema between requests
+ * @param state Tracks when the schema is discovered to be async, to skip futile sync attempts on subsequent requests
  * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,
   trySyncValidation: boolean | undefined,
-  state?: { syncImpossible: boolean },
+  state?: { isAsync: boolean },
 ): Promise<z.output<T>> => {
   // Skip the futile attempt when the feature is disabled or the schema was already found to be async
-  if (!trySyncValidation || state?.syncImpossible)
-    return schema.parseAsync(input);
+  if (!trySyncValidation || state?.isAsync) return schema.parseAsync(input);
   try {
     return schema.parse(input);
   } catch (e) {
     if (e instanceof z.core.$ZodAsyncError) {
-      if (state) state.syncImpossible = true;
+      if (state) state.isAsync = true;
       return schema.parseAsync(input);
     }
     throw e;

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -92,11 +92,7 @@ export const ensureError = (subject: unknown): Error =>
       ? new z.ZodRealError(subject.issues)
       : new Error(String(subject));
 
-/**
- * @desc Parses the schema synchronously via `.parse()` when possible, falling back to `.parseAsync()` for schemas
- *       containing async refinements (which throw `$ZodAsyncError` on a synchronous parse). This keeps compiled
- *       schemas on the fast path while covering schemas with async logic.
- * */
+/** @desc Attempts to parse the schema synchronously first. Made for parsing compiled schemas */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -94,13 +94,14 @@ export const ensureError = (subject: unknown): Error =>
 
 /**
  * @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements.
- * @param trySyncValidation Enables sync attempts (per the `trySyncValidation` config option)
+ * @param config The config, only `trySyncValidation` is being used
  * @param state Tracks when the schema is discovered to be async, to skip futile sync attempts on subsequent requests
+ * @todo enable trySyncValidation by default in v30
  * */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   input: unknown,
-  trySyncValidation: boolean | undefined,
+  { trySyncValidation = false }: CommonConfig,
   state?: { isAsync: boolean },
 ): Promise<z.output<T>> => {
   // Skip the futile attempt when the feature is disabled or the schema was already found to be async

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -92,7 +92,7 @@ export interface CommonConfig {
   /**
    * @desc Attempts using .parse() method first, falling back to .parseAsync() if fails due to async refinements.
    * @desc In that case, async refinements and transformations execute twice, so avoid side effects in them.
-   * @example true — parses sync schemas ~1.3x faster, but it's ~14x slower if it occasionally hits an async one.
+   * @example true — parses sync schemas ~1.3x faster, but it retries async ones (first request to the endpoint only).
    * @example false — always uses .parseAsync() and does not support compiled schemas (legacy behavior).
    * @default false
    * @todo remove in v30 or enable by default

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -91,6 +91,7 @@ export interface CommonConfig {
   inputSources?: Partial<InputSources>;
   /**
    * @desc Attempts using .parse() method first, falling back to .parseAsync() if fails due to async refinements.
+   * @desc In that case, async refinements and transformations execute twice, so avoid side effects in them.
    * @example true — parses sync schemas ~1.3x faster, but it's ~14x slower if it occasionally hits an async one.
    * @example false — always uses .parseAsync() and does not support compiled schemas (legacy behavior).
    * @default false

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -89,6 +89,14 @@ export interface CommonConfig {
    * @see defaultInputSources
    */
   inputSources?: Partial<InputSources>;
+  /**
+   * @desc Attempts using .parse() method first, falling back to .parseAsync() if fails due to async refinements.
+   * @example true — parses sync schemas ~1.3x faster, but it's ~14x slower if it occasionally hits an async one.
+   * @example false — always uses .parseAsync() and does not support compiled schemas (legacy behavior).
+   * @default false
+   * @todo remove in v30 or enable by default
+   */
+  trySyncValidation?: boolean;
 }
 
 type BeforeUpload = (params: {

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -91,8 +91,8 @@ export class Endpoint<
   readonly #def: ConstructorParameters<typeof Endpoint<IN, OUT, CTX>>[0];
   #requestType?: ContentType;
   /** @desc Set to true once a schema turns out to be async, to skip sync attempts in the future. */
-  #inputParsingState = { syncImpossible: false };
-  #outputParsingState = { syncImpossible: false };
+  #inputParsingState = { isAsync: false };
+  #outputParsingState = { isAsync: false };
 
   /** considered an expensive operation, only required for generators */
   #ensureOutputExamples = R.once(() => {

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -9,6 +9,7 @@ import {
   getInput,
   ensureError,
   isSchema,
+  parseMaybeAsync,
 } from "./common-helpers";
 import type { CommonConfig } from "./config-type";
 import { InputValidationError, OutputValidationError } from "./errors";
@@ -213,7 +214,10 @@ export class Endpoint<
 
   async #parseOutput(output: z.input<OUT>) {
     try {
-      return (await this.#def.outputSchema.parseAsync(output)) as FlatObject;
+      return (await parseMaybeAsync(
+        this.#def.outputSchema,
+        output,
+      )) as FlatObject;
     } catch (e) {
       throw e instanceof z.ZodError ? new OutputValidationError(e) : e;
     }
@@ -261,7 +265,7 @@ export class Endpoint<
   }) {
     let finalInput: z.output<IN>; // final input types transformations for handler
     try {
-      finalInput = await this.#def.inputSchema.parseAsync(input);
+      finalInput = await parseMaybeAsync(this.#def.inputSchema, input);
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;
     }

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -223,7 +223,7 @@ export class Endpoint<
       return await parseMaybeAsync(
         this.#def.outputSchema,
         output,
-        config.trySyncValidation,
+        config,
         this.#outputParsingState,
       );
     } catch (e) {
@@ -266,7 +266,7 @@ export class Endpoint<
 
   async #parseAndRunHandler({
     input,
-    config: { trySyncValidation },
+    config,
     ...rest
   }: {
     input: Readonly<FlatObject>;
@@ -279,7 +279,7 @@ export class Endpoint<
       finalInput = await parseMaybeAsync(
         this.#def.inputSchema,
         input,
-        trySyncValidation,
+        config,
         this.#inputParsingState,
       );
     } catch (e) {

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -212,12 +212,11 @@ export class Endpoint<
     return this.#def.getOperationId?.(method);
   }
 
-  async #parseOutput(output: z.input<OUT>) {
+  async #parseOutput(output: z.input<OUT>, config: CommonConfig) {
     try {
-      return (await parseMaybeAsync(
-        this.#def.outputSchema,
-        output,
-      )) as FlatObject;
+      return (await (config.trySyncValidation
+        ? parseMaybeAsync(this.#def.outputSchema, output)
+        : this.#def.outputSchema.parseAsync(output))) as FlatObject;
     } catch (e) {
       throw e instanceof z.ZodError ? new OutputValidationError(e) : e;
     }
@@ -236,6 +235,7 @@ export class Endpoint<
     response: Response;
     logger: ActualLogger;
     ctx: Partial<CTX>;
+    config: CommonConfig;
   }) {
     for (const mw of this.#def.middlewares || []) {
       if (
@@ -257,15 +257,19 @@ export class Endpoint<
 
   async #parseAndRunHandler({
     input,
+    config,
     ...rest
   }: {
     input: Readonly<FlatObject>;
     ctx: CTX;
     logger: ActualLogger;
+    config: CommonConfig;
   }) {
     let finalInput: z.output<IN>; // final input types transformations for handler
     try {
-      finalInput = await parseMaybeAsync(this.#def.inputSchema, input);
+      finalInput = config.trySyncValidation
+        ? await parseMaybeAsync(this.#def.inputSchema, input)
+        : await this.#def.inputSchema.parseAsync(input);
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;
     }
@@ -307,6 +311,7 @@ export class Endpoint<
         response,
         logger,
         ctx,
+        config,
       });
       if (response.writableEnded) return;
       if (method === ("options" satisfies CORSMethod))
@@ -314,10 +319,11 @@ export class Endpoint<
       const output = await this.#parseAndRunHandler({
         input,
         logger,
+        config,
         ctx: ctx as CTX, // ensured the complete CTX by writableEnded condition and try-catch
       });
       if (response.writableEnded) return; // Endpoint closed the stream (304)
-      result = { output: await this.#parseOutput(output), error: null };
+      result = { output: await this.#parseOutput(output, config), error: null };
     } catch (e) {
       result = { output: null, error: ensureError(e) };
     }

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -212,11 +212,14 @@ export class Endpoint<
     return this.#def.getOperationId?.(method);
   }
 
-  async #parseOutput(output: z.input<OUT>, config: CommonConfig) {
+  async #parseOutput(
+    output: z.input<OUT>,
+    { trySyncValidation = false }: CommonConfig, // @todo set true in v30
+  ): Promise<FlatObject> {
     try {
-      return (await (config.trySyncValidation
-        ? parseMaybeAsync(this.#def.outputSchema, output)
-        : this.#def.outputSchema.parseAsync(output))) as FlatObject;
+      return trySyncValidation
+        ? await parseMaybeAsync(this.#def.outputSchema, output)
+        : await this.#def.outputSchema.parseAsync(output);
     } catch (e) {
       throw e instanceof z.ZodError ? new OutputValidationError(e) : e;
     }
@@ -257,7 +260,7 @@ export class Endpoint<
 
   async #parseAndRunHandler({
     input,
-    config,
+    config: { trySyncValidation = false }, // @todo set true in v30
     ...rest
   }: {
     input: Readonly<FlatObject>;
@@ -267,7 +270,7 @@ export class Endpoint<
   }) {
     let finalInput: z.output<IN>; // final input types transformations for handler
     try {
-      finalInput = config.trySyncValidation
+      finalInput = trySyncValidation
         ? await parseMaybeAsync(this.#def.inputSchema, input)
         : await this.#def.inputSchema.parseAsync(input);
     } catch (e) {

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -90,6 +90,9 @@ export class Endpoint<
 > extends AbstractEndpoint {
   readonly #def: ConstructorParameters<typeof Endpoint<IN, OUT, CTX>>[0];
   #requestType?: ContentType;
+  /** @desc Set to true once a schema turns out to be async, to skip sync attempts in the future. */
+  #inputParsingState = { syncImpossible: false };
+  #outputParsingState = { syncImpossible: false };
 
   /** considered an expensive operation, only required for generators */
   #ensureOutputExamples = R.once(() => {
@@ -218,7 +221,11 @@ export class Endpoint<
   ): Promise<FlatObject> {
     try {
       return trySyncValidation
-        ? await parseMaybeAsync(this.#def.outputSchema, output)
+        ? await parseMaybeAsync(
+            this.#def.outputSchema,
+            output,
+            this.#outputParsingState,
+          )
         : await this.#def.outputSchema.parseAsync(output);
     } catch (e) {
       throw e instanceof z.ZodError ? new OutputValidationError(e) : e;
@@ -271,7 +278,11 @@ export class Endpoint<
     let finalInput: z.output<IN>; // final input types transformations for handler
     try {
       finalInput = trySyncValidation
-        ? await parseMaybeAsync(this.#def.inputSchema, input)
+        ? await parseMaybeAsync(
+            this.#def.inputSchema,
+            input,
+            this.#inputParsingState,
+          )
         : await this.#def.inputSchema.parseAsync(input);
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -90,7 +90,6 @@ export class Endpoint<
 > extends AbstractEndpoint {
   readonly #def: ConstructorParameters<typeof Endpoint<IN, OUT, CTX>>[0];
   #requestType?: ContentType;
-  /** @desc Set to true once a schema turns out to be async, to skip sync attempts in the future. */
   #inputParsingState = { isAsync: false };
   #outputParsingState = { isAsync: false };
 

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -217,16 +217,15 @@ export class Endpoint<
 
   async #parseOutput(
     output: z.input<OUT>,
-    { trySyncValidation = false }: CommonConfig, // @todo set true in v30
+    config: CommonConfig,
   ): Promise<FlatObject> {
     try {
-      return trySyncValidation
-        ? await parseMaybeAsync(
-            this.#def.outputSchema,
-            output,
-            this.#outputParsingState,
-          )
-        : await this.#def.outputSchema.parseAsync(output);
+      return await parseMaybeAsync(
+        this.#def.outputSchema,
+        output,
+        config.trySyncValidation,
+        this.#outputParsingState,
+      );
     } catch (e) {
       throw e instanceof z.ZodError ? new OutputValidationError(e) : e;
     }
@@ -267,7 +266,7 @@ export class Endpoint<
 
   async #parseAndRunHandler({
     input,
-    config: { trySyncValidation = false }, // @todo set true in v30
+    config: { trySyncValidation },
     ...rest
   }: {
     input: Readonly<FlatObject>;
@@ -277,13 +276,12 @@ export class Endpoint<
   }) {
     let finalInput: z.output<IN>; // final input types transformations for handler
     try {
-      finalInput = trySyncValidation
-        ? await parseMaybeAsync(
-            this.#def.inputSchema,
-            input,
-            this.#inputParsingState,
-          )
-        : await this.#def.inputSchema.parseAsync(input);
+      finalInput = await parseMaybeAsync(
+        this.#def.inputSchema,
+        input,
+        trySyncValidation,
+        this.#inputParsingState,
+      );
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;
     }

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -11,6 +11,7 @@ import type { IOSchema } from "./io-schema";
 import type { LogicalContainer } from "./logical-container";
 import type { Security } from "./security";
 import type { ActualLogger } from "./logger-helpers";
+import type { CommonConfig } from "./config-type";
 import { isPromise } from "node:util/types";
 
 type Handler<IN, CTX, RET> = (params: {
@@ -114,6 +115,7 @@ export class Middleware<
   /** @throws InputValidationError */
   public override async execute({
     input,
+    config,
     ...rest
   }: {
     input: unknown;
@@ -121,12 +123,13 @@ export class Middleware<
     request: Request;
     response: Response;
     logger: ActualLogger;
+    config?: CommonConfig; // @todo either make config required in v30 or remove it from here
   }) {
+    const schema = this.#schema || emptySchema;
     try {
-      const validInput = (await parseMaybeAsync(
-        this.#schema || emptySchema,
-        input,
-      )) as z.output<IN>;
+      const validInput = (await (config?.trySyncValidation
+        ? parseMaybeAsync(schema, input)
+        : schema.parseAsync(input))) as z.output<IN>;
       return this.#handler({ ...rest, input: validInput });
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -128,10 +128,9 @@ export class Middleware<
     logger: ActualLogger;
     config?: CommonConfig; // @todo either make it required in v30 or remove it from here
   }) {
-    const schema = this.#schema || emptySchema;
     try {
       const validInput = await parseMaybeAsync(
-        schema,
+        this.#schema || emptySchema,
         input,
         config ?? {}, // @todo rm fallback in v30
         this.#parsingState,

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -60,7 +60,7 @@ export class Middleware<
 > extends AbstractMiddleware {
   readonly #schema: IN;
   /** @desc Set to true once the input schema turns out to be async, to skip sync attempts in the future. */
-  #parsingState = { syncImpossible: false };
+  #parsingState = { isAsync: false };
   readonly #security?: LogicalContainer<
     Security<Extract<keyof z.input<IN>, string>, SCO>
   >;

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -43,6 +43,7 @@ export abstract class AbstractMiddleware {
     request: Request;
     response: Response;
     logger: ActualLogger;
+    config?: CommonConfig; // @todo either make it required in v30 or remove it from here
   }): Promise<FlatObject>;
 }
 
@@ -123,7 +124,7 @@ export class Middleware<
     request: Request;
     response: Response;
     logger: ActualLogger;
-    config?: CommonConfig; // @todo either make config required in v30 or remove it from here
+    config?: CommonConfig; // @todo either make it required in v30 or remove it from here
   }) {
     const schema = this.#schema || emptySchema;
     try {

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -127,10 +127,10 @@ export class Middleware<
   }) {
     const schema = this.#schema || emptySchema;
     try {
-      const validInput = (await (config?.trySyncValidation
-        ? parseMaybeAsync(schema, input)
-        : schema.parseAsync(input))) as z.output<IN>;
-      return this.#handler({ ...rest, input: validInput });
+      const validInput = config?.trySyncValidation // @todo make it true by default in v30
+        ? await parseMaybeAsync(schema, input)
+        : await schema.parseAsync(input);
+      return this.#handler({ ...rest, input: validInput as z.output<IN> });
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;
     }

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -130,9 +130,12 @@ export class Middleware<
   }) {
     const schema = this.#schema || emptySchema;
     try {
-      const validInput = config?.trySyncValidation // @todo make it true by default in v30
-        ? await parseMaybeAsync(schema, input, this.#parsingState)
-        : await schema.parseAsync(input);
+      const validInput = await parseMaybeAsync(
+        schema,
+        input,
+        config?.trySyncValidation,
+        this.#parsingState,
+      );
       return this.#handler({ ...rest, input: validInput as z.output<IN> });
     } catch (e) {
       throw e instanceof z.ZodError ? new InputValidationError(e) : e;

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -1,6 +1,10 @@
 import type { NextFunction, Request, Response } from "express";
 import { z } from "zod";
-import { emptySchema, type FlatObject } from "./common-helpers";
+import {
+  emptySchema,
+  parseMaybeAsync,
+  type FlatObject,
+} from "./common-helpers";
 import { InputValidationError } from "./errors";
 import { FrozenSet } from "./frozen-set";
 import type { IOSchema } from "./io-schema";
@@ -119,7 +123,8 @@ export class Middleware<
     logger: ActualLogger;
   }) {
     try {
-      const validInput = (await (this.#schema || emptySchema).parseAsync(
+      const validInput = (await parseMaybeAsync(
+        this.#schema || emptySchema,
         input,
       )) as z.output<IN>;
       return this.#handler({ ...rest, input: validInput });

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -133,7 +133,7 @@ export class Middleware<
       const validInput = await parseMaybeAsync(
         schema,
         input,
-        config?.trySyncValidation,
+        config ?? ({} as CommonConfig),
         this.#parsingState,
       );
       return this.#handler({ ...rest, input: validInput as z.output<IN> });

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -133,7 +133,7 @@ export class Middleware<
       const validInput = await parseMaybeAsync(
         schema,
         input,
-        config ?? ({} as CommonConfig),
+        config ?? {}, // @todo rm fallback in v30
         this.#parsingState,
       );
       return this.#handler({ ...rest, input: validInput as z.output<IN> });

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -59,6 +59,8 @@ export class Middleware<
   IN extends IOSchema | undefined = undefined,
 > extends AbstractMiddleware {
   readonly #schema: IN;
+  /** @desc Set to true once the input schema turns out to be async, to skip sync attempts in the future. */
+  #parsingState = { syncImpossible: false };
   readonly #security?: LogicalContainer<
     Security<Extract<keyof z.input<IN>, string>, SCO>
   >;
@@ -129,7 +131,7 @@ export class Middleware<
     const schema = this.#schema || emptySchema;
     try {
       const validInput = config?.trySyncValidation // @todo make it true by default in v30
-        ? await parseMaybeAsync(schema, input)
+        ? await parseMaybeAsync(schema, input, this.#parsingState)
         : await schema.parseAsync(input);
       return this.#handler({ ...rest, input: validInput as z.output<IN> });
     } catch (e) {

--- a/express-zod-api/src/testing.ts
+++ b/express-zod-api/src/testing.ts
@@ -144,12 +144,11 @@ export const testMiddleware = async <
     request: mocks.requestMock,
     response: mocks.responseMock,
     logger: mocks.loggerMock,
-    config: configMock,
     input,
     ctx,
   };
   try {
-    const output = await middleware.execute(commons);
+    const output = await middleware.execute({ ...commons, config: configMock });
     return { ...mocks, output };
   } catch (e) {
     await errorHandler.execute({

--- a/express-zod-api/src/testing.ts
+++ b/express-zod-api/src/testing.ts
@@ -137,15 +137,14 @@ export const testMiddleware = async <
   /** @desc The aggregated returns of previously executed middlewares */
   ctx?: FlatObject;
 }) => {
-  const {
-    configMock: { inputSources, errorHandler = defaultResultHandler },
-    ...mocks
-  } = makeTestingMocks(rest);
+  const { configMock, ...mocks } = makeTestingMocks(rest);
+  const { inputSources, errorHandler = defaultResultHandler } = configMock;
   const input = getInput(mocks.requestMock, inputSources);
   const commons = {
     request: mocks.requestMock,
     response: mocks.responseMock,
     logger: mocks.loggerMock,
+    config: configMock,
     input,
     ctx,
   };

--- a/express-zod-api/tests/__snapshots__/env.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/env.spec.ts.snap
@@ -1,6 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodEmail' definition 1`] = `
+exports[`Environment checks > Zod > Metadata > meta() merge, not just overrides 1`] = `
+{
+  "description": "some",
+  "examples": [
+    "test",
+  ],
+  "title": "last",
+}
+`;
+
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodEmail' definition 1`] = `
 {
   "bag": {
     "format": "email",
@@ -39,7 +49,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodEmai
 }
 `;
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumber' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumber' definition 1`] = `
 {
   "bag": {
     "format": "safeint",
@@ -76,7 +86,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumb
 }
 `;
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumberFormat' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 1`] = `
 {
   "bag": {
     "format": "safeint",
@@ -112,7 +122,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumb
 }
 `;
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumberFormat' definition 2`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 2`] = `
 {
   "bag": {
     "format": "int32",
@@ -148,7 +158,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumb
 }
 `;
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumberFormat' definition 3`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 3`] = `
 {
   "bag": {
     "format": "safeint",
@@ -193,7 +203,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodNumb
 }
 `;
 
-exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodString' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodString' definition 1`] = `
 {
   "bag": {
     "format": "email",
@@ -231,7 +241,7 @@ exports[`Environment checks > Zod checks/refinements > Snapshot control 'ZodStri
 }
 `;
 
-exports[`Environment checks > Zod imperfections > circular object schema has no sign of getter in its shape 1`] = `
+exports[`Environment checks > Zod > imperfections > circular object schema has no sign of getter in its shape 1`] = `
 {
   "features": {
     "configurable": true,
@@ -270,21 +280,21 @@ exports[`Environment checks > Zod imperfections > circular object schema has no 
 }
 `;
 
-exports[`Environment checks > Zod imperfections > z.coerce and z.preprocess have no effect on JSON schema depiction 0 1`] = `
+exports[`Environment checks > Zod > imperfections > z.coerce and z.preprocess have no effect on JSON schema depiction 0 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "number",
 }
 `;
 
-exports[`Environment checks > Zod imperfections > z.coerce and z.preprocess have no effect on JSON schema depiction 1 1`] = `
+exports[`Environment checks > Zod > imperfections > z.coerce and z.preprocess have no effect on JSON schema depiction 1 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "number",
 }
 `;
 
-exports[`Environment checks > Zod new features > input examples of transformations 1`] = `
+exports[`Environment checks > Zod > input examples of transformations 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "examples": [
@@ -294,17 +304,7 @@ exports[`Environment checks > Zod new features > input examples of transformatio
 }
 `;
 
-exports[`Environment checks > Zod new features > meta() merge, not just overrides 1`] = `
-{
-  "description": "some",
-  "examples": [
-    "test",
-  ],
-  "title": "last",
-}
-`;
-
-exports[`Environment checks > Zod new features > output examples of transformations 1`] = `
+exports[`Environment checks > Zod > output examples of transformations 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "examples": [

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -403,30 +403,21 @@ describe("Common Helpers", () => {
   });
 
   describe("parseMaybeAsync()", () => {
-    test("should parse synchronously when the schema is synchronous", async () => {
+    test.each([
+      ["sync", { trySyncValidation: true }],
+      ["async", { trySyncValidation: false }],
+    ])("should parse %s", async (variant, cfg) => {
       const schema = z.object({ num: z.number() });
+      const parseSpy = vi.spyOn(schema, "parse");
       const asyncSpy = vi.spyOn(schema, "parseAsync");
       const result = await parseMaybeAsync(
         schema,
         { num: 123 },
-        { trySyncValidation: true, cors: false },
+        { cors: false, ...cfg },
       );
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
-      expect(asyncSpy).not.toHaveBeenCalled();
-    });
-
-    test("should use parseAsync when the sync validation is not enabled", async () => {
-      const schema = z.object({ num: z.number() });
-      const parseSpy = vi.spyOn(schema, "parse");
-      await expect(
-        parseMaybeAsync(
-          schema,
-          { num: 123 },
-          { trySyncValidation: false, cors: false },
-        ),
-      ).resolves.toEqual({ num: 123 });
-      expect(parseSpy).not.toHaveBeenCalled();
+      expect(variant === "sync" ? asyncSpy : parseSpy).not.toHaveBeenCalled();
     });
 
     test("should fall back to parseAsync for async refinements", async () => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -420,20 +420,31 @@ describe("Common Helpers", () => {
       expect(variant === "sync" ? asyncSpy : parseSpy).not.toHaveBeenCalled();
     });
 
-    test("should fall back to async when sync parsing met async cb", async () => {
-      const schema = z.object({ str: z.string() }).refine(async () => true);
-      const parseSpy = vi.spyOn(schema, "parse");
-      const asyncSpy = vi.spyOn(schema, "parseAsync");
-      await expect(
-        parseMaybeAsync(
-          schema,
-          { str: "test" },
-          { trySyncValidation: true, cors: false },
-        ),
-      ).resolves.toEqual({ str: "test" });
-      expect(parseSpy).toHaveBeenCalled();
-      expect(asyncSpy).toHaveBeenCalled();
-    });
+    test.each([
+      undefined,
+      { isAsync: false }, // should flip it
+    ])(
+      "should fall back to async when sync parsing met async cb %#",
+      async (state) => {
+        const schema = z.object({ str: z.string() }).refine(async () => true);
+        const parseSpy = vi.spyOn(schema, "parse");
+        const asyncSpy = vi.spyOn(schema, "parseAsync");
+        const attempt = () =>
+          parseMaybeAsync(
+            schema,
+            { str: "test" },
+            { trySyncValidation: true, cors: false },
+            state,
+          );
+        await expect(attempt()).resolves.toEqual({ str: "test" });
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        expect(asyncSpy).toHaveBeenCalledTimes(1);
+        if (state) expect(state.isAsync).toBe(true);
+        await attempt();
+        expect(parseSpy).toHaveBeenCalledTimes(state ? 1 : 2); // the state prevents another sync attempt
+        expect(asyncSpy).toHaveBeenCalledTimes(2);
+      },
+    );
 
     test.each([
       z.object({ num: z.number() }),
@@ -448,32 +459,6 @@ describe("Common Helpers", () => {
         ),
       ).rejects.toBeInstanceOf(z.ZodError);
       expect(asyncSpy).not.toHaveBeenCalled();
-    });
-
-    test("should set the state for an async schema and skip the sync attempt on the next call", async () => {
-      const schema = z.object({ str: z.string() }).refine(async () => true);
-      const parseSpy = vi.spyOn(schema, "parse");
-      const state = { isAsync: false };
-      await expect(
-        parseMaybeAsync(
-          schema,
-          { str: "test" },
-          { trySyncValidation: true, cors: false },
-          state,
-        ),
-      ).resolves.toEqual({ str: "test" });
-      expect(parseSpy).toHaveBeenCalledTimes(1); // the futile sync attempt
-      expect(state.isAsync).toBe(true);
-      parseSpy.mockClear();
-      await expect(
-        parseMaybeAsync(
-          schema,
-          { str: "again" },
-          { trySyncValidation: true, cors: false },
-          state,
-        ),
-      ).resolves.toEqual({ str: "again" });
-      expect(parseSpy).not.toHaveBeenCalled(); // straight to parseAsync
     });
   });
 

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -410,11 +410,7 @@ describe("Common Helpers", () => {
       const schema = z.object({ num: z.number() });
       const parseSpy = vi.spyOn(schema, "parse");
       const asyncSpy = vi.spyOn(schema, "parseAsync");
-      const result = await parseMaybeAsync(
-        schema,
-        { num: 123 },
-        { cors: false, ...cfg },
-      );
+      const result = await parseMaybeAsync(schema, { num: 123 }, cfg);
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
       expect(variant === "sync" ? asyncSpy : parseSpy).not.toHaveBeenCalled();
@@ -433,7 +429,7 @@ describe("Common Helpers", () => {
           parseMaybeAsync(
             schema,
             { str: "test" },
-            { trySyncValidation: true, cors: false },
+            { trySyncValidation: true },
             state,
           );
         await expect(attempt()).resolves.toEqual({ str: "test" });
@@ -452,11 +448,7 @@ describe("Common Helpers", () => {
     ])("should rethrow validation errors", async (schema) => {
       const asyncSpy = vi.spyOn(schema, "parseAsync");
       await expect(
-        parseMaybeAsync(
-          schema,
-          { num: "test" },
-          { trySyncValidation: true, cors: false },
-        ),
+        parseMaybeAsync(schema, { num: "test" }, { trySyncValidation: true }),
       ).rejects.toBeInstanceOf(z.ZodError);
       expect(asyncSpy).not.toHaveBeenCalled();
     });

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -405,7 +405,14 @@ describe("Common Helpers", () => {
   describe("parseMaybeAsync()", () => {
     test("should parse synchronously when the schema is synchronous", async () => {
       const schema = z.object({ num: z.number() });
-      const result = await parseMaybeAsync(schema, { num: 123 }, true);
+      const result = await parseMaybeAsync(
+        schema,
+        { num: 123 },
+        {
+          trySyncValidation: true,
+          cors: false,
+        },
+      );
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
     });
@@ -414,7 +421,11 @@ describe("Common Helpers", () => {
       const schema = z.object({ num: z.number() });
       const parseSpy = vi.spyOn(schema, "parse");
       await expect(
-        parseMaybeAsync(schema, { num: 123 }, false),
+        parseMaybeAsync(
+          schema,
+          { num: 123 },
+          { trySyncValidation: false, cors: false },
+        ),
       ).resolves.toEqual({ num: 123 });
       expect(parseSpy).not.toHaveBeenCalled();
     });
@@ -422,14 +433,22 @@ describe("Common Helpers", () => {
     test("should fall back to parseAsync for async refinements", async () => {
       const schema = z.object({ str: z.string() }).refine(async () => true);
       await expect(
-        parseMaybeAsync(schema, { str: "test" }, true),
+        parseMaybeAsync(
+          schema,
+          { str: "test" },
+          { trySyncValidation: true, cors: false },
+        ),
       ).resolves.toEqual({ str: "test" });
     });
 
     test("should throw a ZodError on a synchronous validation failure", async () => {
       const schema = z.object({ num: z.number() });
       await expect(
-        parseMaybeAsync(schema, { num: "test" }, true),
+        parseMaybeAsync(
+          schema,
+          { num: "test" },
+          { trySyncValidation: true, cors: false },
+        ),
       ).rejects.toBeInstanceOf(z.ZodError);
     });
 
@@ -439,7 +458,11 @@ describe("Common Helpers", () => {
         .refine(() => true, "custom issue");
       const spy = vi.spyOn(schema, "parseAsync");
       await expect(
-        parseMaybeAsync(schema, { num: "test" }, true),
+        parseMaybeAsync(
+          schema,
+          { num: "test" },
+          { trySyncValidation: true, cors: false },
+        ),
       ).rejects.toBeInstanceOf(z.ZodError);
       expect(spy).not.toHaveBeenCalled();
     });
@@ -449,13 +472,23 @@ describe("Common Helpers", () => {
       const parseSpy = vi.spyOn(schema, "parse");
       const state = { isAsync: false };
       await expect(
-        parseMaybeAsync(schema, { str: "test" }, true, state),
+        parseMaybeAsync(
+          schema,
+          { str: "test" },
+          { trySyncValidation: true, cors: false },
+          state,
+        ),
       ).resolves.toEqual({ str: "test" });
       expect(parseSpy).toHaveBeenCalledTimes(1); // the futile sync attempt
       expect(state.isAsync).toBe(true);
       parseSpy.mockClear();
       await expect(
-        parseMaybeAsync(schema, { str: "again" }, true, state),
+        parseMaybeAsync(
+          schema,
+          { str: "again" },
+          { trySyncValidation: true, cors: false },
+          state,
+        ),
       ).resolves.toEqual({ str: "again" });
       expect(parseSpy).not.toHaveBeenCalled(); // straight to parseAsync
     });

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -402,7 +402,7 @@ describe("Common Helpers", () => {
     });
   });
 
-  describe("parseBySchema()", () => {
+  describe("parseMaybeAsync()", () => {
     test("should parse synchronously when the schema is synchronous", async () => {
       const schema = z.object({ num: z.number() });
       const result = await parseMaybeAsync(schema, { num: 123 });

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -11,6 +11,7 @@ import {
   shouldHaveContent,
   getInputSources,
   emptySchema,
+  parseMaybeAsync,
   type EmptySchema,
   type EmptyObject,
   type FlatObject,
@@ -398,6 +399,40 @@ describe("Common Helpers", () => {
       expect(result).toHaveProperty("message");
       expect(typeof result.message).toBe("string");
       expect(result.message).toBe(expected);
+    });
+  });
+
+  describe("parseBySchema()", () => {
+    test("should parse synchronously when the schema is synchronous", async () => {
+      const schema = z.object({ num: z.number() });
+      const result = await parseMaybeAsync(schema, { num: 123 });
+      expectTypeOf(result).toEqualTypeOf<{ num: number }>();
+      expect(result).toEqual({ num: 123 });
+    });
+
+    test("should fall back to parseAsync for async refinements", async () => {
+      const schema = z.object({ str: z.string() }).refine(async () => true);
+      await expect(parseMaybeAsync(schema, { str: "test" })).resolves.toEqual({
+        str: "test",
+      });
+    });
+
+    test("should throw a ZodError on a synchronous validation failure", async () => {
+      const schema = z.object({ num: z.number() });
+      await expect(
+        parseMaybeAsync(schema, { num: "test" }),
+      ).rejects.toBeInstanceOf(z.ZodError);
+    });
+
+    test("should NOT retry with parseAsync on a non-async validation failure", async () => {
+      const schema = z
+        .object({ num: z.number() })
+        .refine(() => true, "custom issue");
+      const spy = vi.spyOn(schema, "parseAsync");
+      await expect(
+        parseMaybeAsync(schema, { num: "test" }),
+      ).rejects.toBeInstanceOf(z.ZodError);
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -447,12 +447,12 @@ describe("Common Helpers", () => {
     test("should set the state for an async schema and skip the sync attempt on the next call", async () => {
       const schema = z.object({ str: z.string() }).refine(async () => true);
       const parseSpy = vi.spyOn(schema, "parse");
-      const state = { syncImpossible: false };
+      const state = { isAsync: false };
       await expect(
         parseMaybeAsync(schema, { str: "test" }, true, state),
       ).resolves.toEqual({ str: "test" });
       expect(parseSpy).toHaveBeenCalledTimes(1); // the futile sync attempt
-      expect(state.syncImpossible).toBe(true);
+      expect(state.isAsync).toBe(true);
       parseSpy.mockClear();
       await expect(
         parseMaybeAsync(schema, { str: "again" }, true, state),

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -405,22 +405,31 @@ describe("Common Helpers", () => {
   describe("parseMaybeAsync()", () => {
     test("should parse synchronously when the schema is synchronous", async () => {
       const schema = z.object({ num: z.number() });
-      const result = await parseMaybeAsync(schema, { num: 123 });
+      const result = await parseMaybeAsync(schema, { num: 123 }, true);
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
     });
 
+    test("should use parseAsync when the sync validation is not enabled", async () => {
+      const schema = z.object({ num: z.number() });
+      const parseSpy = vi.spyOn(schema, "parse");
+      await expect(
+        parseMaybeAsync(schema, { num: 123 }, false),
+      ).resolves.toEqual({ num: 123 });
+      expect(parseSpy).not.toHaveBeenCalled();
+    });
+
     test("should fall back to parseAsync for async refinements", async () => {
       const schema = z.object({ str: z.string() }).refine(async () => true);
-      await expect(parseMaybeAsync(schema, { str: "test" })).resolves.toEqual({
-        str: "test",
-      });
+      await expect(
+        parseMaybeAsync(schema, { str: "test" }, true),
+      ).resolves.toEqual({ str: "test" });
     });
 
     test("should throw a ZodError on a synchronous validation failure", async () => {
       const schema = z.object({ num: z.number() });
       await expect(
-        parseMaybeAsync(schema, { num: "test" }),
+        parseMaybeAsync(schema, { num: "test" }, true),
       ).rejects.toBeInstanceOf(z.ZodError);
     });
 
@@ -430,7 +439,7 @@ describe("Common Helpers", () => {
         .refine(() => true, "custom issue");
       const spy = vi.spyOn(schema, "parseAsync");
       await expect(
-        parseMaybeAsync(schema, { num: "test" }),
+        parseMaybeAsync(schema, { num: "test" }, true),
       ).rejects.toBeInstanceOf(z.ZodError);
       expect(spy).not.toHaveBeenCalled();
     });
@@ -440,13 +449,13 @@ describe("Common Helpers", () => {
       const parseSpy = vi.spyOn(schema, "parse");
       const state = { syncImpossible: false };
       await expect(
-        parseMaybeAsync(schema, { str: "test" }, state),
+        parseMaybeAsync(schema, { str: "test" }, true, state),
       ).resolves.toEqual({ str: "test" });
       expect(parseSpy).toHaveBeenCalledTimes(1); // the futile sync attempt
       expect(state.syncImpossible).toBe(true);
       parseSpy.mockClear();
       await expect(
-        parseMaybeAsync(schema, { str: "again" }, state),
+        parseMaybeAsync(schema, { str: "again" }, true, state),
       ).resolves.toEqual({ str: "again" });
       expect(parseSpy).not.toHaveBeenCalled(); // straight to parseAsync
     });

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -405,16 +405,15 @@ describe("Common Helpers", () => {
   describe("parseMaybeAsync()", () => {
     test("should parse synchronously when the schema is synchronous", async () => {
       const schema = z.object({ num: z.number() });
+      const asyncSpy = vi.spyOn(schema, "parseAsync");
       const result = await parseMaybeAsync(
         schema,
         { num: 123 },
-        {
-          trySyncValidation: true,
-          cors: false,
-        },
+        { trySyncValidation: true, cors: false },
       );
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
+      expect(asyncSpy).not.toHaveBeenCalled();
     });
 
     test("should use parseAsync when the sync validation is not enabled", async () => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -406,7 +406,7 @@ describe("Common Helpers", () => {
     test.each([
       ["sync", { trySyncValidation: true }],
       ["async", { trySyncValidation: false }],
-    ])("should parse %s", async (variant, cfg) => {
+    ])("should parse %s depending on config", async (variant, cfg) => {
       const schema = z.object({ num: z.number() });
       const parseSpy = vi.spyOn(schema, "parse");
       const asyncSpy = vi.spyOn(schema, "parseAsync");
@@ -420,8 +420,10 @@ describe("Common Helpers", () => {
       expect(variant === "sync" ? asyncSpy : parseSpy).not.toHaveBeenCalled();
     });
 
-    test("should fall back to parseAsync for async refinements", async () => {
+    test("should fall back to async when sync parsing met async cb", async () => {
       const schema = z.object({ str: z.string() }).refine(async () => true);
+      const parseSpy = vi.spyOn(schema, "parse");
+      const asyncSpy = vi.spyOn(schema, "parseAsync");
       await expect(
         parseMaybeAsync(
           schema,
@@ -429,6 +431,8 @@ describe("Common Helpers", () => {
           { trySyncValidation: true, cors: false },
         ),
       ).resolves.toEqual({ str: "test" });
+      expect(parseSpy).toHaveBeenCalled();
+      expect(asyncSpy).toHaveBeenCalled();
     });
 
     test("should throw a ZodError on a synchronous validation failure", async () => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -434,6 +434,22 @@ describe("Common Helpers", () => {
       ).rejects.toBeInstanceOf(z.ZodError);
       expect(spy).not.toHaveBeenCalled();
     });
+
+    test("should set the state for an async schema and skip the sync attempt on the next call", async () => {
+      const schema = z.object({ str: z.string() }).refine(async () => true);
+      const parseSpy = vi.spyOn(schema, "parse");
+      const state = { syncImpossible: false };
+      await expect(
+        parseMaybeAsync(schema, { str: "test" }, state),
+      ).resolves.toEqual({ str: "test" });
+      expect(parseSpy).toHaveBeenCalledTimes(1); // the futile sync attempt
+      expect(state.syncImpossible).toBe(true);
+      parseSpy.mockClear();
+      await expect(
+        parseMaybeAsync(schema, { str: "again" }, state),
+      ).resolves.toEqual({ str: "again" });
+      expect(parseSpy).not.toHaveBeenCalled(); // straight to parseAsync
+    });
   });
 
   describe("makeCleanId()", () => {

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -435,8 +435,11 @@ describe("Common Helpers", () => {
       expect(asyncSpy).toHaveBeenCalled();
     });
 
-    test("should throw a ZodError on a synchronous validation failure", async () => {
-      const schema = z.object({ num: z.number() });
+    test.each([
+      z.object({ num: z.number() }),
+      z.object({ num: z.number() }).refine(() => true), // doesn't get into refinement
+    ])("should rethrow validation errors", async (schema) => {
+      const asyncSpy = vi.spyOn(schema, "parseAsync");
       await expect(
         parseMaybeAsync(
           schema,
@@ -444,21 +447,7 @@ describe("Common Helpers", () => {
           { trySyncValidation: true, cors: false },
         ),
       ).rejects.toBeInstanceOf(z.ZodError);
-    });
-
-    test("should NOT retry with parseAsync on a non-async validation failure", async () => {
-      const schema = z
-        .object({ num: z.number() })
-        .refine(() => true, "custom issue");
-      const spy = vi.spyOn(schema, "parseAsync");
-      await expect(
-        parseMaybeAsync(
-          schema,
-          { num: "test" },
-          { trySyncValidation: true, cors: false },
-        ),
-      ).rejects.toBeInstanceOf(z.ZodError);
-      expect(spy).not.toHaveBeenCalled();
+      expect(asyncSpy).not.toHaveBeenCalled();
     });
 
     test("should set the state for an async schema and skip the sync attempt on the next call", async () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -501,51 +501,63 @@ describe("Endpoint", () => {
   });
 
   describe("Issue #269: Async refinements", () => {
-    test.each([{ trySyncValidation: false }, { trySyncValidation: true }])(
-      "should handle async refinements with %s config",
-      async (configProps) => {
-        const mwRefinement = vi.fn(async (m: number) => m < 10);
-        const inputRefinement = vi.fn(async (n: number) => n > 100);
-        const outputRefinement = vi.fn(async (str: string) => str.length > 3);
-        const endpoint = new EndpointsFactory(defaultResultHandler)
-          .addMiddleware({
-            input: z.object({ m: z.number().refine(mwRefinement) }),
-            handler: async () => ({}),
-          })
-          .build({
-            method: "post",
-            input: z.object({ n: z.number().refine(inputRefinement) }),
-            output: z.object({ str: z.string().refine(outputRefinement) }),
-            handler: async () => ({ str: "This is fine" }),
+    const mwRefinement = vi.fn(async (m: number) => m < 10);
+    const inputRefinement = vi.fn(async (n: number) => n > 100);
+    const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+    const mwInput = z.object({ m: z.number().refine(mwRefinement) });
+    const epInput = z.object({ n: z.number().refine(inputRefinement) });
+    const epOutput = z.object({ str: z.string().refine(outputRefinement) });
+
+    beforeEach(() => {
+      mwRefinement.mockClear();
+      inputRefinement.mockClear();
+      outputRefinement.mockClear();
+    });
+
+    describe.each(["plain", "compiled"] as const)("%s schemas", (variant) => {
+      test.each([{ trySyncValidation: false }, { trySyncValidation: true }])(
+        "should handle async refinements with %s config",
+        async (configProps) => {
+          const endpoint = new EndpointsFactory(defaultResultHandler)
+            .addMiddleware({
+              input: variant === "plain" ? mwInput : z.compile(mwInput),
+              handler: async () => ({}),
+            })
+            .build({
+              method: "post",
+              input: variant === "plain" ? epInput : z.compile(epInput),
+              output: variant === "plain" ? epOutput : z.compile(epOutput),
+              handler: async () => ({ str: "This is fine" }),
+            });
+          const attempt = () =>
+            testEndpoint({
+              endpoint,
+              requestProps: { method: "POST", body: { n: 123, m: 5 } },
+              configProps,
+            });
+          const { responseMock } = await attempt();
+          expect(responseMock._getJSONData()).toEqual({
+            status: "success",
+            data: { str: "This is fine" },
           });
-        const attempt = () =>
-          testEndpoint({
-            endpoint,
-            requestProps: { method: "POST", body: { n: 123, m: 5 } },
-            configProps,
-          });
-        const { responseMock } = await attempt();
-        expect(responseMock._getJSONData()).toEqual({
-          status: "success",
-          data: { str: "This is fine" },
-        });
-        expect(mwRefinement).toHaveBeenCalledTimes(
-          configProps.trySyncValidation ? 4 : 2,
-        );
-        expect(inputRefinement).toHaveBeenCalledTimes(1);
-        expect(outputRefinement).toHaveBeenCalledTimes(
-          configProps.trySyncValidation ? 2 : 1,
-        );
-        await attempt();
-        expect(mwRefinement).toHaveBeenCalledTimes(
-          configProps.trySyncValidation ? 6 : 4,
-        );
-        expect(inputRefinement).toHaveBeenCalledTimes(2);
-        expect(outputRefinement).toHaveBeenCalledTimes(
-          configProps.trySyncValidation ? 3 : 2,
-        );
-      },
-    );
+          expect(mwRefinement).toHaveBeenCalledTimes(
+            configProps.trySyncValidation ? 4 : 2,
+          );
+          expect(inputRefinement).toHaveBeenCalledTimes(1);
+          expect(outputRefinement).toHaveBeenCalledTimes(
+            configProps.trySyncValidation ? 2 : 1,
+          );
+          await attempt();
+          expect(mwRefinement).toHaveBeenCalledTimes(
+            configProps.trySyncValidation ? 6 : 4,
+          );
+          expect(inputRefinement).toHaveBeenCalledTimes(2);
+          expect(outputRefinement).toHaveBeenCalledTimes(
+            configProps.trySyncValidation ? 3 : 2,
+          );
+        },
+      );
+    });
   });
 
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -533,6 +533,45 @@ describe("Endpoint", () => {
         data: { str: "This is fine" },
       });
     });
+
+    test("should handle compiled schemas with async refinements", async () => {
+      const endpoint = defaultEndpointsFactory
+        .addMiddleware({
+          input: z.compile(
+            z.object({
+              m: z.number().refine(async (m) => m < 10),
+            }),
+          ),
+          handler: async () => ({}),
+        })
+        .build({
+          method: "post",
+          input: z.compile(
+            z.object({
+              n: z.number().refine(async (n) => n > 100),
+            }),
+          ),
+          output: z.compile(
+            z.object({
+              str: z.string().refine(async (str) => str.length > 3),
+            }),
+          ),
+          handler: async () => ({
+            str: "This is fine",
+          }),
+        });
+      const { responseMock } = await testEndpoint({
+        endpoint,
+        requestProps: {
+          method: "POST",
+          body: { n: 123, m: 5 },
+        },
+      });
+      expect(responseMock._getJSONData()).toEqual({
+        status: "success",
+        data: { str: "This is fine" },
+      });
+    });
   });
 
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -584,6 +584,38 @@ describe("Endpoint", () => {
         expect(outputRefinement).toHaveBeenCalledTimes(outputRefineCalls);
       },
     );
+
+    test("should skip the sync attempts for schemas already found to be async", async () => {
+      const mwRefinement = vi.fn(async (m: number) => m < 10);
+      const inputRefinement = vi.fn(async (n: number) => n > 100);
+      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+      const endpoint = buildAsyncRefinedEndpoint(
+        false,
+        mwRefinement,
+        inputRefinement,
+        outputRefinement,
+      );
+      const requestProps = {
+        method: "POST" as const,
+        body: { n: 123, m: 5 },
+      };
+      await testEndpoint({
+        endpoint,
+        configProps: { trySyncValidation: true },
+        requestProps,
+      });
+      expect(mwRefinement).toHaveBeenCalledTimes(4); // double execution on the first request
+      expect(inputRefinement).toHaveBeenCalledTimes(1);
+      expect(outputRefinement).toHaveBeenCalledTimes(2);
+      await testEndpoint({
+        endpoint,
+        configProps: { trySyncValidation: true },
+        requestProps,
+      });
+      expect(mwRefinement).toHaveBeenCalledTimes(6); // only 2 more calls on the second request
+      expect(inputRefinement).toHaveBeenCalledTimes(2);
+      expect(outputRefinement).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -501,77 +501,89 @@ describe("Endpoint", () => {
   });
 
   describe("Issue #269: Async refinements", () => {
-    test("should handle async refinements in input, output and middleware", async () => {
-      const endpoint = new EndpointsFactory(defaultResultHandler)
+    const buildAsyncRefinedEndpoint = (
+      shouldCompile: boolean,
+      mwRefinement: (m: number) => Promise<boolean>,
+      inputRefinement: (n: number) => Promise<boolean>,
+      outputRefinement: (str: string) => Promise<boolean>,
+    ) => {
+      const wrapper = <T extends z.ZodType>(schema: T) =>
+        shouldCompile ? z.compile(schema) : schema;
+      return new EndpointsFactory(defaultResultHandler)
         .addMiddleware({
-          input: z.object({
-            m: z.number().refine(async (m) => m < 10),
-          }),
+          input: wrapper(z.object({ m: z.number().refine(mwRefinement) })),
           handler: async () => ({}),
         })
         .build({
           method: "post",
-          input: z.object({
-            n: z.number().refine(async (n) => n > 100),
-          }),
-          output: z.object({
-            str: z.string().refine(async (str) => str.length > 3),
-          }),
-          handler: async () => ({
-            str: "This is fine",
-          }),
+          input: wrapper(z.object({ n: z.number().refine(inputRefinement) })),
+          output: wrapper(
+            z.object({
+              str: z.string().refine(outputRefinement),
+            }),
+          ),
+          handler: async () => ({ str: "This is fine" }),
         });
-      const { responseMock } = await testEndpoint({
-        endpoint,
-        requestProps: {
-          method: "POST",
-          body: { n: 123, m: 5 },
-        },
-      });
-      expect(responseMock._getJSONData()).toEqual({
-        status: "success",
-        data: { str: "This is fine" },
-      });
-    });
+    };
 
-    test("should handle compiled schemas with async refinements", async () => {
-      const endpoint = defaultEndpointsFactory
-        .addMiddleware({
-          input: z.compile(
-            z.object({
-              m: z.number().refine(async (m) => m < 10),
-            }),
+    test.each([
+      {
+        name: "plain schemas, single execution via parseAsync",
+        shouldCompile: false,
+        mwRefineCalls: 2, // Middleware::execute(), Endpoint::execute()
+        inputRefineCalls: 1,
+        outputRefineCalls: 1,
+      },
+      {
+        name: "plain schemas with trySyncValidation enabled",
+        shouldCompile: false,
+        configProps: { trySyncValidation: true },
+        mwRefineCalls: 4, // Middleware::execute() x2, Endpoint::execute() x2
+        inputRefineCalls: 1, // hits Middlewares async during Endpoint::execute()
+        outputRefineCalls: 2, // Endpoint::execute() x2
+      },
+      {
+        name: "compiled schemas with trySyncValidation enabled",
+        shouldCompile: true,
+        configProps: { trySyncValidation: true },
+        mwRefineCalls: 4, // Middleware::execute() x2, Endpoint::execute() x2
+        inputRefineCalls: 1, // hits Middlewares async during Endpoint::execute()
+        outputRefineCalls: 2, // Endpoint::execute() x2
+      },
+    ])(
+      "should handle async refinements for $name",
+      async ({
+        shouldCompile,
+        configProps,
+        mwRefineCalls,
+        inputRefineCalls,
+        outputRefineCalls,
+      }) => {
+        const mwRefinement = vi.fn(async (m: number) => m < 10);
+        const inputRefinement = vi.fn(async (n: number) => n > 100);
+        const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+        const { responseMock } = await testEndpoint({
+          endpoint: buildAsyncRefinedEndpoint(
+            shouldCompile,
+            mwRefinement,
+            inputRefinement,
+            outputRefinement,
           ),
-          handler: async () => ({}),
-        })
-        .build({
-          method: "post",
-          input: z.compile(
-            z.object({
-              n: z.number().refine(async (n) => n > 100),
-            }),
-          ),
-          output: z.compile(
-            z.object({
-              str: z.string().refine(async (str) => str.length > 3),
-            }),
-          ),
-          handler: async () => ({
-            str: "This is fine",
-          }),
+          configProps,
+          requestProps: {
+            method: "POST",
+            body: { n: 123, m: 5 },
+          },
         });
-      const { responseMock } = await testEndpoint({
-        endpoint,
-        requestProps: {
-          method: "POST",
-          body: { n: 123, m: 5 },
-        },
-      });
-      expect(responseMock._getJSONData()).toEqual({
-        status: "success",
-        data: { str: "This is fine" },
-      });
-    });
+        expect(responseMock._getJSONData()).toEqual({
+          status: "success",
+          data: { str: "This is fine" },
+        });
+        expect(mwRefinement).toHaveBeenCalledTimes(mwRefineCalls);
+        expect(inputRefinement).toHaveBeenCalledTimes(inputRefineCalls);
+        expect(outputRefinement).toHaveBeenCalledTimes(outputRefineCalls);
+      },
+    );
   });
 
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -526,64 +526,56 @@ describe("Endpoint", () => {
         });
     };
 
-    test.each([
-      {
-        name: "plain schemas, single execution via parseAsync",
-        shouldCompile: false,
-        mwRefineCalls: 2, // Middleware::execute(), Endpoint::execute()
-        inputRefineCalls: 1,
-        outputRefineCalls: 1,
-      },
-      {
-        name: "plain schemas with trySyncValidation enabled",
-        shouldCompile: false,
+    test("should handle async refinements in the input and output schemas", async () => {
+      const mwRefinement = vi.fn(async (m: number) => m < 10);
+      const inputRefinement = vi.fn(async (n: number) => n > 100);
+      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+      const { responseMock } = await testEndpoint({
+        endpoint: buildAsyncRefinedEndpoint(
+          false,
+          mwRefinement,
+          inputRefinement,
+          outputRefinement,
+        ),
+        requestProps: {
+          method: "POST",
+          body: { n: 123, m: 5 },
+        },
+      });
+      expect(responseMock._getJSONData()).toEqual({
+        status: "success",
+        data: { str: "This is fine" },
+      });
+      expect(mwRefinement).toHaveBeenCalledTimes(2); // Middleware::execute(), Endpoint::execute()
+      expect(inputRefinement).toHaveBeenCalledTimes(1);
+      expect(outputRefinement).toHaveBeenCalledTimes(1);
+    });
+
+    test("should handle async refinements in compiled schemas with trySyncValidation", async () => {
+      const mwRefinement = vi.fn(async (m: number) => m < 10);
+      const inputRefinement = vi.fn(async (n: number) => n > 100);
+      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+      const { responseMock } = await testEndpoint({
+        endpoint: buildAsyncRefinedEndpoint(
+          true,
+          mwRefinement,
+          inputRefinement,
+          outputRefinement,
+        ),
         configProps: { trySyncValidation: true },
-        mwRefineCalls: 4, // Middleware::execute() x2, Endpoint::execute() x2
-        inputRefineCalls: 1, // hits Middlewares async during Endpoint::execute()
-        outputRefineCalls: 2, // Endpoint::execute() x2
-      },
-      {
-        name: "compiled schemas with trySyncValidation enabled",
-        shouldCompile: true,
-        configProps: { trySyncValidation: true },
-        mwRefineCalls: 4, // Middleware::execute() x2, Endpoint::execute() x2
-        inputRefineCalls: 1, // hits Middlewares async during Endpoint::execute()
-        outputRefineCalls: 2, // Endpoint::execute() x2
-      },
-    ])(
-      "should handle async refinements for $name",
-      async ({
-        shouldCompile,
-        configProps,
-        mwRefineCalls,
-        inputRefineCalls,
-        outputRefineCalls,
-      }) => {
-        const mwRefinement = vi.fn(async (m: number) => m < 10);
-        const inputRefinement = vi.fn(async (n: number) => n > 100);
-        const outputRefinement = vi.fn(async (str: string) => str.length > 3);
-        const { responseMock } = await testEndpoint({
-          endpoint: buildAsyncRefinedEndpoint(
-            shouldCompile,
-            mwRefinement,
-            inputRefinement,
-            outputRefinement,
-          ),
-          configProps,
-          requestProps: {
-            method: "POST",
-            body: { n: 123, m: 5 },
-          },
-        });
-        expect(responseMock._getJSONData()).toEqual({
-          status: "success",
-          data: { str: "This is fine" },
-        });
-        expect(mwRefinement).toHaveBeenCalledTimes(mwRefineCalls);
-        expect(inputRefinement).toHaveBeenCalledTimes(inputRefineCalls);
-        expect(outputRefinement).toHaveBeenCalledTimes(outputRefineCalls);
-      },
-    );
+        requestProps: {
+          method: "POST",
+          body: { n: 123, m: 5 },
+        },
+      });
+      expect(responseMock._getJSONData()).toEqual({
+        status: "success",
+        data: { str: "This is fine" },
+      });
+      expect(mwRefinement).toHaveBeenCalledTimes(4); // Middleware::execute() x2, Endpoint::execute() x2
+      expect(inputRefinement).toHaveBeenCalledTimes(1); // hits Middlewares async during Endpoint::execute()
+      expect(outputRefinement).toHaveBeenCalledTimes(2); // Endpoint::execute() x2
+    });
 
     test("should skip the sync attempts for schemas already found to be async", async () => {
       const mwRefinement = vi.fn(async (m: number) => m < 10);

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -501,113 +501,51 @@ describe("Endpoint", () => {
   });
 
   describe("Issue #269: Async refinements", () => {
-    const buildAsyncRefinedEndpoint = (
-      shouldCompile: boolean,
-      mwRefinement: (m: number) => Promise<boolean>,
-      inputRefinement: (n: number) => Promise<boolean>,
-      outputRefinement: (str: string) => Promise<boolean>,
-    ) => {
-      const wrapper = <T extends z.ZodType>(schema: T) =>
-        shouldCompile ? z.compile(schema) : schema;
-      return new EndpointsFactory(defaultResultHandler)
-        .addMiddleware({
-          input: wrapper(z.object({ m: z.number().refine(mwRefinement) })),
-          handler: async () => ({}),
-        })
-        .build({
-          method: "post",
-          input: wrapper(z.object({ n: z.number().refine(inputRefinement) })),
-          output: wrapper(
-            z.object({
-              str: z.string().refine(outputRefinement),
-            }),
-          ),
-          handler: async () => ({ str: "This is fine" }),
+    test.each([{ trySyncValidation: false }, { trySyncValidation: true }])(
+      "should handle async refinements with %s config",
+      async (configProps) => {
+        const mwRefinement = vi.fn(async (m: number) => m < 10);
+        const inputRefinement = vi.fn(async (n: number) => n > 100);
+        const outputRefinement = vi.fn(async (str: string) => str.length > 3);
+        const endpoint = new EndpointsFactory(defaultResultHandler)
+          .addMiddleware({
+            input: z.object({ m: z.number().refine(mwRefinement) }),
+            handler: async () => ({}),
+          })
+          .build({
+            method: "post",
+            input: z.object({ n: z.number().refine(inputRefinement) }),
+            output: z.object({ str: z.string().refine(outputRefinement) }),
+            handler: async () => ({ str: "This is fine" }),
+          });
+        const attempt = () =>
+          testEndpoint({
+            endpoint,
+            requestProps: { method: "POST", body: { n: 123, m: 5 } },
+            configProps,
+          });
+        const { responseMock } = await attempt();
+        expect(responseMock._getJSONData()).toEqual({
+          status: "success",
+          data: { str: "This is fine" },
         });
-    };
-
-    test("should handle async refinements in the input and output schemas", async () => {
-      const mwRefinement = vi.fn(async (m: number) => m < 10);
-      const inputRefinement = vi.fn(async (n: number) => n > 100);
-      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
-      const { responseMock } = await testEndpoint({
-        endpoint: buildAsyncRefinedEndpoint(
-          false,
-          mwRefinement,
-          inputRefinement,
-          outputRefinement,
-        ),
-        requestProps: {
-          method: "POST",
-          body: { n: 123, m: 5 },
-        },
-      });
-      expect(responseMock._getJSONData()).toEqual({
-        status: "success",
-        data: { str: "This is fine" },
-      });
-      expect(mwRefinement).toHaveBeenCalledTimes(2); // Middleware::execute(), Endpoint::execute()
-      expect(inputRefinement).toHaveBeenCalledTimes(1);
-      expect(outputRefinement).toHaveBeenCalledTimes(1);
-    });
-
-    test("should handle async refinements in compiled schemas with trySyncValidation", async () => {
-      const mwRefinement = vi.fn(async (m: number) => m < 10);
-      const inputRefinement = vi.fn(async (n: number) => n > 100);
-      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
-      const { responseMock } = await testEndpoint({
-        endpoint: buildAsyncRefinedEndpoint(
-          true,
-          mwRefinement,
-          inputRefinement,
-          outputRefinement,
-        ),
-        configProps: { trySyncValidation: true },
-        requestProps: {
-          method: "POST",
-          body: { n: 123, m: 5 },
-        },
-      });
-      expect(responseMock._getJSONData()).toEqual({
-        status: "success",
-        data: { str: "This is fine" },
-      });
-      expect(mwRefinement).toHaveBeenCalledTimes(4); // Middleware::execute() x2, Endpoint::execute() x2
-      expect(inputRefinement).toHaveBeenCalledTimes(1); // hits Middlewares async during Endpoint::execute()
-      expect(outputRefinement).toHaveBeenCalledTimes(2); // Endpoint::execute() x2
-    });
-
-    test("should skip the sync attempts for schemas already found to be async", async () => {
-      const mwRefinement = vi.fn(async (m: number) => m < 10);
-      const inputRefinement = vi.fn(async (n: number) => n > 100);
-      const outputRefinement = vi.fn(async (str: string) => str.length > 3);
-      const endpoint = buildAsyncRefinedEndpoint(
-        false,
-        mwRefinement,
-        inputRefinement,
-        outputRefinement,
-      );
-      const requestProps = {
-        method: "POST" as const,
-        body: { n: 123, m: 5 },
-      };
-      await testEndpoint({
-        endpoint,
-        configProps: { trySyncValidation: true },
-        requestProps,
-      });
-      expect(mwRefinement).toHaveBeenCalledTimes(4); // double execution on the first request
-      expect(inputRefinement).toHaveBeenCalledTimes(1);
-      expect(outputRefinement).toHaveBeenCalledTimes(2);
-      await testEndpoint({
-        endpoint,
-        configProps: { trySyncValidation: true },
-        requestProps,
-      });
-      expect(mwRefinement).toHaveBeenCalledTimes(6); // only 2 more calls on the second request
-      expect(inputRefinement).toHaveBeenCalledTimes(2);
-      expect(outputRefinement).toHaveBeenCalledTimes(3);
-    });
+        expect(mwRefinement).toHaveBeenCalledTimes(
+          configProps.trySyncValidation ? 4 : 2,
+        );
+        expect(inputRefinement).toHaveBeenCalledTimes(1);
+        expect(outputRefinement).toHaveBeenCalledTimes(
+          configProps.trySyncValidation ? 2 : 1,
+        );
+        await attempt();
+        expect(mwRefinement).toHaveBeenCalledTimes(
+          configProps.trySyncValidation ? 6 : 4,
+        );
+        expect(inputRefinement).toHaveBeenCalledTimes(2);
+        expect(outputRefinement).toHaveBeenCalledTimes(
+          configProps.trySyncValidation ? 3 : 2,
+        );
+      },
+    );
   });
 
   describe("Issue #514: Express native middlewares for OPTIONS request", () => {

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -5,130 +5,137 @@ import { createRequire } from "node:module";
 import { METHODS } from "node:http";
 
 describe("Environment checks", () => {
-  describe("Zod global registry", () => {
-    test("is shared across both of its ESM and CJS packages", () => {
-      createRequire(import.meta.url)("zod");
-      const { globalRegistry } = createRequire(import.meta.url)("zod");
-      expect(globalRegistry).toBe(z.globalRegistry);
-    });
-  });
-
-  describe("Zod Dates", () => {
-    test.each(["2021-01-32", "22/01/2022", "2021-01-31T25:00:00.000Z"])(
-      "should detect invalid date %#",
-      (str) => {
-        expect(z.validate(z.date(), new Date(str))).toBeFalsy();
-        expect(z.validate(z.string().date(), str)).toBeFalsy();
-        expect(z.validate(z.string().datetime(), str)).toBeFalsy();
-        expect(z.validate(z.iso.date(), str)).toBeFalsy();
-        expect(z.validate(z.iso.datetime(), str)).toBeFalsy();
-      },
-    );
-  });
-
-  describe("Zod checks/refinements", () => {
-    test.each([
-      z.string().email(),
-      z.email(),
-      z.number().int(),
-      z.int(),
-      z.int32(),
-      z.int().max(1000),
-    ])("Snapshot control $constructor.name definition", (schema) => {
-      const snapshot = R.omit(["version"], schema._zod);
-      expect(snapshot).toMatchSnapshot();
-    });
-  });
-
-  describe("Zod imperfections", () => {
-    test("discriminated unions are not depicted well", () => {
-      expect(
-        z.toJSONSchema(
-          z.discriminatedUnion("status", [
-            z.object({ status: z.literal("success"), data: z.any() }),
-            z.object({
-              status: z.literal("error"),
-              error: z.object({ message: z.string() }),
-            }),
-          ]),
-        ),
-      ).not.toHaveProperty("discriminator");
+  describe("Zod", () => {
+    describe("global registry", () => {
+      test("is shared across both of its ESM and CJS packages", () => {
+        createRequire(import.meta.url)("zod");
+        const { globalRegistry } = createRequire(import.meta.url)("zod");
+        expect(globalRegistry).toBe(z.globalRegistry);
+      });
     });
 
-    test("bigint is not representable", () => {
-      const json = z.toJSONSchema(z.bigint(), { unrepresentable: "any" });
-      expect(R.omit(["$schema"], json)).toEqual({});
-    });
-
-    test("circular object schema has no sign of getter in its shape", () => {
-      const schema = z.object({
-        name: z.string(),
-        get features() {
-          return schema.array();
+    describe("Dates", () => {
+      test.each(["2021-01-32", "22/01/2022", "2021-01-31T25:00:00.000Z"])(
+        "should detect invalid date %#",
+        (str) => {
+          expect(z.validate(z.date(), new Date(str))).toBeFalsy();
+          expect(z.validate(z.string().date(), str)).toBeFalsy();
+          expect(z.validate(z.string().datetime(), str)).toBeFalsy();
+          expect(z.validate(z.iso.date(), str)).toBeFalsy();
+          expect(z.validate(z.iso.datetime(), str)).toBeFalsy();
         },
-      });
-      expect(
-        Object.getOwnPropertyDescriptors(schema._zod.def.shape),
-      ).toMatchSnapshot();
-    });
-
-    test("ZodError inequality", () => {
-      const issue: z.core.$ZodIssue = {
-        code: "invalid_type",
-        expected: "string",
-        input: 123,
-        path: [],
-        message: "expected string, received number",
-      };
-      const error = new z.ZodError([issue]);
-      const real = new z.ZodRealError([issue]);
-      expect(error).not.toBeInstanceOf(Error); // and this is important
-      expect(real).toBeInstanceOf(Error);
-      expect(real).toBeInstanceOf(z.ZodError); // important inheritance
-      expect(error).toHaveProperty("message");
-      expect(real).toHaveProperty("message");
-    });
-
-    test("both z.enum() and z.literal() can be empty", () => {
-      expect(z.enum([])._zod.def.entries).toEqual({});
-      /** @since 4.5.0 https://github.com/colinhacks/zod/pull/6459, 4.0.9 — 4.3.4 throws */
-      expect(z.literal([])._zod.def.values).toEqual([]);
-    });
-
-    test.each([z.coerce.number(), z.preprocess(Number, z.number())])(
-      "z.coerce and z.preprocess have no effect on JSON schema depiction %#",
-      (schema) => {
-        expect(schema.toJSONSchema()).toMatchSnapshot();
-      },
-    );
-  });
-
-  describe("Zod new features", () => {
-    test("Codecs can be reversed", () => {
-      const schema = z.codec(z.iso.datetime(), z.date(), {
-        decode: (str) => new Date(str),
-        encode: (date) => date.toISOString(),
-      });
-      const reversed = z.invertCodec(schema);
-      expect(reversed.parse(new Date("2022-01-01T00:00:00.000Z"))).toBe(
-        "2022-01-01T00:00:00.000Z",
       );
     });
 
-    test("Codec strictly typed methods still validate inputs in runtime", () => {
-      const schema = z.codec(z.string(), z.number(), {
-        decode: Number,
-        encode: String,
+    describe("checks/refinements", () => {
+      test.each([
+        z.string().email(),
+        z.email(),
+        z.number().int(),
+        z.int(),
+        z.int32(),
+        z.int().max(1000),
+      ])("Snapshot control $constructor.name definition", (schema) => {
+        const snapshot = R.omit(["version"], schema._zod);
+        expect(snapshot).toMatchSnapshot();
       });
-      expect(() => schema.decode(true as unknown as string)).toThrow(
-        /expected string, received boolean/,
-      );
-      expect(() => schema.encode(false as unknown as number)).toThrow(
-        /expected number, received boolean/,
+
+      test("parsing with async refinement throws $ZodAsyncError", () => {
+        const schema = z.string().refine(async () => true);
+        expect(() => schema.parse("")).toThrow(new z.core.$ZodAsyncError());
+      });
+    });
+
+    describe("imperfections", () => {
+      test("discriminated unions are depicted without discriminator", () => {
+        expect(
+          z.toJSONSchema(
+            z.discriminatedUnion("status", [
+              z.object({ status: z.literal("success"), data: z.any() }),
+              z.object({
+                status: z.literal("error"),
+                error: z.object({ message: z.string() }),
+              }),
+            ]),
+          ),
+        ).not.toHaveProperty("discriminator");
+      });
+
+      test("bigint is not representable", () => {
+        const json = z.toJSONSchema(z.bigint(), { unrepresentable: "any" });
+        expect(R.omit(["$schema"], json)).toEqual({});
+      });
+
+      test("circular object schema has no sign of getter in its shape", () => {
+        const schema = z.object({
+          name: z.string(),
+          get features() {
+            return schema.array();
+          },
+        });
+        expect(
+          Object.getOwnPropertyDescriptors(schema._zod.def.shape),
+        ).toMatchSnapshot();
+      });
+
+      test("ZodError inequality", () => {
+        const issue: z.core.$ZodIssue = {
+          code: "invalid_type",
+          expected: "string",
+          input: 123,
+          path: [],
+          message: "expected string, received number",
+        };
+        const error = new z.ZodError([issue]);
+        const real = new z.ZodRealError([issue]);
+        expect(error).not.toBeInstanceOf(Error); // and this is important
+        expect(real).toBeInstanceOf(Error);
+        expect(real).toBeInstanceOf(z.ZodError); // important inheritance
+        expect(error).toHaveProperty("message");
+        expect(real).toHaveProperty("message");
+      });
+
+      test("both z.enum() and z.literal() can be empty", () => {
+        expect(z.enum([])._zod.def.entries).toEqual({});
+        /** @since 4.5.0 https://github.com/colinhacks/zod/pull/6459, 4.0.9 — 4.3.4 throws */
+        expect(z.literal([])._zod.def.values).toEqual([]);
+      });
+
+      test.each([z.coerce.number(), z.preprocess(Number, z.number())])(
+        "z.coerce and z.preprocess have no effect on JSON schema depiction %#",
+        (schema) => {
+          expect(schema.toJSONSchema()).toMatchSnapshot();
+        },
       );
     });
 
-    test("ZodError equality", () => {
+    describe("Codecs", () => {
+      test("can be reversed", () => {
+        const schema = z.codec(z.iso.datetime(), z.date(), {
+          decode: (str) => new Date(str),
+          encode: (date) => date.toISOString(),
+        });
+        const reversed = z.invertCodec(schema);
+        expect(reversed.parse(new Date("2022-01-01T00:00:00.000Z"))).toBe(
+          "2022-01-01T00:00:00.000Z",
+        );
+      });
+
+      test("its strictly typed methods still validate inputs in runtime", () => {
+        const schema = z.codec(z.string(), z.number(), {
+          decode: Number,
+          encode: String,
+        });
+        expect(() => schema.decode(true as unknown as string)).toThrow(
+          /expected string, received boolean/,
+        );
+        expect(() => schema.encode(false as unknown as number)).toThrow(
+          /expected number, received boolean/,
+        );
+      });
+    });
+
+    test("safe/unsafe thrown/returned error equality", () => {
       try {
         z.number().parse("test");
       } catch (caught) {
@@ -141,19 +148,45 @@ describe("Environment checks", () => {
       }
     });
 
-    test("meta() merge, not just overrides", () => {
-      const schema = z
-        .string()
-        .meta({ examples: ["test"] })
-        .describe("some")
-        .meta({ title: "last" });
-      expect(schema.meta()).toMatchSnapshot();
-    });
+    describe("Metadata", () => {
+      test("meta() merge, not just overrides", () => {
+        const schema = z
+          .string()
+          .meta({ examples: ["test"] })
+          .describe("some")
+          .meta({ title: "last" });
+        expect(schema.meta()).toMatchSnapshot();
+      });
 
-    test("metadata is inheritable since zod 4.3.0", () => {
-      const parent = z.string().meta({ one: "test" });
-      const subject = parent.min(1).meta({ two: "another" });
-      expect(subject.meta()).toHaveProperty("one", "test");
+      test("is inheritable since zod 4.3.0", () => {
+        const parent = z.string().meta({ one: "test" });
+        const subject = parent.min(1).meta({ two: "another" });
+        expect(subject.meta()).toHaveProperty("one", "test");
+      });
+
+      test("id does NOT go into depiction", () => {
+        expect(
+          z.toJSONSchema(z.string().meta({ id: "uniq" })),
+        ).not.toHaveProperty("id");
+      });
+
+      /**
+       * @link https://github.com/colinhacks/zod/commit/adf65cdef4d8de10b788293808e8d52807adb7c0
+       * @since zod v4.3.0, 29.12.2025
+       * */
+      test("id uniqueness is NOT checked", () => {
+        const id = "Shared";
+        const alpha = z.string().meta({ id });
+        let beta: z.ZodType;
+        expect(() => {
+          beta = z.number().meta({ id });
+        }).not.toThrow();
+        const metaAlpha = z.globalRegistry.get(alpha)!;
+        const metaBeta = z.globalRegistry.get(beta!)!;
+        expect(metaAlpha).toBeTruthy();
+        expect(metaBeta).toBeTruthy();
+        expect(metaAlpha.id).toBe(metaBeta.id);
+      });
     });
 
     test("object shape conveys the keys optionality", () => {
@@ -221,30 +254,6 @@ describe("Environment checks", () => {
         ).toMatchSnapshot();
       },
     );
-
-    test("meta id does NOT go into depiction", () => {
-      expect(
-        z.toJSONSchema(z.string().meta({ id: "uniq" })),
-      ).not.toHaveProperty("id");
-    });
-
-    /**
-     * @link https://github.com/colinhacks/zod/commit/adf65cdef4d8de10b788293808e8d52807adb7c0
-     * @since zod v4.3.0, 29.12.2025
-     * */
-    test("meta id uniqueness is NOT checked", () => {
-      const id = "Shared";
-      const alpha = z.string().meta({ id });
-      let beta: z.ZodType;
-      expect(() => {
-        beta = z.number().meta({ id });
-      }).not.toThrow();
-      const metaAlpha = z.globalRegistry.get(alpha)!;
-      const metaBeta = z.globalRegistry.get(beta!)!;
-      expect(metaAlpha).toBeTruthy();
-      expect(metaBeta).toBeTruthy();
-      expect(metaAlpha.id).toBe(metaBeta.id);
-    });
 
     test("depicting intersection of objects is a flat object", () => {
       const c = z.object({ a: z.string() }).and(z.object({ b: z.string() }));

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -109,29 +109,32 @@ describe("Middleware", () => {
       });
     });
 
-    test("should handle async refinements in the input schema with trySyncValidation", async () => {
-      const refineMock = vi.fn(async () => true);
-      const handlerMock = vi.fn(async () => ({ result: "test" }));
-      const mw = new Middleware({
-        input: z.object({ test: z.string().refine(refineMock) }),
-        handler: handlerMock,
-      });
-      const loggerMock = makeLoggerMock();
-      const requestMock = makeRequestMock();
-      const responseMock = makeResponseMock();
-      const commons = {
-        input: { test: "something" },
-        ctx: {},
-        logger: loggerMock,
-        request: requestMock,
-        response: responseMock,
-        config: { trySyncValidation: true, cors: false },
-      };
-      expect(await mw.execute(commons)).toEqual({ result: "test" });
-      expect(refineMock).toHaveBeenCalledTimes(2); // sync attempt then parseAsync retry
-      await mw.execute({ ...commons, input: { test: "something else" } });
-      expect(refineMock).toHaveBeenCalledTimes(3); // the sync attempt is remembered and skipped
-    });
+    test.each([{ trySyncValidation: true }, { trySyncValidation: false }])(
+      "should handle async refinements with %s config",
+      async (cfg) => {
+        const refineMock = vi.fn(async () => true);
+        const mw = new Middleware({
+          input: z.object({ test: z.string().refine(refineMock) }),
+          handler: vi.fn(async () => ({ result: "test" })),
+        });
+        const loggerMock = makeLoggerMock();
+        const requestMock = makeRequestMock();
+        const responseMock = makeResponseMock();
+        const attempt = () =>
+          mw.execute({
+            input: { test: "something" },
+            ctx: {},
+            logger: loggerMock,
+            request: requestMock,
+            response: responseMock,
+            config: { ...cfg, cors: false },
+          });
+        await expect(attempt()).resolves.toEqual({ result: "test" });
+        expect(refineMock).toHaveBeenCalledTimes(cfg.trySyncValidation ? 2 : 1); // sync+async
+        await attempt();
+        expect(refineMock).toHaveBeenCalledTimes(cfg.trySyncValidation ? 3 : 2); // sync attempt skipped
+      },
+    );
   });
 });
 

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -108,6 +108,25 @@ describe("Middleware", () => {
         response: responseMock,
       });
     });
+
+    test("should handle async refinements in the input schema", async () => {
+      const handlerMock = vi.fn(async () => ({ result: "test" }));
+      const mw = new Middleware({
+        input: z.object({ test: z.string().refine(async (s) => s.length > 3) }),
+        handler: handlerMock,
+      });
+      const result = await mw.execute({
+        input: { test: "something" },
+        ctx: {},
+        logger: makeLoggerMock(),
+        request: makeRequestMock(),
+        response: makeResponseMock(),
+      });
+      expect(result).toEqual({ result: "test" });
+      expect(handlerMock).toHaveBeenCalledWith(
+        expect.objectContaining({ input: { test: "something" } }),
+      );
+    });
   });
 });
 

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -109,24 +109,35 @@ describe("Middleware", () => {
       });
     });
 
-    test("should handle async refinements in the input schema", async () => {
-      const handlerMock = vi.fn(async () => ({ result: "test" }));
-      const mw = new Middleware({
-        input: z.object({ test: z.string().refine(async (s) => s.length > 3) }),
-        handler: handlerMock,
-      });
-      const result = await mw.execute({
-        input: { test: "something" },
-        ctx: {},
-        logger: makeLoggerMock(),
-        request: makeRequestMock(),
-        response: makeResponseMock(),
-      });
-      expect(result).toEqual({ result: "test" });
-      expect(handlerMock).toHaveBeenCalledWith(
-        expect.objectContaining({ input: { test: "something" } }),
-      );
-    });
+    test.each([{ trySyncValidation: true }, { trySyncValidation: false }])(
+      "should handle async refinements in the input schema %#",
+      async ({ trySyncValidation }) => {
+        const refineMock = vi.fn(async () => true);
+        const handlerMock = vi.fn(async () => ({ result: "test" }));
+        const mw = new Middleware({
+          input: z.object({ test: z.string().refine(refineMock) }),
+          handler: handlerMock,
+        });
+        const loggerMock = makeLoggerMock();
+        const requestMock = makeRequestMock();
+        const responseMock = makeResponseMock();
+        const result = await mw.execute({
+          input: { test: "something" },
+          ctx: {},
+          logger: loggerMock,
+          request: requestMock,
+          response: responseMock,
+          config: { trySyncValidation, cors: false },
+        });
+        expect(result).toEqual({ result: "test" });
+        expect(handlerMock).toHaveBeenCalledWith(
+          expect.objectContaining({ input: { test: "something" } }),
+        );
+        expect(refineMock).toHaveBeenCalledTimes(
+          trySyncValidation ? 2 : 1, // sync attempt then parseAsync retry
+        );
+      },
+    );
   });
 });
 

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -136,6 +136,17 @@ describe("Middleware", () => {
         expect(refineMock).toHaveBeenCalledTimes(
           trySyncValidation ? 2 : 1, // sync attempt then parseAsync retry
         );
+        await mw.execute({
+          input: { test: "something else" },
+          ctx: {},
+          logger: loggerMock,
+          request: requestMock,
+          response: responseMock,
+          config: { trySyncValidation, cors: false },
+        });
+        expect(refineMock).toHaveBeenCalledTimes(
+          trySyncValidation ? 3 : 2, // the sync attempt is remembered and skipped
+        );
       },
     );
   });

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -109,46 +109,29 @@ describe("Middleware", () => {
       });
     });
 
-    test.each([{ trySyncValidation: true }, { trySyncValidation: false }])(
-      "should handle async refinements in the input schema %#",
-      async ({ trySyncValidation }) => {
-        const refineMock = vi.fn(async () => true);
-        const handlerMock = vi.fn(async () => ({ result: "test" }));
-        const mw = new Middleware({
-          input: z.object({ test: z.string().refine(refineMock) }),
-          handler: handlerMock,
-        });
-        const loggerMock = makeLoggerMock();
-        const requestMock = makeRequestMock();
-        const responseMock = makeResponseMock();
-        const result = await mw.execute({
-          input: { test: "something" },
-          ctx: {},
-          logger: loggerMock,
-          request: requestMock,
-          response: responseMock,
-          config: { trySyncValidation, cors: false },
-        });
-        expect(result).toEqual({ result: "test" });
-        expect(handlerMock).toHaveBeenCalledWith(
-          expect.objectContaining({ input: { test: "something" } }),
-        );
-        expect(refineMock).toHaveBeenCalledTimes(
-          trySyncValidation ? 2 : 1, // sync attempt then parseAsync retry
-        );
-        await mw.execute({
-          input: { test: "something else" },
-          ctx: {},
-          logger: loggerMock,
-          request: requestMock,
-          response: responseMock,
-          config: { trySyncValidation, cors: false },
-        });
-        expect(refineMock).toHaveBeenCalledTimes(
-          trySyncValidation ? 3 : 2, // the sync attempt is remembered and skipped
-        );
-      },
-    );
+    test("should handle async refinements in the input schema with trySyncValidation", async () => {
+      const refineMock = vi.fn(async () => true);
+      const handlerMock = vi.fn(async () => ({ result: "test" }));
+      const mw = new Middleware({
+        input: z.object({ test: z.string().refine(refineMock) }),
+        handler: handlerMock,
+      });
+      const loggerMock = makeLoggerMock();
+      const requestMock = makeRequestMock();
+      const responseMock = makeResponseMock();
+      const commons = {
+        input: { test: "something" },
+        ctx: {},
+        logger: loggerMock,
+        request: requestMock,
+        response: responseMock,
+        config: { trySyncValidation: true, cors: false },
+      };
+      expect(await mw.execute(commons)).toEqual({ result: "test" });
+      expect(refineMock).toHaveBeenCalledTimes(2); // sync attempt then parseAsync retry
+      await mw.execute({ ...commons, input: { test: "something else" } });
+      expect(refineMock).toHaveBeenCalledTimes(3); // the sync attempt is remembered and skipped
+    });
   });
 });
 

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -85,19 +85,23 @@ describe("Testing", () => {
     test.each([{ trySyncValidation: true }, { trySyncValidation: false }])(
       "Should forward config.trySyncValidation to the middleware %#",
       async (configProps) => {
-        const refineMock = vi.fn(async () => true);
-        const { output } = await testMiddleware({
+        const middleware = new Middleware({
+          input: z.object({ test: z.string().refine(async () => true) }),
+          handler: async () => ({}),
+        });
+        const execSpy = vi.spyOn(middleware, "execute");
+        await testMiddleware({
           requestProps: { method: "POST", body: { test: "something" } },
           configProps,
-          middleware: new Middleware({
-            input: z.object({ test: z.string().refine(refineMock) }),
-            handler: async () => ({}),
-          }),
+          middleware,
         });
-        expect(refineMock).toHaveBeenCalledTimes(
-          configProps.trySyncValidation ? 2 : 1,
-        ); // sync attempt then parseAsync retry
-        expect(output).toEqual({});
+        expect(execSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({
+              trySyncValidation: configProps.trySyncValidation,
+            }),
+          }),
+        );
       },
     );
 

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -82,6 +82,25 @@ describe("Testing", () => {
       });
     });
 
+    test.each([{ trySyncValidation: true }, { trySyncValidation: false }])(
+      "Should forward config.trySyncValidation to the middleware %#",
+      async (configProps) => {
+        const refineMock = vi.fn(async () => true);
+        const { output } = await testMiddleware({
+          requestProps: { method: "POST", body: { test: "something" } },
+          configProps,
+          middleware: new Middleware({
+            input: z.object({ test: z.string().refine(refineMock) }),
+            handler: async () => ({}),
+          }),
+        });
+        expect(refineMock).toHaveBeenCalledTimes(
+          configProps.trySyncValidation ? 2 : 1,
+        ); // sync attempt then parseAsync retry
+        expect(output).toEqual({});
+      },
+    );
+
     test.each<CommonConfig["errorHandler"]>([
       undefined,
       new ResultHandler({


### PR DESCRIPTION
This should unblock #3666 for compiled schemas.
We're gonna try parsing synchronously first, but if it fails we do async.
Historically established `.parseAsync()` is chosen for versatility, due to the #269.

The happy path does not affect the performance.

```
 ✓ bench/parse-maybe-async.bench.ts > Parsing 'sync' schemas 2959ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · .parseAsync()       8,148,819.69  0.0000  2.1694  0.0001  0.0001  0.0003  0.0004  0.0006  ±0.89%  4074410
   · parseMaybeAsync()  10,416,248.81  0.0000  0.1899  0.0001  0.0001  0.0002  0.0002  0.0005  ±0.26%  5208125

 ✓ bench/parse-maybe-async.bench.ts > Parsing 'async' schemas 1593ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · .parseAsync()      3,368,112.15  0.0002  0.1607  0.0003  0.0003  0.0005  0.0007  0.0008  ±0.28%  1684062
   · parseMaybeAsync()    227,643.07  0.0038  0.1916  0.0044  0.0045  0.0055  0.0058  0.0100  ±0.19%   113822
```

Meaning:
- Parsing sync schemas (happy path): becomes `1.3x` faster than before (even without schema compilation);
- Parsing occasionally async schemas regrettably becomes `~14x` slower than it used to be with `.parseAsync()`;

Therefore:
- I decided to make it an opt-in feature for now, that will become default in v30 #3643 , when Zod 4.5 will be a required min version and we'll use compiled schemas anyway for performance benefits;
- but even when enabled, it will try it only once per schema (first request, cache findings), so if we find out that the schema is async then we'll keep using `parseAsync` for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added the opt-in `trySyncValidation` setting for endpoint and middleware schema validation.
- Synchronous validation is attempted first, with automatic fallback to asynchronous validation when needed.
- Added support for compiled schemas with asynchronous refinements.
- Middleware testing utilities now forward validation configuration correctly.

## Tests

- Expanded coverage for synchronous and asynchronous validation behavior.
- Added benchmarks comparing validation performance across schema types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->