### PR TITLE
Using Vitest 5

### DIFF
--- a/example/__snapshots__/index.spec.ts.snap
+++ b/example/__snapshots__/index.spec.ts.snap
@@ -136,7 +136,7 @@ exports[`Example > Positive > Should handle valid GET request 1`] = `
 }
 `;
 
-exports[`Example > Positive > Should respond with array for 'application/json' 1`] = `
+exports[`Example > Positive > Should respond with array for application/json 1`] = `
 [
   {
     "name": "Maria Merian",
@@ -165,7 +165,7 @@ exports[`Example > Positive > Should respond with array for 'application/json' 1
 ]
 `;
 
-exports[`Example > Positive > Should respond with array for 'application/x-www-form-urlencoded' 1`] = `
+exports[`Example > Positive > Should respond with array for application/x-www-form-urlencoded 1`] = `
 [
   {
     "name": "Maria Merian",

--- a/express-zod-api/bench/array-from-map.bench.ts
+++ b/express-zod-api/bench/array-from-map.bench.ts
@@ -1,14 +1,13 @@
-import { bench } from "vitest";
-
-describe("Experiment on mapping", () => {
+test("Experiment on mapping", async ({ bench }) => {
   const src = new Set([1, 2, 3, 4, 5]);
   const mapper = (x: number) => x * 2;
 
-  bench("Array.from().map()", () => {
-    Array.from(src).map(mapper);
-  });
-
-  bench("Array.from(map)", () => {
-    Array.from(src, mapper);
-  });
+  await bench.compare(
+    bench("Array.from().map()", () => {
+      Array.from(src).map(mapper);
+    }),
+    bench("Array.from(map)", () => {
+      Array.from(src, mapper);
+    }),
+  );
 });

--- a/express-zod-api/bench/experiment.bench.ts
+++ b/express-zod-api/bench/experiment.bench.ts
@@ -1,9 +1,8 @@
-import { bench } from "vitest";
 import type { UploadedFile } from "express-fileupload";
 import { isObjectOfUploadShape } from "../src/upload-schema";
 import { z } from "zod";
 
-describe("Experiment for upload schema", () => {
+test("Experiment for upload schema", async ({ bench }) => {
   const current = () =>
     z.custom<UploadedFile>(
       (subject) =>
@@ -44,13 +43,14 @@ describe("Experiment for upload schema", () => {
         typeof subject.mv === "function",
     );
 
-  bench("current", () => {
-    const one = current();
-    one.safeParse({});
-  });
-
-  bench("featured", () => {
-    const one = featured();
-    one.safeParse({});
-  });
+  await bench.compare(
+    bench("current", () => {
+      const one = current();
+      one.safeParse({});
+    }),
+    bench("featured", () => {
+      const one = featured();
+      one.safeParse({});
+    }),
+  );
 });

--- a/express-zod-api/bench/headers-lookup.bench.ts
+++ b/express-zod-api/bench/headers-lookup.bench.ts
@@ -1,16 +1,18 @@
-import { bench } from "vitest";
 import { getWellKnownHeaders } from "../src/well-known-headers";
 
 const target = "x-frame-options";
 
-describe("Array.includes vs Set.has for well-known headers lookup", () => {
+test("Array.includes vs Set.has for well-known headers lookup", async ({
+  bench,
+}) => {
   const headersArray = Array.from(getWellKnownHeaders());
 
-  bench("Array.includes", () => {
-    headersArray.includes(target);
-  });
-
-  bench("Set.has", () => {
-    getWellKnownHeaders().has(target);
-  });
+  await bench.compare(
+    bench("Array.includes", () => {
+      headersArray.includes(target);
+    }),
+    bench("Set.has", () => {
+      getWellKnownHeaders().has(target);
+    }),
+  );
 });

--- a/express-zod-api/bench/headers-lookup.bench.ts
+++ b/express-zod-api/bench/headers-lookup.bench.ts
@@ -5,6 +5,7 @@ const target = "x-frame-options";
 test("Array.includes vs Set.has for well-known headers lookup", async ({
   bench,
 }) => {
+  const theSet = getWellKnownHeaders();
   const headersArray = Array.from(getWellKnownHeaders());
 
   await bench.compare(
@@ -12,7 +13,7 @@ test("Array.includes vs Set.has for well-known headers lookup", async ({
       headersArray.includes(target);
     }),
     bench("Set.has", () => {
-      getWellKnownHeaders().has(target);
+      theSet.has(target);
     }),
   );
 });

--- a/express-zod-api/bench/normalize-params.bench.ts
+++ b/express-zod-api/bench/normalize-params.bench.ts
@@ -1,34 +1,33 @@
-import { bench } from "vitest";
 import { normalizeParams } from "../src/common-helpers";
 
-describe("Experiment for checkDuplicate normalization", () => {
+test("Experiment for checkDuplicate normalization", async ({ bench }) => {
   const pathNoParams = "/users/check/some/stuff";
   const pathWithParams = "/users/:userId/books/:bookId/pages/:pageNum";
   const method = "get" as const;
   const visitedWith = new Set<string>();
   const visitedWithout = new Set<string>();
 
-  bench("with normalization and params", () => {
-    const normalized = pathWithParams.includes(":")
-      ? normalizeParams(pathWithParams)
-      : pathWithParams;
-    const key = `${method} ${normalized}`;
-    void visitedWith.has(key);
-    visitedWith.add(key);
-  });
-
-  bench("with normalization no params", () => {
-    const normalized = pathNoParams.includes(":")
-      ? normalizeParams(pathNoParams)
-      : pathNoParams;
-    const key = `${method} ${normalized}`;
-    void visitedWith.has(key);
-    visitedWith.add(key);
-  });
-
-  bench("without normalization (baseline)", () => {
-    const key = `${method} ${pathWithParams}`;
-    void visitedWithout.has(key);
-    visitedWithout.add(key);
-  });
+  await bench.compare(
+    bench("with normalization and params", () => {
+      const normalized = pathWithParams.includes(":")
+        ? normalizeParams(pathWithParams)
+        : pathWithParams;
+      const key = `${method} ${normalized}`;
+      void visitedWith.has(key);
+      visitedWith.add(key);
+    }),
+    bench("with normalization no params", () => {
+      const normalized = pathNoParams.includes(":")
+        ? normalizeParams(pathNoParams)
+        : pathNoParams;
+      const key = `${method} ${normalized}`;
+      void visitedWith.has(key);
+      visitedWith.add(key);
+    }),
+    bench("without normalization (baseline)", () => {
+      const key = `${method} ${pathWithParams}`;
+      void visitedWithout.has(key);
+      visitedWithout.add(key);
+    }),
+  );
 });

--- a/express-zod-api/bench/parse-maybe-async.bench.ts
+++ b/express-zod-api/bench/parse-maybe-async.bench.ts
@@ -1,16 +1,19 @@
-import { bench } from "vitest";
 import { z } from "zod";
 import { parseMaybeAsync } from "../src/common-helpers.ts";
 
-describe.each([
+test.for([
   [z.string(), "sync"],
   [z.string().refine(async () => true), "async"],
-])("Parsing $1 schemas", (schema) => {
-  bench(".parseAsync()", async () => {
-    await schema.parseAsync("");
-  });
-
-  bench("parseMaybeAsync()", async () => {
-    await parseMaybeAsync(schema, "", { trySyncValidation: true, cors: false });
-  });
+] as const)("Parsing $1 schemas", async ([schema], { bench }) => {
+  await bench.compare(
+    bench(".parseAsync()", async () => {
+      await schema.parseAsync("");
+    }),
+    bench("parseMaybeAsync()", async () => {
+      await parseMaybeAsync(schema, "", {
+        trySyncValidation: true,
+        cors: false,
+      });
+    }),
+  );
 });

--- a/express-zod-api/bench/set-iter.bench.ts
+++ b/express-zod-api/bench/set-iter.bench.ts
@@ -1,12 +1,12 @@
-import { bench } from "vitest";
-
-describe("Set iteration", () => {
+test("Set iteration", async ({ bench }) => {
   const set = new Set([1, 2]);
   const mapper = (x: number) => x * 2;
-  bench("spread map", () => {
-    [...set].map(mapper);
-  });
-  bench("values map", () => {
-    set.values().map(mapper);
-  });
+  await bench.compare(
+    bench("spread map", () => {
+      [...set].map(mapper);
+    }),
+    bench("values map", () => {
+      set.values().map(mapper);
+    }),
+  );
 });

--- a/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/documentation-helpers.spec.ts.snap
@@ -169,13 +169,13 @@ exports[`Documentation helpers > depictNullable() > should not add null type whe
 }
 `;
 
-exports[`Documentation helpers > depictPipeline > should depict as 'number (out)' 1`] = `
+exports[`Documentation helpers > depictPipeline > should depict as number (out) 1`] = `
 {
   "type": "number",
 }
 `;
 
-exports[`Documentation helpers > depictPipeline > should depict as 'string (preprocess)' 1`] = `
+exports[`Documentation helpers > depictPipeline > should depict as string (preprocess) 1`] = `
 {
   "format": "string (preprocessed)",
 }
@@ -502,7 +502,7 @@ exports[`Documentation helpers > depictSecurity() > should handle undefined flow
 ]
 `;
 
-exports[`Documentation helpers > depictSecurity() > should inform on 'actual' placement of the input security parameter 1`] = `
+exports[`Documentation helpers > depictSecurity() > should inform on actual placement of the input security parameter 1`] = `
 [
   [
     {
@@ -517,7 +517,7 @@ exports[`Documentation helpers > depictSecurity() > should inform on 'actual' pl
 ]
 `;
 
-exports[`Documentation helpers > depictSecurity() > should inform on 'alternative' placement of the input security parameter 1`] = `
+exports[`Documentation helpers > depictSecurity() > should inform on alternative placement of the input security parameter 1`] = `
 [
   [
     {

--- a/express-zod-api/tests/__snapshots__/env.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/env.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`Environment checks > Zod > Metadata > meta() merge, not just overrides 
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodEmail' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodEmail definition 1`] = `
 {
   "bag": {
     "format": "email",
@@ -49,7 +49,7 @@ exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodEm
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumber' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodNumber definition 1`] = `
 {
   "bag": {
     "format": "safeint",
@@ -86,7 +86,7 @@ exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNu
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodNumberFormat definition 1`] = `
 {
   "bag": {
     "format": "safeint",
@@ -122,7 +122,7 @@ exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNu
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 2`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodNumberFormat definition 2`] = `
 {
   "bag": {
     "format": "int32",
@@ -158,7 +158,7 @@ exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNu
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNumberFormat' definition 3`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodNumberFormat definition 3`] = `
 {
   "bag": {
     "format": "safeint",
@@ -203,7 +203,7 @@ exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodNu
 }
 `;
 
-exports[`Environment checks > Zod > checks/refinements > Snapshot control 'ZodString' definition 1`] = `
+exports[`Environment checks > Zod > checks/refinements > Snapshot control ZodString definition 1`] = `
 {
   "bag": {
     "format": "email",

--- a/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/result-handler.spec.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle HTTP error 1`] = `"Something not found"`;
+exports[`ResultHandler > arrayResultHandler > Should handle HTTP error 1`] = `"Something not found"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle generic error 1`] = `
+exports[`ResultHandler > arrayResultHandler > Should handle generic error 1`] = `
 [
   [
     "Server side error",
@@ -22,9 +22,9 @@ exports[`ResultHandler > 'arrayResultHandler' > Should handle generic error 1`] 
 ]
 `;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle generic error 2`] = `"Some error"`;
+exports[`ResultHandler > arrayResultHandler > Should handle generic error 2`] = `"Some error"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle regular response 1`] = `
+exports[`ResultHandler > arrayResultHandler > Should handle regular response 1`] = `
 [
   "One",
   "Two",
@@ -32,9 +32,9 @@ exports[`ResultHandler > 'arrayResultHandler' > Should handle regular response 1
 ]
 `;
 
-exports[`ResultHandler > 'arrayResultHandler' > Should handle schema error 1`] = `"something: Expected string, got number"`;
+exports[`ResultHandler > arrayResultHandler > Should handle schema error 1`] = `"something: Expected string, got number"`;
 
-exports[`ResultHandler > 'arrayResultHandler' > should forward output schema examples 1`] = `
+exports[`ResultHandler > arrayResultHandler > should forward output schema examples 1`] = `
 {
   "examples": [
     [
@@ -46,7 +46,7 @@ exports[`ResultHandler > 'arrayResultHandler' > should forward output schema exa
 }
 `;
 
-exports[`ResultHandler > 'arrayResultHandler' > should generate negative response example 1`] = `
+exports[`ResultHandler > arrayResultHandler > should generate negative response example 1`] = `
 {
   "examples": [
     "Sample error message",
@@ -54,7 +54,19 @@ exports[`ResultHandler > 'arrayResultHandler' > should generate negative respons
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle HTTP error 1`] = `
+exports[`ResultHandler > arrayResultHandler should attempt to take examples from the items prop 1`] = `
+{
+  "examples": [
+    [
+      "One",
+      "Two",
+      "Three",
+    ],
+  ],
+}
+`;
+
+exports[`ResultHandler > defaultResultHandler > Should handle HTTP error 1`] = `
 {
   "error": {
     "message": "Something not found",
@@ -63,7 +75,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle HTTP error 1`] =
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 1`] = `
+exports[`ResultHandler > defaultResultHandler > Should handle generic error 1`] = `
 [
   [
     "Server side error",
@@ -83,7 +95,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 1`
 ]
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 2`] = `
+exports[`ResultHandler > defaultResultHandler > Should handle generic error 2`] = `
 {
   "error": {
     "message": "Some error",
@@ -92,7 +104,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle generic error 2`
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle regular response 1`] = `
+exports[`ResultHandler > defaultResultHandler > Should handle regular response 1`] = `
 {
   "data": {
     "anything": 118,
@@ -106,7 +118,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle regular response
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`] = `
+exports[`ResultHandler > defaultResultHandler > Should handle schema error 1`] = `
 {
   "error": {
     "message": "something: Expected string, got number",
@@ -115,7 +127,7 @@ exports[`ResultHandler > 'defaultResultHandler' > Should handle schema error 1`]
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > should forward output schema examples 1`] = `
+exports[`ResultHandler > defaultResultHandler > should forward output schema examples 1`] = `
 {
   "examples": [
     {
@@ -133,7 +145,7 @@ exports[`ResultHandler > 'defaultResultHandler' > should forward output schema e
 }
 `;
 
-exports[`ResultHandler > 'defaultResultHandler' > should generate negative response example 1`] = `
+exports[`ResultHandler > defaultResultHandler > should generate negative response example 1`] = `
 {
   "examples": [
     {
@@ -142,18 +154,6 @@ exports[`ResultHandler > 'defaultResultHandler' > should generate negative respo
       },
       "status": "error",
     },
-  ],
-}
-`;
-
-exports[`ResultHandler > arrayResultHandler should attempt to take examples from the items prop 1`] = `
-{
-  "examples": [
-    [
-      "One",
-      "Two",
-      "Three",
-    ],
   ],
 }
 `;

--- a/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/zts.spec.ts.snap
@@ -177,11 +177,11 @@ exports[`zod-to-ts > PrimitiveSchema (isResponse=true) > outputs correct typescr
 }"
 `;
 
-exports[`zod-to-ts > enums > handles 'numeric' literals 1`] = `""Red" | "Green" | "Blue" | 0 | 1 | 2"`;
+exports[`zod-to-ts > enums > handles numeric literals 1`] = `""Red" | "Green" | "Blue" | 0 | 1 | 2"`;
 
-exports[`zod-to-ts > enums > handles 'quoted string' literals 1`] = `""Two Words" | "'Quotes\\"" | "\\\\\\"Escaped\\\\\\"" | 0 | 1 | 2"`;
+exports[`zod-to-ts > enums > handles quoted string literals 1`] = `""Two Words" | "'Quotes\\"" | "\\\\\\"Escaped\\\\\\"" | 0 | 1 | 2"`;
 
-exports[`zod-to-ts > enums > handles 'string' literals 1`] = `""apple" | "banana" | "cantaloupe""`;
+exports[`zod-to-ts > enums > handles string literals 1`] = `""apple" | "banana" | "cantaloupe""`;
 
 exports[`zod-to-ts > ez.buffer() > should be Blob 1`] = `"Blob"`;
 
@@ -301,9 +301,9 @@ exports[`zod-to-ts > z.pipe() > transformations > should handle preprocess error
 
 exports[`zod-to-ts > z.pipe() > transformations > should handle unsupported transformation in response 1`] = `"unknown"`;
 
-exports[`zod-to-ts > z.pipe() > transformations > should produce the schema type 'intact' 1`] = `"number"`;
+exports[`zod-to-ts > z.pipe() > transformations > should produce the schema type intact 1`] = `"number"`;
 
-exports[`zod-to-ts > z.pipe() > transformations > should produce the schema type 'transformed' 1`] = `"string"`;
+exports[`zod-to-ts > z.pipe() > transformations > should produce the schema type transformed 1`] = `"string"`;
 
 exports[`zod-to-ts > z.templateLiteral() > should produce the correct typescript 0 1`] = `"\`start\${number}mid\${boolean}end\`"`;
 

--- a/express-zod-api/vitest.setup.ts
+++ b/express-zod-api/vitest.setup.ts
@@ -1,9 +1,9 @@
-import type { NewPlugin } from "@vitest/pretty-format";
+import type { SnapshotSerializer } from "vitest";
 import { z } from "zod";
 import { ResultHandlerError } from "./src/errors";
 
 /** Takes cause and certain props of custom errors into account */
-const errorSerializer: NewPlugin = {
+const errorSerializer: SnapshotSerializer = {
   test: (subject) => subject instanceof Error,
   serialize: (error: Error, config, indentation, depth, refs, printer) => {
     const { name, message, cause } = error;
@@ -19,7 +19,7 @@ const errorSerializer: NewPlugin = {
   },
 };
 
-const schemaSerializer: NewPlugin = {
+const schemaSerializer: SnapshotSerializer = {
   test: (subject) => subject instanceof z.ZodType,
   serialize: (entity: z.ZodType, config, indentation, depth, refs, printer) => {
     const serialization = z.toJSONSchema(entity, { unrepresentable: "any" });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@arethetypeswrong/core": "^0.18.2",
     "@tsconfig/node22": "^22.0.5",
     "@types/node": "^26.0.1",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/coverage-v8": "^5.0.0",
     "eslint-plugin-allowed-dependencies": "^3.1.0",
     "husky": "^9.1.7",
     "openai": "^7.0.0",
@@ -25,7 +25,7 @@
     "oxlint": "^1.76.0",
     "oxlint-plugin-eslint": "^1.76.0",
     "tsdown": "^0.22.4",
-    "vitest": "^4.1.5"
+    "vitest": "^5.0.0"
   },
   "packageManager": "pnpm@12.1.0+sha512.d9b8276d97f6ec86e49815877f91ee9f63cee61f2063b304e43b6dab8fa07ce8a9afd46d2facd39f921e6a9d06b3c75a81349c7b888c2d22886bae0229901037"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: ^26.0.1
         version: 26.4.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.5
-        version: 4.1.11(vitest@4.1.11)
+        specifier: ^5.0.0
+        version: 5.0.0(vitest@5.0.0)
       eslint-plugin-allowed-dependencies:
         specifier: ^3.1.0
         version: 3.1.0(oxlint@1.80.0)
@@ -194,8 +194,8 @@ importers:
         specifier: ^0.22.4
         version: 0.22.14(@arethetypeswrong/core@0.18.5)(typescript@7.0.2)
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(yaml@2.9.0)
+        specifier: ^5.0.0
+        version: 5.0.0(@types/node@26.4.0)(@vitest/coverage-v8@5.0.0)(vite@8.2.1)
 
   cjs-test:
     devDependencies:
@@ -803,9 +803,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
   '@tsconfig/node22@22.0.6':
     resolution: {integrity: sha512-/5thavHAnWDZwH2H6eEn/T8pBEBhtuKaWGMslsj82kJfvzQgOgEMK7X4goBbIUjgVtAzPTtM9Ml64LA0uxO6Iw==}
 
@@ -1001,20 +998,25 @@ packages:
     resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
 
-  '@vitest/coverage-v8@4.1.11':
-    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
+  '@vitest/coverage-v8@5.0.0':
+    resolution: {integrity: sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==}
     peerDependencies:
-      '@vitest/browser': 4.1.11
-      vitest: 4.1.11
+      '@vitest/browser': 5.0.0
+      vitest: 5.0.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.11':
-    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+  '@vitest/istanbul-lib-coverage@1.0.1':
+    resolution: {integrity: sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==}
+    engines: {node: '>=22'}
 
-  '@vitest/mocker@4.1.11':
-    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+  '@vitest/istanbul-lib-report@1.0.1':
+    resolution: {integrity: sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==}
+    engines: {node: '>=22'}
+
+  '@vitest/mocker@5.0.0':
+    resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1024,20 +1026,8 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.11':
-    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
-
-  '@vitest/runner@4.1.11':
-    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
-
-  '@vitest/snapshot@4.1.11':
-    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
-
-  '@vitest/spy@4.1.11':
-    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
-
-  '@vitest/utils@4.1.11':
-    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+  '@vitest/spy@5.0.0':
+    resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
 
   '@yuku-codegen/binding-darwin-arm64@0.8.2':
     resolution: {integrity: sha512-jphw5TTa0heJQ23YGkiOHyenSpxFVV+w6pJGTfQANq2mfPmlsSsJsZ/ZTjxPu1VRlZLIPyuVH5TIB7wdpYg3AA==}
@@ -1242,9 +1232,6 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
   cookie-parser@1.4.7:
     resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
     engines: {node: '>= 0.8.0'}
@@ -1445,9 +1432,6 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
-  html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1479,18 +1463,6 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
-  istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
-
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1501,15 +1473,11 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
-
-  make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1681,14 +1649,15 @@ packages:
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
-  pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   postcss@8.5.26:
@@ -1824,8 +1793,9 @@ packages:
     peerDependencies:
       express: '>=4.0.0 || >=5.0.0-beta'
 
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+  tinybench@6.1.4:
+    resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
+    engines: {node: '>=20.0.0'}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -1988,22 +1958,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.11:
-    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+  vitest@5.0.0:
+    resolution: {integrity: sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.11
-      '@vitest/browser-preview': 4.1.11
-      '@vitest/browser-webdriverio': 4.1.11
-      '@vitest/coverage-istanbul': 4.1.11
-      '@vitest/coverage-v8': 4.1.11
-      '@vitest/ui': 4.1.11
+      '@types/node': ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 5.0.0
+      '@vitest/browser-preview': 5.0.0
+      '@vitest/browser-webdriverio': ^5.0.0-beta.5 || >=5.0.0
+      '@vitest/coverage-istanbul': 5.0.0
+      '@vitest/coverage-v8': 5.0.0
+      '@vitest/ui': 5.0.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.4.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2267,8 +2238,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@standard-schema/spec@1.1.0': {}
-
   '@tsconfig/node22@22.0.6': {}
 
   '@types/body-parser@1.19.6':
@@ -2424,60 +2393,34 @@ snapshots:
     dependencies:
       '@typescript/old': typescript@6.0.3
 
-  '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
+  '@vitest/coverage-v8@5.0.0(vitest@5.0.0)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.11
+      '@vitest/istanbul-lib-coverage': 1.0.1
+      '@vitest/istanbul-lib-report': 1.0.1
       ast-v8-to-istanbul: 1.0.5
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
       magicast: 0.5.4
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(yaml@2.9.0)
+      vitest: 5.0.0(@types/node@26.4.0)(@vitest/coverage-v8@5.0.0)(vite@8.2.1)
 
-  '@vitest/expect@4.1.11':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      chai: 6.2.2
-      tinyrainbow: 3.1.1
+  '@vitest/istanbul-lib-coverage@1.0.1': {}
 
-  '@vitest/mocker@4.1.11(vite@8.2.1)':
+  '@vitest/istanbul-lib-report@1.0.1':
     dependencies:
-      '@vitest/spy': 4.1.11
+      '@vitest/istanbul-lib-coverage': 1.0.1
+
+  '@vitest/mocker@5.0.0(vite@8.2.1)':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
       estree-walker: 3.0.3
-      magic-string: 0.30.21
+      magic-string: 1.2.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.4.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.11':
-    dependencies:
-      tinyrainbow: 3.1.1
-
-  '@vitest/runner@4.1.11':
-    dependencies:
-      '@vitest/utils': 4.1.11
-      pathe: 2.0.3
-
-  '@vitest/snapshot@4.1.11':
-    dependencies:
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/utils': 4.1.11
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
-  '@vitest/spy@4.1.11': {}
-
-  '@vitest/utils@4.1.11':
-    dependencies:
-      '@vitest/pretty-format': 4.1.11
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.1
+  '@vitest/spy@5.0.0': {}
 
   '@yuku-codegen/binding-darwin-arm64@0.8.2':
     optional: true
@@ -2630,8 +2573,6 @@ snapshots:
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
-
-  convert-source-map@2.0.0: {}
 
   cookie-parser@1.4.7:
     dependencies:
@@ -2837,7 +2778,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  has-flag@4.0.0: {}
+  has-flag@4.0.0:
+    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -2846,8 +2788,6 @@ snapshots:
       function-bind: 1.1.2
 
   hookable@6.1.1: {}
-
-  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2873,26 +2813,13 @@ snapshots:
 
   is-promise@4.0.0: {}
 
-  istanbul-lib-coverage@3.2.2: {}
-
-  istanbul-lib-report@3.0.1:
-    dependencies:
-      istanbul-lib-coverage: 3.2.2
-      make-dir: 4.0.0
-      supports-color: 7.2.0
-
-  istanbul-reports@3.2.0:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.1
-
   js-tokens@10.0.0: {}
 
   lodash.snakecase@4.1.1: {}
 
   lru-cache@11.5.2: {}
 
-  magic-string@0.30.21:
+  magic-string@1.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -2901,10 +2828,6 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
-
-  make-dir@4.0.0:
-    dependencies:
-      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -3038,11 +2961,11 @@ snapshots:
 
   path-to-regexp@8.4.0: {}
 
-  pathe@2.0.3: {}
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  picomatch@4.0.7: {}
 
   postcss@8.5.26:
     dependencies:
@@ -3199,6 +3122,7 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+    optional: true
 
   swagger-ui-dist@5.32.5: {}
 
@@ -3207,7 +3131,7 @@ snapshots:
       express: 5.2.1(supports-color@7.2.0)
       swagger-ui-dist: 5.32.5
 
-  tinybench@2.9.0: {}
+  tinybench@6.1.4: {}
 
   tinyexec@1.3.0: {}
 
@@ -3324,44 +3248,27 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(yaml@2.9.0):
+  vitest@5.0.0(@types/node@26.4.0)(@vitest/coverage-v8@5.0.0)(vite@8.2.1):
     dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.1)
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(vite@8.2.1)
+      chai: 6.2.2
       es-module-lexer: 2.3.2
       expect-type: 1.4.0
-      magic-string: 0.30.21
+      magic-string: 1.2.3
       obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       std-env: 4.2.0
-      tinybench: 2.9.0
+      tinybench: 6.1.4
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
       vite: 8.2.1(@types/node@26.4.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.4.0
-      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/coverage-v8': 5.0.0(vitest@5.0.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1652,10 +1652,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.7:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
@@ -2726,9 +2722,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fdir@6.5.0(picomatch@4.0.5):
+  fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
-      picomatch: 4.0.5
+      picomatch: 4.0.7
 
   fflate@0.8.3: {}
 
@@ -2963,8 +2959,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.5: {}
-
   picomatch@4.0.7: {}
 
   postcss@8.5.26:
@@ -3137,8 +3131,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinypool@2.1.0: {}
 
@@ -3159,7 +3153,7 @@ snapshots:
       hookable: 6.1.1
       import-without-cache: 0.4.0
       obug: 2.1.4
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       rolldown: 1.2.4
       rolldown-plugin-dts: 0.27.14(rolldown@1.2.4)(typescript@7.0.2)
       tinyexec: 1.3.0
@@ -3239,7 +3233,7 @@ snapshots:
 
   vite@8.2.1(@types/node@26.4.0)(yaml@2.9.0):
     dependencies:
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       postcss: 8.5.26
       rolldown: 1.2.4
       tinyglobby: 0.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,10 +13,13 @@ autoInstallPeers: false
 dedupePeers: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - eslint-plugin-allowed-dependencies # maintained by myself
-  - zod@4.5.4 # verified by Socket Security
-  # Renovate security update: qs@6.16.0
+  - eslint-plugin-allowed-dependencies
+  - zod@4.5.4
   - qs@6.16.0
+  - vitest@5.0.0
+  - "@vitest/coverage-v8@5.0.0"
+  - "@vitest/mocker@5.0.0"
+  - "@vitest/spy@5.0.0"
 publicHoistPattern:
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts
   - "@types/qs" # used by index.ts, fixes TS2742 for attachRouting

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,13 +13,13 @@ autoInstallPeers: false
 dedupePeers: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - eslint-plugin-allowed-dependencies
-  - zod@4.5.4
-  - qs@6.16.0
-  - vitest@5.0.0
-  - "@vitest/coverage-v8@5.0.0"
-  - "@vitest/mocker@5.0.0"
-  - "@vitest/spy@5.0.0"
+  - eslint-plugin-allowed-dependencies # maintained by myself
+  - zod@4.5.4 # verified by Socket Security
+  - qs@6.16.0 # Renovate security update
+  - vitest@5.0.0 # verified by Socket Security
+  - "@vitest/coverage-v8@5.0.0" # verified by Socket Security
+  - "@vitest/mocker@5.0.0" # verified by Socket Security
+  - "@vitest/spy@5.0.0" # verified by Socket Security
 publicHoistPattern:
   - "@vitest/*" # used by vitest.setup.ts and vitest.config.ts
   - "@types/qs" # used by index.ts, fixes TS2742 for attachRouting


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Vitest and its coverage tooling to version 5.
  * Added explanatory comments for package release-age exclusions without changing configuration behavior.

* **Tests**
  * Modernized benchmark definitions to compare performance scenarios through the current test API.
  * Updated snapshot serializer typing for compatibility with the latest Vitest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->