### PR TITLE
fix(test): Clarifications on postponed pruning

### DIFF
--- a/express-zod-api/src/documentation-helpers.ts
+++ b/express-zod-api/src/documentation-helpers.ts
@@ -124,7 +124,7 @@ export const depictUnion: Depicter = ({ zodSchema, jsonSchema }) => {
   };
 };
 
-/** @todo require min zod 4.5.0 and remove this */
+/** @todo remove when it learns to merge examples https://github.com/colinhacks/zod/pull/6461 */
 export const depictIntersection = R.tryCatch<Depicter>(
   ({ jsonSchema }) => {
     if (!jsonSchema.allOf) throw "no allOf";
@@ -135,7 +135,7 @@ export const depictIntersection = R.tryCatch<Depicter>(
 
 /**
  * @since OAS 3.1 nullable replaced with type array having null
- * @todo require zod 4.5 and remove this
+ * @todo remove when it learns to merge types having additional props https://github.com/colinhacks/zod/pull/6339
  * */
 export const depictNullable: Depicter = ({ jsonSchema }) => {
   if (!jsonSchema.anyOf || !jsonSchema.anyOf.length) return jsonSchema;

--- a/express-zod-api/tests/env.spec.ts
+++ b/express-zod-api/tests/env.spec.ts
@@ -47,6 +47,20 @@ describe("Environment checks", () => {
     });
 
     describe("imperfections", () => {
+      test("object intersection with examples does not get merged", () => {
+        expect(
+          z
+            .object({ a: z.number() })
+            .meta({ examples: [{ a: 1 }] })
+            .and(z.object({ b: z.number() }).meta({ examples: [{ b: 2 }] }))
+            .toJSONSchema(),
+        ).toHaveProperty("allOf"); // rm depictIntersection when this test fails
+      });
+
+      test("nullable does not merge types for schemas having other props", () => {
+        expect(z.int().nullable().toJSONSchema()).toHaveProperty("anyOf"); // rm depictNullable when it fails
+      });
+
       test("discriminated unions are depicted without discriminator", () => {
         expect(
           z.toJSONSchema(


### PR DESCRIPTION
Cherry-picked from #3666 
Zod 4.5 does not yet do it the desired way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development notes to reference relevant upstream Zod changes for schema examples and additional properties.

- **Tests**
  - Added coverage for JSON Schema output when intersecting objects with examples metadata.
  - Added coverage for nullable integer schemas, verifying their expected `anyOf` representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->