### PR TITLE
feat(endpoint)!: Enabling `trySyncValidation` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@
 - Config option `trySyncValidation` is now enabled by default (potentially breaking behavior change):
   - First request to Endpoints having schemas with async refinements would execute those refinements twice. If those
     refinements have side effects sensitive to the number of calls, then the option should be disabled.
-- The `config` property on the argument of `Middleware::execute()` is now required:
-  - It had a fallback to an empty configuration in v29 but must now be passed explicitly;
-  - `testMiddleware()` already forwards the mocked configuration into `Middleware::execute()`.
+- The `config` property on the `Middleware::execute()` argument is now required: `testMiddleware()` already handles it.
 - `DocumentationError` removed from main entrypoint: import from `express-zod-api/documentation` instead.
 - The rate-limiting Middleware now explicitly declares the `statusCode` that it may interrupt the request handling:
   - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Supported TypeScript versions (optional peer): `^6.0.3`:
   - Entirely `#private` props are now restored in the classes of the distributed `.d.ts` files.
+- Config option `trySyncValidation` is now enabled by default (potentially breaking behavior change):
+  - First request to Endpoints having schemas with async refinements would execute those refinements twice. If those
+    refinements have side effects sensitive to the number of calls, then the option should be disabled.
 - `DocumentationError` removed from main entrypoint: import from `express-zod-api/documentation` instead.
 - The rate-limiting Middleware now explicitly declares the `statusCode` that it may interrupt the request handling:
   - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Config option `trySyncValidation` is now enabled by default (potentially breaking behavior change):
   - First request to Endpoints having schemas with async refinements would execute those refinements twice. If those
     refinements have side effects sensitive to the number of calls, then the option should be disabled.
+- The `config` property on the argument of `Middleware::execute()` is now required:
+  - It had a fallback to an empty configuration in v29 but must now be passed explicitly;
+  - `testMiddleware()` already forwards the mocked configuration into `Middleware::execute()`.
 - `DocumentationError` removed from main entrypoint: import from `express-zod-api/documentation` instead.
 - The rate-limiting Middleware now explicitly declares the `statusCode` that it may interrupt the request handling:
   - Uses the `statusCode` option given to `EndpointsFactory::useRateLimit()` and `createRateLimitMiddleware()` or 429;

