### PR TITLE
fix(compat): Handling unstable traverse order of compiled schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 29
 
+### v29.5.2
+
+- Compatibility fix for the Zod 4.5 feature of [compiled](https://zod.dev/compile) schemas:
+  - Ensured the correct recognition of the expected request type for the case where `ez.form()` wraps `ez.upload()`.
+
 ### v29.5.1
 
 - Performance tuning for startup diagnostics and Documentation generator:

--- a/express-zod-api/src/deep-checks.ts
+++ b/express-zod-api/src/deep-checks.ts
@@ -4,8 +4,6 @@ import { ezBufferBrand } from "./buffer-schema";
 import { ezDateInBrand } from "./date-in-schema";
 import { ezDateOutBrand } from "./date-out-schema";
 import { DeepCheckError, type LookupContext } from "./errors";
-import { ezFormBrand } from "./form-schema";
-import type { IOSchema } from "./io-schema";
 import { brandProperty } from "./metadata";
 import type { FirstPartyKind } from "./schema-walker";
 import { ezUploadBrand } from "./upload-schema";
@@ -52,16 +50,6 @@ export const hasCycle = (
   }
   return false;
 };
-
-const isRequestDefiningBrand = Set.prototype.has.bind(
-  new Set([ezUploadBrand, ezRawBrand, ezFormBrand]),
-);
-export const findRequestTypeDefiningSchema = (subject: IOSchema) =>
-  findNestedSchema(subject, {
-    condition: ({ jsonSchema }) =>
-      isRequestDefiningBrand(jsonSchema[brandProperty]),
-    io: "input",
-  });
 
 const unsupported = new Set<FirstPartyKind>([
   "nan",

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import * as R from "ramda";
 import { z, globalRegistry } from "zod";
 import type { NormalizedResponse, ResponseVariant } from "./api-response";
-import { findRequestTypeDefiningSchema } from "./deep-checks";
+import { findNestedSchema } from "./deep-checks";
 import {
   type FlatObject,
   getActualMethod,
@@ -168,14 +168,21 @@ export class Endpoint<
   public override getProbableRequestType(method?: ClientMethod) {
     if (method === "query") return "form";
     return (this.#requestType ??= (() => {
-      const found = findRequestTypeDefiningSchema(this.#def.inputSchema);
+      let hasForm = false; // the order is not guaranteed since zod 4.5 for compiled schemas
+      const found = findNestedSchema(this.#def.inputSchema, {
+        io: "input",
+        condition: ({ jsonSchema: { [brandProperty]: brand } }) => {
+          if (brand === ezUploadBrand || brand === ezRawBrand) return true;
+          if (brand === ezFormBrand) hasForm = true;
+          return false;
+        },
+      });
       if (found) {
         const { [brandProperty]: brand } = found.jsonSchema;
         if (brand === ezUploadBrand) return "upload";
         if (brand === ezRawBrand) return "raw";
-        if (brand === ezFormBrand) return "form";
       }
-      return "json";
+      return hasForm ? "form" : "json";
     })());
   }
 

--- a/express-zod-api/src/endpoint.ts
+++ b/express-zod-api/src/endpoint.ts
@@ -168,21 +168,19 @@ export class Endpoint<
   public override getProbableRequestType(method?: ClientMethod) {
     if (method === "query") return "form";
     return (this.#requestType ??= (() => {
+      let found: ContentType | undefined;
+      const exitEarly = (value: ContentType) => Boolean((found = value));
       let hasForm = false; // the order is not guaranteed since zod 4.5 for compiled schemas
-      const found = findNestedSchema(this.#def.inputSchema, {
+      void findNestedSchema(this.#def.inputSchema, {
         io: "input",
         condition: ({ jsonSchema: { [brandProperty]: brand } }) => {
-          if (brand === ezUploadBrand || brand === ezRawBrand) return true;
+          if (brand === ezUploadBrand) return exitEarly("upload");
+          if (brand === ezRawBrand) return exitEarly("raw");
           if (brand === ezFormBrand) hasForm = true;
           return false;
         },
       });
-      if (found) {
-        const { [brandProperty]: brand } = found.jsonSchema;
-        if (brand === ezUploadBrand) return "upload";
-        if (brand === ezRawBrand) return "raw";
-      }
-      return hasForm ? "form" : "json";
+      return found ?? (hasForm ? "form" : "json");
     })());
   }
 

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -455,9 +455,8 @@ describe("Endpoint", () => {
   describe(".getProbableRequestType()", () => {
     test("should return 'form' for QUERY method %#", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
-      const endpoint = factory.build({
+      const endpoint = factory.buildVoid({
         input: ez.raw(),
-        output: z.object({}),
         handler: vi.fn(),
       });
       expect(endpoint.getProbableRequestType()).toBe("raw");
@@ -469,15 +468,12 @@ describe("Endpoint", () => {
       { input: z.object({ file: ez.upload() }), expected: "upload" },
       { input: ez.form({}), expected: "form" },
       { input: ez.form({ file: ez.upload() }), expected: "upload" },
+      { input: z.compile(ez.form({ file: ez.upload() })), expected: "upload" },
     ])(
       "should return the one based on the input schema %#",
       ({ input, expected }) => {
         const factory = new EndpointsFactory(defaultResultHandler);
-        const endpoint = factory.build({
-          input,
-          output: z.object({}),
-          handler: vi.fn(),
-        });
+        const endpoint = factory.buildVoid({ input, handler: vi.fn() });
         expect(endpoint.getProbableRequestType()).toEqual(expected);
       },
     );


### PR DESCRIPTION
Another compatibility fix found necessary during my work on #3666 
The traverse order is no longer guaranteed (compiled schemas do it differently), so we have to treat the edge case `z.compile( ez.form({ ez.upload }) )` specially.

This implementation preserves early exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic request-type detection for schemas containing file uploads.
  - Compiled form schemas with uploaded files are now correctly recognized as upload requests, including schemas compiled with Zod 4.5.
  - Existing detection for JSON, raw, and form request types remains supported.

- **Tests**
  - Added coverage for compiled form schemas that include file uploads.
  - Updated endpoint request-type tests across supported schema formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->