### PR TITLE
fix(test): avoid redundant schemas

### DIFF
--- a/express-zod-api/tests/documentation.spec.ts
+++ b/express-zod-api/tests/documentation.spec.ts
@@ -561,18 +561,18 @@ describe("Documentation", () => {
               }),
               handler: async () => ({ num: 123 }),
             }),
-            setSomething: defaultEndpointsFactory.addMiddleware(mw2).build({
+            setSomething: defaultEndpointsFactory.addMiddleware(mw2).buildVoid({
               scope: "write",
               method: "post",
-              output: z.object({}),
-              handler: async () => ({}),
+              handler: vi.fn(),
             }),
-            updateSomething: defaultEndpointsFactory.addMiddleware(mw3).build({
-              scope: "this should be omitted",
-              method: "put",
-              output: z.object({}),
-              handler: async () => ({}),
-            }),
+            updateSomething: defaultEndpointsFactory
+              .addMiddleware(mw3)
+              .buildVoid({
+                scope: "this should be omitted",
+                method: "put",
+                handler: vi.fn(),
+              }),
           },
         },
       }).getSpecAsYaml();
@@ -610,19 +610,17 @@ describe("Documentation", () => {
         routing: {
           v1: {
             getSome: {
-              thing: defaultEndpointsFactory.build({
+              thing: defaultEndpointsFactory.buildVoid({
                 description: "thing is the path segment",
                 summary: "operationIdEndpoint",
-                output: z.object({}),
-                handler: async () => ({}),
+                handler: vi.fn(),
               }),
-              ":thing": defaultEndpointsFactory.build({
+              ":thing": defaultEndpointsFactory.buildVoid({
                 description: "thing is the path parameter",
                 input: z.object({
                   thing: z.string(),
                 }),
-                output: z.object({}),
-                handler: async () => ({}),
+                handler: vi.fn(),
               }),
             },
           },
@@ -638,11 +636,10 @@ describe("Documentation", () => {
         routing: {
           v1: {
             getSome: {
-              thing: defaultEndpointsFactory.build({
+              thing: defaultEndpointsFactory.buildVoid({
                 description: "thing is the path segment",
                 operationId,
-                output: z.object({}),
-                handler: async () => ({}),
+                handler: vi.fn(),
               }),
             },
           },
@@ -659,12 +656,11 @@ describe("Documentation", () => {
         routing: {
           v1: {
             getSome: {
-              thing: defaultEndpointsFactory.build({
+              thing: defaultEndpointsFactory.buildVoid({
                 description: "thing is the path segment",
                 method: ["get", "post"],
                 operationId: (method) => `${method}${operationId}`,
-                output: z.object({}),
-                handler: async () => ({}),
+                handler: vi.fn(),
               }),
             },
           },
@@ -691,19 +687,17 @@ describe("Documentation", () => {
             routing: {
               v1: {
                 getSome: {
-                  thing: defaultEndpointsFactory.build({
+                  thing: defaultEndpointsFactory.buildVoid({
                     description: "thing is the path segment",
                     operationId,
-                    output: z.object({}),
-                    handler: async () => ({}),
+                    handler: vi.fn(),
                   }),
                 },
                 getSomeTwo: {
-                  thing: defaultEndpointsFactory.build({
+                  thing: defaultEndpointsFactory.buildVoid({
                     description: "thing is the path segment",
                     operationId,
-                    output: z.object({}),
-                    handler: async () => ({}),
+                    handler: vi.fn(),
                   }),
                 },
               },
@@ -731,10 +725,7 @@ describe("Documentation", () => {
         config: sampleConfig,
         routing: {
           v1: {
-            getSomething: factory.build({
-              output: z.object({}),
-              handler: async () => ({}),
-            }),
+            getSomething: factory.buildVoid({ handler: vi.fn() }),
           },
         },
       }).getSpecAsYaml();
@@ -807,7 +798,7 @@ describe("Documentation", () => {
         config: sampleConfig,
         routing: {
           v1: {
-            ":name": defaultEndpointsFactory.build({
+            ":name": defaultEndpointsFactory.buildVoid({
               method: "post",
               input: z.object({
                 name: z
@@ -816,7 +807,6 @@ describe("Documentation", () => {
                   .meta({ id: "NameParam" }),
                 other: z.boolean(),
               }),
-              output: z.object({}),
               handler: vi.fn(),
             }),
           },
@@ -842,13 +832,12 @@ describe("Documentation", () => {
           },
           routing: {
             v1: {
-              ":name": defaultEndpointsFactory.build({
+              ":name": defaultEndpointsFactory.buildVoid({
                 method: "post",
                 input: z.object({
                   name: z.literal("John").or(z.literal("Jane")),
                   other: z.boolean(),
                 }),
-                output: z.object({}),
                 handler: vi.fn(),
               }),
             },
@@ -863,12 +852,11 @@ describe("Documentation", () => {
         config: sampleConfig,
         routing: {
           v1: {
-            ":name": defaultEndpointsFactory.build({
+            ":name": defaultEndpointsFactory.buildVoid({
               input: z.object({
                 name: z.literal("John").or(z.literal("Jane")),
                 other: z.boolean(),
               }),
-              output: z.object({}),
               handler: vi.fn(),
             }),
           },
@@ -884,7 +872,7 @@ describe("Documentation", () => {
         config: sampleConfig,
         routing: {
           v1: {
-            ":id": defaultEndpointsFactory.build({
+            ":id": defaultEndpointsFactory.buildVoid({
               method: "post",
               input: z
                 .object({
@@ -897,7 +885,6 @@ describe("Documentation", () => {
                     { id: "456", bodyField: false },
                   ],
                 }),
-              output: z.object({}),
               handler: vi.fn(),
             }),
           },
@@ -985,13 +972,12 @@ describe("Documentation", () => {
           config: specificConfig,
           routing: {
             v1: {
-              test: defaultEndpointsFactory.build({
+              test: defaultEndpointsFactory.buildVoid({
                 method,
                 input: z.object({
                   id: z.string(),
                   "x-request-id": z.string(),
                 }),
-                output: z.object({}),
                 handler: vi.fn(),
               }),
             },
@@ -1096,11 +1082,8 @@ describe("Documentation", () => {
     });
 
     test("Feature #2390: should support deprecations", () => {
-      const endpoint = defaultEndpointsFactory.build({
-        input: z.object({
-          str: z.string().meta({ deprecated: true }),
-        }),
-        output: z.object({}),
+      const endpoint = defaultEndpointsFactory.buildVoid({
+        input: z.object({ str: z.string().meta({ deprecated: true }) }),
         handler: vi.fn(),
       });
       const spec = new Documentation({
@@ -1116,7 +1099,7 @@ describe("Documentation", () => {
         config: sampleConfig,
         routing: {
           hris: {
-            employees: defaultEndpointsFactory.build({
+            employees: defaultEndpointsFactory.buildVoid({
               input: z.object({
                 cursor: z
                   .string()
@@ -1126,8 +1109,7 @@ describe("Documentation", () => {
                       " This can be retrieved from the `next` property of the previous page response.",
                   ),
               }),
-              output: z.object({}),
-              handler: async () => ({}),
+              handler: vi.fn(),
             }),
           },
         },
@@ -1369,12 +1351,10 @@ describe("Documentation", () => {
       const spec = new Documentation({
         routing: {
           "get /a": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: item,
             handler: vi.fn(),
           }),
           "get /b": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: item,
             handler: vi.fn(),
           }),
@@ -1420,22 +1400,18 @@ describe("Documentation", () => {
       const spec = new Documentation({
         routing: {
           "get /a": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: itemA,
             handler: vi.fn(),
           }),
           "get /b": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: itemA,
             handler: vi.fn(),
           }),
           "get /c": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: itemB,
             handler: vi.fn(),
           }),
           "get /d": defaultEndpointsFactory.build({
-            input: z.object({}),
             output: itemB,
             handler: vi.fn(),
           }),
@@ -1468,12 +1444,10 @@ describe("Documentation", () => {
           new Documentation({
             routing: {
               "get /a": defaultEndpointsFactory.build({
-                input: z.object({}),
                 output: alpha,
                 handler: vi.fn(),
               }),
               "get /b": defaultEndpointsFactory.build({
-                input: z.object({}),
                 output: beta,
                 handler: vi.fn(),
               }),

--- a/express-zod-api/tests/endpoint.spec.ts
+++ b/express-zod-api/tests/endpoint.spec.ts
@@ -117,18 +117,15 @@ describe("Endpoint", () => {
     });
 
     test("should close the stream on OPTIONS request", async () => {
-      const handlerMock = vi.fn();
-      const endpoint = defaultEndpointsFactory.build({
-        output: z.object({}),
-        handler: handlerMock,
-      });
+      const handler = vi.fn();
+      const endpoint = defaultEndpointsFactory.buildVoid({ handler });
       const { responseMock, loggerMock } = await testEndpoint({
         endpoint,
         requestProps: { method: "OPTIONS" },
       });
       expect(loggerMock._getLogs().error).toHaveLength(0);
       expect(responseMock._getStatusCode()).toBe(200);
-      expect(handlerMock).toHaveBeenCalledTimes(0);
+      expect(handler).toHaveBeenCalledTimes(0);
       expect(responseMock.writableEnded).toBeTruthy();
     });
 
@@ -152,8 +149,7 @@ describe("Endpoint", () => {
 
   describe(".deprecated()", () => {
     test("should make a deprecated copy of the endpoint", () => {
-      const endpointMock = defaultEndpointsFactory.build({
-        output: z.object({}),
+      const endpointMock = defaultEndpointsFactory.buildVoid({
         handler: vi.fn(),
       });
       expect(endpointMock.isDeprecated).toBe(false);
@@ -165,10 +161,7 @@ describe("Endpoint", () => {
 
   describe(".nest()", () => {
     test("should return Routing arrangement", () => {
-      const subject = defaultEndpointsFactory.build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const subject = defaultEndpointsFactory.buildVoid({ handler: vi.fn() });
       expect(subject).toHaveProperty("nest", expect.any(Function));
       expect(subject.nest({ subpath: subject })).toEqual({
         "": subject,
@@ -225,9 +218,8 @@ describe("Endpoint", () => {
         handler: middlewareMock,
       });
       const handlerMock = vi.fn();
-      const endpoint = factory.build({
+      const endpoint = factory.buildVoid({
         method: "post",
-        output: z.object({}),
         handler: handlerMock,
       });
       const { responseMock, loggerMock } = await testEndpoint({
@@ -443,7 +435,7 @@ describe("Endpoint", () => {
           security: { type: "header", name: "X-API-Key" },
           handler: vi.fn(),
         })
-        .build({ output: z.object({}), handler: vi.fn() });
+        .buildVoid({ handler: vi.fn() });
       const { security } = endpoint;
       expect(security).toEqual([
         { name: "X-Token", type: "header" },
@@ -463,7 +455,7 @@ describe("Endpoint", () => {
       expect(endpoint.getProbableRequestType("query")).toBe("form");
     });
     test.each([
-      { input: z.object({}), expected: "json" },
+      { input: z.object(), expected: "json" },
       { input: ez.raw(), expected: "raw" },
       { input: z.object({ file: ez.upload() }), expected: "upload" },
       { input: ez.form({}), expected: "form" },
@@ -755,7 +747,7 @@ describe("Endpoint", () => {
   });
 
   describe("Feature #600: Top level refinements", () => {
-    const endpoint = defaultEndpointsFactory.build({
+    const endpoint = defaultEndpointsFactory.buildVoid({
       method: "post",
       input: z
         .object({
@@ -767,8 +759,7 @@ describe("Endpoint", () => {
           (x) => Object.keys(x).length >= 1,
           "Please provide at least one property",
         ),
-      output: z.object({}),
-      handler: async () => ({}),
+      handler: vi.fn(),
     });
 
     test("should accept valid inputs", async () => {

--- a/express-zod-api/tests/endpoints-factory.spec.ts
+++ b/express-zod-api/tests/endpoints-factory.spec.ts
@@ -396,10 +396,9 @@ describe("EndpointsFactory", () => {
 
     test("should create an endpoint without input schema", () => {
       const factory = new EndpointsFactory(resultHandlerMock);
-      const endpoint = factory.build({
+      const endpoint = factory.buildVoid({
         method: "get",
         deprecated: true,
-        output: z.object({}),
         handler: vi.fn(),
       });
       expectTypeOf(

--- a/express-zod-api/tests/integration.spec.ts
+++ b/express-zod-api/tests/integration.spec.ts
@@ -32,13 +32,10 @@ describe("Integration", () => {
         routing: {
           v1: {
             test: defaultEndpointsFactory
-              .build({
+              .buildVoid({
                 method: "query",
-                input: z.object({
-                  features: recursiveSchema,
-                }),
-                output: z.object({}),
-                handler: async () => ({}),
+                input: z.object({ features: recursiveSchema }),
+                handler: vi.fn(),
               })
               .deprecated(),
           },

--- a/express-zod-api/tests/routing.spec.ts
+++ b/express-zod-api/tests/routing.spec.ts
@@ -117,18 +117,9 @@ describe("Routing", () => {
     test("Should handle method depending assignments", () => {
       const handlerMock = vi.fn();
       const factory = new EndpointsFactory(defaultResultHandler);
-      const getEndpoint = factory.build({
-        output: z.object({}),
-        handler: handlerMock,
-      });
-      const postEndpoint = factory.build({
-        output: z.object({}),
-        handler: handlerMock,
-      });
-      const putAndPatchEndpoint = factory.build({
-        output: z.object({}),
-        handler: handlerMock,
-      });
+      const getEndpoint = factory.buildVoid({ handler: handlerMock });
+      const postEndpoint = factory.buildVoid({ handler: handlerMock });
+      const putAndPatchEndpoint = factory.buildVoid({ handler: handlerMock });
       const routing: Routing = {
         v1: {
           user: {
@@ -162,9 +153,8 @@ describe("Routing", () => {
 
     test("Should check if endpoint supports the method it's assigned to", () => {
       const factory = new EndpointsFactory(defaultResultHandler);
-      const putAndPatchEndpoint = factory.build({
+      const putAndPatchEndpoint = factory.buildVoid({
         method: ["put", "patch"],
-        output: z.object({}),
         handler: vi.fn(),
       });
       const routing: Routing = {
@@ -236,10 +226,11 @@ describe("Routing", () => {
     });
 
     test("Should accept parameters", () => {
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          handler: vi.fn(),
+        },
+      );
       const routing: Routing = {
         v1: {
           user: {
@@ -259,10 +250,11 @@ describe("Routing", () => {
     });
 
     test("Should handle empty paths and trim spaces", () => {
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          handler: vi.fn(),
+        },
+      );
       const routing: Routing = {
         v1: {
           user: {
@@ -291,10 +283,11 @@ describe("Routing", () => {
     });
 
     test("Should handle slashes in routing keys", () => {
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          handler: vi.fn(),
+        },
+      );
       const logger = makeLoggerMock();
       initRouting({
         app: appMock as unknown as IRouter,
@@ -363,11 +356,12 @@ describe("Routing", () => {
     });
 
     test("Should check if endpoint supports an explicitly specified method", () => {
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        method: "post",
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          method: "post",
+          handler: vi.fn(),
+        },
+      );
       const logger = makeLoggerMock();
       expect(() =>
         initRouting({
@@ -384,10 +378,11 @@ describe("Routing", () => {
     });
 
     test("Should prohibit nested routing within a route having explicit method", () => {
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          handler: vi.fn(),
+        },
+      );
       const logger = makeLoggerMock();
       expect(() =>
         initRouting({
@@ -437,10 +432,11 @@ describe("Routing", () => {
 
     test("Should prohibit duplicated routes", () => {
       const logger = makeLoggerMock();
-      const endpointMock = new EndpointsFactory(defaultResultHandler).build({
-        output: z.object({}),
-        handler: vi.fn(),
-      });
+      const endpointMock = new EndpointsFactory(defaultResultHandler).buildVoid(
+        {
+          handler: vi.fn(),
+        },
+      );
       const routing: Routing = {
         v1: { test: endpointMock },
         "/v1/test": endpointMock,

--- a/express-zod-api/tests/routing.spec.ts
+++ b/express-zod-api/tests/routing.spec.ts
@@ -115,11 +115,11 @@ describe("Routing", () => {
     });
 
     test("Should handle method depending assignments", () => {
-      const handlerMock = vi.fn();
+      const handler = vi.fn();
       const factory = new EndpointsFactory(defaultResultHandler);
-      const getEndpoint = factory.buildVoid({ handler: handlerMock });
-      const postEndpoint = factory.buildVoid({ handler: handlerMock });
-      const putAndPatchEndpoint = factory.buildVoid({ handler: handlerMock });
+      const getEndpoint = factory.buildVoid({ handler });
+      const postEndpoint = factory.buildVoid({ handler });
+      const putAndPatchEndpoint = factory.buildVoid({ handler });
       const routing: Routing = {
         v1: {
           user: {

--- a/express-zod-api/tests/server.spec.ts
+++ b/express-zod-api/tests/server.spec.ts
@@ -125,10 +125,9 @@ describe("Server", () => {
             }),
             handler: vi.fn(),
           }),
-          raw: factory.build({
+          raw: factory.buildVoid({
             method: "patch",
             input: ez.raw(),
-            output: z.object({}),
             handler: vi.fn(),
           }),
           form: factory.buildVoid({
@@ -230,8 +229,7 @@ describe("Server", () => {
       };
       const routingMock = {
         v1: {
-          test: new EndpointsFactory(defaultResultHandler).build({
-            output: z.object({}),
+          test: new EndpointsFactory(defaultResultHandler).buildVoid({
             handler: vi.fn(),
           }),
         },
@@ -326,11 +324,8 @@ describe("Server", () => {
       } satisfies ServerConfig;
       const routingMock = {
         v1: {
-          test: new EndpointsFactory(defaultResultHandler).build({
-            input: z.object({
-              file: ez.upload(),
-            }),
-            output: z.object({}),
+          test: new EndpointsFactory(defaultResultHandler).buildVoid({
+            input: z.object({ file: ez.upload() }),
             handler: vi.fn(),
           }),
         },
@@ -354,9 +349,8 @@ describe("Server", () => {
       } satisfies ServerConfig;
       const routingMock = {
         v1: {
-          test: new EndpointsFactory(defaultResultHandler).build({
+          test: new EndpointsFactory(defaultResultHandler).buildVoid({
             input: ez.raw(),
-            output: z.object({}),
             handler: vi.fn(),
           }),
         },

--- a/express-zod-api/tests/system.spec.ts
+++ b/express-zod-api/tests/system.spec.ts
@@ -100,9 +100,8 @@ describe("App in production mode", () => {
         };
       },
     });
-  const longEndpoint = new EndpointsFactory(defaultResultHandler).build({
-    output: z.object({}),
-    handler: async () => setTimeout(5000, {}),
+  const longEndpoint = new EndpointsFactory(defaultResultHandler).buildVoid({
+    handler: async () => setTimeout(5000),
   });
   const formEndpoint = new EndpointsFactory(defaultResultHandler).buildVoid({
     method: "post",

--- a/express-zod-api/tests/testing.spec.ts
+++ b/express-zod-api/tests/testing.spec.ts
@@ -22,10 +22,7 @@ describe("Testing", () => {
             return {};
           },
         })
-        .build({
-          output: z.object({}),
-          handler: async () => ({}),
-        });
+        .buildVoid({ handler: vi.fn() });
       const { responseMock, requestMock, loggerMock } = await testEndpoint({
         endpoint,
         responseOptions: { locals: { prop1: vi.fn(), prop2: 123 } },
@@ -118,7 +115,6 @@ describe("Testing", () => {
         const { output, loggerMock, responseMock } = await testMiddleware({
           configProps: { errorHandler },
           middleware: new Middleware({
-            input: z.object({}),
             handler: async ({ logger }) => {
               logger.info("logging something");
               throw new Error("something went wrong");

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -128,6 +128,21 @@ const tsFactoryConcerns = [
   },
 ];
 
+const redundancyConcerns = [
+  {
+    selector:
+      "Property[key.name='input'] > " +
+      "CallExpression[callee.property.name='object'] > ObjectExpression[properties.length=0]",
+    message: "empty object input is redundant",
+  },
+  {
+    selector:
+      "Property[key.name='output'] > " +
+      "CallExpression[callee.property.name='object'] > ObjectExpression[properties.length=0]",
+    message: "use .buildVoid() and remove the output property",
+  },
+];
+
 export default defineConfig({
   jsPlugins: [
     { name: "allowed", specifier: "eslint-plugin-allowed-dependencies" },
@@ -310,6 +325,7 @@ export default defineConfig({
       rules: {
         "typescript/no-explicit-any": "off",
         "typescript/no-empty-object-type": "warn",
+        "eslint-js/no-restricted-syntax": ["warn", ...redundancyConcerns],
       },
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated endpoint test coverage to use the void-endpoint API for endpoints without response data.
  * Simplified test handlers and removed redundant empty input and output schemas.

* **Chores**
  * Added lint checks to flag unnecessary empty object schemas in test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->