--- a/README.md
+++ b/README.md
@@ -454,43 +454,15 @@ const factory = defaultEndpointsFactory.use(auth(), {
 
 ## Refinements
 
-You can implement additional validations within schemas using refinements.
-Validation errors are reported in a response with a status code `400`.
+[Refinements](https://zod.dev/api#refinements) provide additional validations for your schemas. Though those functions
+can be async, the framework attempts to parse the first request to an Endpoint synchronously, which will run such async
+functions twice. Therefore, refinements should avoid side effects sensitive to the number of calls.
 
 ```ts
-import { z } from "zod";
-import { Middleware } from "express-zod-api";
-
-const nicknameConstraintMiddleware = new Middleware({
-  input: z.object({
-    nickname: z
-      .string()
-      .min(1)
-      .refine(
-        (nick) => !/^\d.*$/.test(nick),
-        "Nickname cannot start with a digit",
-      ),
-  }),
-  // ...,
-});
-```
-
-By the way, you can also refine the whole I/O object, for example, in case you need a complex validation of its props.
-
-```ts
-const endpoint = endpointsFactory.build({
-  input: z
-    .object({
-      email: z.email().optional(),
-      id: z.string().optional(),
-      otherThing: z.string().optional(),
-    })
-    .refine(
-      (inputs) => Object.keys(inputs).length >= 1,
-      "Please provide at least one property",
-    ),
-  // ...,
-});
+const nickname = z
+  .string()
+  .min(1)
+  .refine((nick) => !/^\d.*$/.test(nick), "Nickname cannot start with a digit");
 ```
 
 ## Query string parser

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ const factory = defaultEndpointsFactory.use(auth(), {
 
 ## Refinements
 
-[Refinements](https://zod.dev/api#refinements) provide additional validations for your schemas. Though those functions
+[Refinements](https://zod.dev/api#refinements) provide additional validations for your schemas. Albeit those functions
 can be async, the framework attempts to parse the first request to an Endpoint synchronously, which will run such async
 functions twice. Therefore, refinements should avoid side effects sensitive to the number of calls.
 

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -96,7 +96,7 @@ export const ensureError = (subject: unknown): Error =>
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   value: unknown,
-  { trySyncValidation = false }: Partial<CommonConfig>,
+  { trySyncValidation = true }: Partial<CommonConfig>,
   prev?: { isAsync: boolean }, // when already found to be async
 ): Promise<z.output<T>> => {
   if (!trySyncValidation || prev?.isAsync) return schema.parseAsync(value);

--- a/express-zod-api/src/common-helpers.ts
+++ b/express-zod-api/src/common-helpers.ts
@@ -92,10 +92,7 @@ export const ensureError = (subject: unknown): Error =>
       ? new z.ZodRealError(subject.issues)
       : new Error(String(subject));
 
-/**
- * @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements.
- * @todo enable trySyncValidation by default in v30
- * */
+/** @desc Attempts to parse the schema synchronously first, falling back to async for schemas with async refinements. */
 export const parseMaybeAsync = async <T extends z.ZodType>(
   schema: T,
   value: unknown,

--- a/express-zod-api/src/config-type.ts
+++ b/express-zod-api/src/config-type.ts
@@ -94,8 +94,7 @@ export interface CommonConfig {
    * @desc In that case, async refinements and transformations execute twice, so avoid side effects in them.
    * @example true — parses sync schemas ~1.3x faster, but it retries async ones (first request to the endpoint only).
    * @example false — always uses .parseAsync() and does not support compiled schemas (legacy behavior).
-   * @default false
-   * @todo remove in v30 or enable by default
+   * @default true
    */
   trySyncValidation?: boolean;
 }

--- a/express-zod-api/src/middleware.ts
+++ b/express-zod-api/src/middleware.ts
@@ -43,7 +43,7 @@ export abstract class AbstractMiddleware {
     request: Request;
     response: Response;
     logger: ActualLogger;
-    config?: CommonConfig; // @todo either make it required in v30 or remove it from here
+    config: CommonConfig;
   }): Promise<FlatObject>;
 }
 
@@ -126,13 +126,13 @@ export class Middleware<
     request: Request;
     response: Response;
     logger: ActualLogger;
-    config?: CommonConfig; // @todo either make it required in v30 or remove it from here
+    config: CommonConfig;
   }) {
     try {
       const validInput = await parseMaybeAsync(
         this.#schema || emptySchema,
         input,
-        config ?? {}, // @todo rm fallback in v30
+        config,
         this.#parsingState,
       );
       return this.#handler({ ...rest, input: validInput as z.output<IN> });

--- a/express-zod-api/tests/common-helpers.spec.ts
+++ b/express-zod-api/tests/common-helpers.spec.ts
@@ -406,6 +406,7 @@ describe("Common Helpers", () => {
     test.each([
       ["sync", { trySyncValidation: true }],
       ["async", { trySyncValidation: false }],
+      ["sync by default", {}],
     ])("should parse %s depending on config", async (variant, cfg) => {
       const schema = z.object({ num: z.number() });
       const parseSpy = vi.spyOn(schema, "parse");
@@ -413,7 +414,7 @@ describe("Common Helpers", () => {
       const result = await parseMaybeAsync(schema, { num: 123 }, cfg);
       expectTypeOf(result).toEqualTypeOf<{ num: number }>();
       expect(result).toEqual({ num: 123 });
-      expect(variant === "sync" ? asyncSpy : parseSpy).not.toHaveBeenCalled();
+      expect(variant === "async" ? parseSpy : asyncSpy).not.toHaveBeenCalled();
     });
 
     test.each([

--- a/express-zod-api/tests/middleware.spec.ts
+++ b/express-zod-api/tests/middleware.spec.ts
@@ -78,6 +78,7 @@ describe("Middleware", () => {
           logger: makeLoggerMock(),
           request: makeRequestMock(),
           response: makeResponseMock(),
+          config: { cors: false },
         }),
       ).rejects.toThrow(InputValidationError);
     });
@@ -98,6 +99,7 @@ describe("Middleware", () => {
           logger: loggerMock,
           request: requestMock,
           response: responseMock,
+          config: { cors: false },
         }),
       ).toEqual({ result: "test" });
       expect(handlerMock).toHaveBeenCalledWith({


### PR DESCRIPTION
Marked as breaking due to behavior change only.
Having this enabled by default, first requests to Endpoints having schemas with async refinements would execute those refinements twice before figuring out its async nature. If those refinements contain side effects that are sensitive to the number of calls — that could be a breaking behaviour change requiring to disable the config option.

Related to #3672 (was opt-in)
Unblocks #3666 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Synchronous validation attempts are now enabled by default. Async refinements may run twice on the first request, so they should avoid call-sensitive side effects.

- **API Changes**
  - Middleware execution now requires a configuration object.

- **Documentation**
  - Updated refinement guidance with inline examples and details about async refinement behavior.
  - Documented the new default validation behavior and its potential impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->