### PR TITLE
fix(perf): using depicted `x-brand` for deep checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 29
 
+### v29.5.1
+
+- Performance tuning for startup diagnostics and Documentation generator:
+  - Delegated the `x-brand` acquisition to Zod JSON Schema instead of checking the `globalRegistry` during the traverse.
+
 ### v29.5.0
 
 - Added the `trySyncValidation` option to the configuration (opt-in, disabled by default):

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -81,18 +81,18 @@ export const findJsonIncompatible = (
 ) =>
   findNestedSchema(subject, {
     io,
-    condition: ({ zodSchema, jsonSchema }) => {
+    condition: ({ zodSchema, jsonSchema: { [brandProperty]: brand } }) => {
       const { type } = zodSchema._zod.def;
       if (unsupported.has(type)) return true;
-      if (jsonSchema[brandProperty] === ezBufferBrand) return true;
+      if (brand === ezBufferBrand) return true;
       if (io === "input") {
         if (type === "date") return true;
-        if (jsonSchema[brandProperty] === ezDateOutBrand) return true;
+        if (brand === ezDateOutBrand) return true;
       }
       if (io === "output") {
-        if (jsonSchema[brandProperty] === ezDateInBrand) return true;
-        if (jsonSchema[brandProperty] === ezRawBrand) return true;
-        if (jsonSchema[brandProperty] === ezUploadBrand) return true;
+        if (brand === ezDateInBrand) return true;
+        if (brand === ezRawBrand) return true;
+        if (brand === ezUploadBrand) return true;
       }
       return false;
     },

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -6,14 +6,17 @@ import { ezDateOutBrand } from "./date-out-schema";
 import { DeepCheckError } from "./errors";
 import { ezFormBrand } from "./form-schema";
 import type { IOSchema } from "./io-schema";
-import { getBrand } from "./metadata";
+import { brandProperty } from "./metadata";
 import type { FirstPartyKind } from "./schema-walker";
 import { ezUploadBrand } from "./upload-schema";
 import { ezRawBrand } from "./raw-schema";
 
+export type LookupContext = Parameters<
+  Required<z.core.JSONSchemaGeneratorParams>["override"]
+>[0];
 interface NestedSchemaLookupProps {
   io: "input" | "output";
-  condition: (zodSchema: z.core.$ZodType) => boolean;
+  condition: (ctx: LookupContext) => boolean;
 }
 
 export const findNestedSchema = (
@@ -25,8 +28,8 @@ export const findNestedSchema = (
       void z.toJSONSchema(subject, {
         io,
         unrepresentable: "any",
-        override: ({ zodSchema }) => {
-          if (condition(zodSchema)) throw new DeepCheckError(zodSchema); // exits early
+        override: (ctx) => {
+          if (condition(ctx)) throw new DeepCheckError(ctx.zodSchema); // exits early
         },
       }),
     (err: DeepCheckError) => err.cause,
@@ -58,7 +61,8 @@ const isRequestDefiningBrand = Set.prototype.has.bind(
 );
 export const findRequestTypeDefiningSchema = (subject: IOSchema) =>
   findNestedSchema(subject, {
-    condition: (schema) => isRequestDefiningBrand(getBrand(schema)),
+    condition: ({ jsonSchema }) =>
+      isRequestDefiningBrand(jsonSchema[brandProperty]),
     io: "input",
   });
 
@@ -80,19 +84,18 @@ export const findJsonIncompatible = (
 ) =>
   findNestedSchema(subject, {
     io,
-    condition: (zodSchema) => {
-      const brand = getBrand(zodSchema);
+    condition: ({ zodSchema, jsonSchema }) => {
       const { type } = zodSchema._zod.def;
       if (unsupported.has(type)) return true;
-      if (brand === ezBufferBrand) return true;
+      if (jsonSchema[brandProperty] === ezBufferBrand) return true;
       if (io === "input") {
         if (type === "date") return true;
-        if (brand === ezDateOutBrand) return true;
+        if (jsonSchema[brandProperty] === ezDateOutBrand) return true;
       }
       if (io === "output") {
-        if (brand === ezDateInBrand) return true;
-        if (brand === ezRawBrand) return true;
-        if (brand === ezUploadBrand) return true;
+        if (jsonSchema[brandProperty] === ezDateInBrand) return true;
+        if (jsonSchema[brandProperty] === ezRawBrand) return true;
+        if (jsonSchema[brandProperty] === ezUploadBrand) return true;
       }
       return false;
     },

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { ezBufferBrand } from "./buffer-schema";
 import { ezDateInBrand } from "./date-in-schema";
 import { ezDateOutBrand } from "./date-out-schema";
-import { DeepCheckError } from "./errors";
+import { DeepCheckError, type LookupContext } from "./errors";
 import { ezFormBrand } from "./form-schema";
 import type { IOSchema } from "./io-schema";
 import { brandProperty } from "./metadata";
@@ -11,9 +11,6 @@ import type { FirstPartyKind } from "./schema-walker";
 import { ezUploadBrand } from "./upload-schema";
 import { ezRawBrand } from "./raw-schema";
 
-export type LookupContext = Parameters<
-  Required<z.core.JSONSchemaGeneratorParams>["override"]
->[0];
 interface NestedSchemaLookupProps {
   io: "input" | "output";
   condition: (ctx: LookupContext) => boolean;
@@ -29,7 +26,7 @@ export const findNestedSchema = (
         io,
         unrepresentable: "any",
         override: (ctx) => {
-          if (condition(ctx)) throw new DeepCheckError(ctx.zodSchema); // exits early
+          if (condition(ctx)) throw new DeepCheckError(ctx); // exits early
         },
       }),
     (err: DeepCheckError) => err.cause,

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -170,7 +170,7 @@ export class Endpoint<
     return (this.#requestType ??= (() => {
       const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
       if (found) {
-        const brand = found.jsonSchema[brandProperty];
+        const { [brandProperty]: brand } = found.jsonSchema;
         if (brand === ezUploadBrand) return "upload";
         if (brand === ezRawBrand) return "raw";
         if (brand === ezFormBrand) return "form";

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -18,7 +18,7 @@ import type { FrozenSet } from "./frozen-set";
 import type { IOSchema } from "./io-schema";
 import type { ActualLogger } from "./logger-helpers";
 import type { LogicalContainer } from "./logical-container";
-import { getBrand, getExamples } from "./metadata";
+import { brandProperty, getExamples } from "./metadata";
 import type { ClientMethod, CORSMethod, Method, SomeMethod } from "./method";
 import { AbstractMiddleware, ExpressMiddleware } from "./middleware";
 import type { ContentType } from "./content-type";
@@ -170,7 +170,7 @@ export class Endpoint<
     return (this.#requestType ??= (() => {
       const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
       if (found) {
-        const brand = getBrand(found);
+        const brand = found.jsonSchema[brandProperty];
         if (brand === ezUploadBrand) return "upload";
         if (brand === ezRawBrand) return "raw";
         if (brand === ezFormBrand) return "form";

--- a/express-zod-api/src/errors.ts
+++ b/express-zod-api/src/errors.ts
@@ -41,10 +41,14 @@ export class IOSchemaError extends Error {
   public override name = "IOSchemaError";
 }
 
+export type LookupContext = Parameters<
+  Required<z.core.JSONSchemaGeneratorParams>["override"]
+>[0];
+
 export class DeepCheckError extends IOSchemaError {
   public override name = "DeepCheckError";
 
-  constructor(public override readonly cause: z.core.$ZodType) {
+  constructor(public override readonly cause: LookupContext) {
     super("Found", { cause });
   }
 }

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -1,13 +1,10 @@
 import type { UploadedFile } from "express-fileupload";
 import { z } from "zod";
 import { ez } from "../src";
-import {
-  findNestedSchema,
-  hasCycle,
-  type LookupContext,
-} from "../src/deep-checks";
+import { findNestedSchema, hasCycle } from "../src/deep-checks";
 import { brandProperty } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
+import type { LookupContext } from "../src/errors.ts";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {

--- a/express-zod-api/tests/deep-checks.spec.ts
+++ b/express-zod-api/tests/deep-checks.spec.ts
@@ -1,14 +1,18 @@
 import type { UploadedFile } from "express-fileupload";
 import { z } from "zod";
 import { ez } from "../src";
-import { findNestedSchema, hasCycle } from "../src/deep-checks";
-import { getBrand } from "../src/metadata";
+import {
+  findNestedSchema,
+  hasCycle,
+  type LookupContext,
+} from "../src/deep-checks";
+import { brandProperty } from "../src/metadata";
 import { ezUploadBrand } from "../src/upload-schema";
 
 describe("Checks", () => {
   describe("findNestedSchema()", () => {
-    const condition = (subject: z.core.$ZodType) =>
-      getBrand(subject) === ezUploadBrand;
+    const condition = ({ jsonSchema }: LookupContext) =>
+      jsonSchema[brandProperty] === ezUploadBrand;
 
     test("should return true for given argument satisfying condition", () => {
       expect(
@@ -52,7 +56,9 @@ describe("Checks", () => {
           }),
         }),
       });
-      const check = vi.fn((schema) => schema instanceof z.ZodNumber);
+      const check = vi.fn(
+        ({ zodSchema }: LookupContext) => zodSchema instanceof z.ZodNumber,
+      );
       findNestedSchema(subject, {
         condition: check,
         io: "input",

--- a/express-zod-api/tests/errors.spec.ts
+++ b/express-zod-api/tests/errors.spec.ts
@@ -7,6 +7,7 @@ import {
   OutputValidationError,
   ResultHandlerError,
   DeepCheckError,
+  type LookupContext,
 } from "../src/errors";
 
 describe("Errors", () => {
@@ -75,8 +76,12 @@ describe("Errors", () => {
   });
 
   describe("DeepCheckError", () => {
-    const schema = z.any();
-    const error = new DeepCheckError(schema);
+    const ctx: LookupContext = {
+      zodSchema: z.any(),
+      jsonSchema: {},
+      path: ["test"],
+    };
+    const error = new DeepCheckError(ctx);
 
     test("should be an instance of IOSchemaError and Error", () => {
       expect(error).toBeInstanceOf(IOSchemaError);
@@ -87,8 +92,8 @@ describe("Errors", () => {
       expect(error.name).toBe("DeepCheckError");
     });
 
-    test("should have the cause matching the schema", () => {
-      expect(error.cause).toBe(schema);
+    test("should have the cause matching the context", () => {
+      expect(error.cause).toBe(ctx);
     });
   });
 

--- a/express-zod-api/tests/routing.spec.ts
+++ b/express-zod-api/tests/routing.spec.ts
@@ -535,11 +535,27 @@ describe("Routing", () => {
       expect(logger._getLogs().warn).toEqual([
         [
           "The final input schema of the endpoint contains an unsupported JSON payload type.",
-          { method: "get", path: "/path", reason: expect.any(z.ZodType) },
+          {
+            method: "get",
+            path: "/path",
+            reason: {
+              zodSchema: expect.any(z.ZodType),
+              jsonSchema: expect.any(Object),
+              path: expect.any(Array),
+            },
+          },
         ],
         [
           "The final positive response schema of the endpoint contains an unsupported JSON payload type.",
-          { method: "get", path: "/path", reason: expect.any(z.ZodType) },
+          {
+            method: "get",
+            path: "/path",
+            reason: {
+              zodSchema: expect.any(z.ZodType),
+              jsonSchema: expect.any(Object),
+              path: expect.any(Array),
+            },
+          },
         ],
       ]);
     });


### PR DESCRIPTION
Using `getBrand()` is a legacy approach from the times when we didn't use the native metadata for storing it.
Since we moved to `x-brand` meta AND using `tsJSONSchema` for traversing, we do already have it in the `jsonSchema` depiction given by `override`

This should help to simplify #3666 a little  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved startup diagnostics and documentation generation performance.
  - Schema metadata is processed more efficiently through generated JSON Schema.

- **Validation**
  - Improved detection of branded schemas and JSON Schema compatibility.
  - Nested-schema checks now provide richer schema context.
  - Continued detection of unsupported types, dates, cycles, and request-defining schemas.

- **Error Reporting**
  - Deep-check errors now include relevant schema details and location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->