### PR TITLE
fix(perf): rm transforming schema from SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### v29.6.1
 
 - Performance optimization in the SSE event emission:
-  - The emission no longer builds the intermediate object schema on each event: the data is parsed against the declared
-    schema directly and formatted into a message string, making the `emit()` method roughly 230x faster.
+  - Removed an intermediate schema on each event: made formatting messages within `emit()` method about 230x faster.
 
 ### v29.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### v29.6.1
 
 - Performance optimization in the SSE event emission:
-  - Emission schemas are now precomputed once per `EventStreamFactory` instance instead of being rebuilt on each event
-    emission, making the `emit()` method roughly 180x faster.
+  - The emission no longer builds the intermediate object schema on each event: the data is parsed against the declared
+    schema directly and formatted into a message string, making the `emit()` method roughly 230x faster.
 
 ### v29.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 29
 
+### v29.6.1
+
+- Performance optimization in the SSE event emission:
+  - Emission schemas are now precomputed once per `EventStreamFactory` instance instead of being rebuilt on each event
+    emission, making the `emit()` method roughly 9.5x faster.
+
 ### v29.6.0
 
 - Added the `isCookie` (a boolean returning function) option to the Documentation generator for your customizations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Performance optimization in the SSE event emission:
   - Emission schemas are now precomputed once per `EventStreamFactory` instance instead of being rebuilt on each event
-    emission, making the `emit()` method roughly 9.5x faster.
+    emission, making the `emit()` method roughly 180x faster.
 
 ### v29.6.0
 

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -1,4 +1,4 @@
-import { formatMessage, makeMessagesMap } from "../src/sse";
+import { formatMessage, makeMessageSchema, makeMessagesMap } from "../src/sse";
 import { z } from "zod";
 
 const formatMessageRef = formatMessage; // avoid module export getter overhead per iteration
@@ -7,8 +7,7 @@ test("Experiment for SSE event formatting", async ({ bench }) => {
   const events = { message: z.string() } as const;
   const schemas = makeMessagesMap(events);
   const current = () =>
-    schemas
-      .get("message")!
+    makeMessageSchema("message", events.message)
       .transform((props) =>
         [
           `event: ${props.event}`,

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -2,11 +2,12 @@ import { formatMessage, makeMessageSchema } from "../src/sse";
 import { z } from "zod";
 
 const formatMessageRef = formatMessage; // avoid module export getter overhead per iteration
+const makeMessageSchemaRef = makeMessageSchema;
 
 test("Experiment for SSE event formatting", async ({ bench }) => {
   const events = { message: z.string() } as const;
   const current = () =>
-    makeMessageSchema("message", events.message)
+    makeMessageSchemaRef("message", events.message)
       .transform((props) =>
         [
           `event: ${props.event}`,

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -1,11 +1,11 @@
-import { formatEmission, makeEmissionMap } from "../src/sse";
+import { formatMessage, makeMessagesMap } from "../src/sse";
 import { z } from "zod";
 
-const formatEmissionRef = formatEmission; // avoid module export getter overhead per iteration
+const formatMessageRef = formatMessage; // avoid module export getter overhead per iteration
 
 test("Experiment for SSE event formatting", async ({ bench }) => {
   const events = { message: z.string() } as const;
-  const schemas = makeEmissionMap(events);
+  const schemas = makeMessagesMap(events);
   const current = () =>
     schemas
       .get("message")!
@@ -19,7 +19,7 @@ test("Experiment for SSE event formatting", async ({ bench }) => {
       )
       .parse({ event: "message", data: "hello" });
 
-  const featured = () => formatEmissionRef(schemas, "message", "hello");
+  const featured = () => formatMessageRef(schemas, "message", "hello");
 
   await bench.compare(
     bench("current", () => current()),

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -6,17 +6,19 @@ const formatMessageRef = formatMessage; // avoid module export getter overhead p
 test("Experiment for SSE event formatting", async ({ bench }) => {
   const events = { message: z.string() } as const;
   const current = () =>
-    makeMessageSchema("message", events.message).transform((props) =>
-      [
-        `event: ${props.event}`,
-        `data: ${JSON.stringify(props.data)}`,
-        "",
-        "" // empty line: events separator
-      ].join("\n")
-    ).parse({
-      event: "message",
-      data: "hello"
-    });
+    makeMessageSchema("message", events.message)
+      .transform((props) =>
+        [
+          `event: ${props.event}`,
+          `data: ${JSON.stringify(props.data)}`,
+          "",
+          "", // empty line: events separator
+        ].join("\n"),
+      )
+      .parse({
+        event: "message",
+        data: "hello",
+      });
 
   const featured = () => formatMessageRef(events, "message", "hello");
 

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -1,0 +1,28 @@
+import { formatEmission, makeEmissionMap } from "../src/sse";
+import { z } from "zod";
+
+const formatEmissionRef = formatEmission; // avoid module export getter overhead per iteration
+
+test("Experiment for SSE event formatting", async ({ bench }) => {
+  const events = { message: z.string() } as const;
+  const schemas = makeEmissionMap(events);
+  const current = () =>
+    schemas
+      .get("message")!
+      .transform((props) =>
+        [
+          `event: ${props.event}`,
+          `data: ${JSON.stringify(props.data)}`,
+          "",
+          "",
+        ].join("\n"),
+      )
+      .parse({ event: "message", data: "hello" });
+
+  const featured = () => formatEmissionRef(schemas, "message", "hello");
+
+  await bench.compare(
+    bench("current", () => current()),
+    bench("featured", () => featured()),
+  );
+});

--- a/express-zod-api/bench/sse-format.bench.ts
+++ b/express-zod-api/bench/sse-format.bench.ts
@@ -1,24 +1,24 @@
-import { formatMessage, makeMessageSchema, makeMessagesMap } from "../src/sse";
+import { formatMessage, makeMessageSchema } from "../src/sse";
 import { z } from "zod";
 
 const formatMessageRef = formatMessage; // avoid module export getter overhead per iteration
 
 test("Experiment for SSE event formatting", async ({ bench }) => {
   const events = { message: z.string() } as const;
-  const schemas = makeMessagesMap(events);
   const current = () =>
-    makeMessageSchema("message", events.message)
-      .transform((props) =>
-        [
-          `event: ${props.event}`,
-          `data: ${JSON.stringify(props.data)}`,
-          "",
-          "",
-        ].join("\n"),
-      )
-      .parse({ event: "message", data: "hello" });
+    makeMessageSchema("message", events.message).transform((props) =>
+      [
+        `event: ${props.event}`,
+        `data: ${JSON.stringify(props.data)}`,
+        "",
+        "" // empty line: events separator
+      ].join("\n")
+    ).parse({
+      event: "message",
+      data: "hello"
+    });
 
-  const featured = () => formatMessageRef(schemas, "message", "hello");
+  const featured = () => formatMessageRef(events, "message", "hello");
 
   await bench.compare(
     bench("current", () => current()),

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -1,14 +1,14 @@
 import type { ResponseVariant } from "./api-response";
 import { contentTypes } from "./content-type";
 import { clientMethods, type ClientMethod } from "./method";
-import type { makeEventSchema } from "./sse";
+import type { makeEmissionSchema } from "./sse";
 import type {
   CursorPaginatedResult,
   OffsetPaginatedResult,
 } from "./paginated-schema";
 
 type IOKind = "input" | "response" | ResponseVariant | "encoded";
-type SSEShape = ReturnType<typeof makeEventSchema>["shape"];
+type SSEShape = ReturnType<typeof makeEmissionSchema>["shape"];
 type Store = Record<IOKind, string>;
 
 const ids = {

--- a/express-zod-api/src/integration-base.ts
+++ b/express-zod-api/src/integration-base.ts
@@ -1,14 +1,14 @@
 import type { ResponseVariant } from "./api-response";
 import { contentTypes } from "./content-type";
 import { clientMethods, type ClientMethod } from "./method";
-import type { makeEmissionSchema } from "./sse";
+import type { makeMessageSchema } from "./sse";
 import type {
   CursorPaginatedResult,
   OffsetPaginatedResult,
 } from "./paginated-schema";
 
 type IOKind = "input" | "response" | ResponseVariant | "encoded";
-type SSEShape = ReturnType<typeof makeEmissionSchema>["shape"];
+type SSEShape = ReturnType<typeof makeMessageSchema>["shape"];
 type Store = Record<IOKind, string>;
 
 const ids = {

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -24,7 +24,7 @@ export interface Emitter<E extends EventsMap> extends FlatObject {
   emit: <K extends keyof E>(event: K, data: z.input<E[K]>) => void;
 }
 
-export const makeEmissionSchema = (event: string, data: z.ZodType) =>
+export const makeMessageSchema = (event: string, data: z.ZodType) =>
   z.object({
     data,
     event: z.literal(event),
@@ -32,21 +32,21 @@ export const makeEmissionSchema = (event: string, data: z.ZodType) =>
     retry: z.int().positive().optional(),
   });
 
-/** @private The schema of an actual emission, wrapping the data into an object with event name and optional fields */
-type EmissionSchema = ReturnType<typeof makeEmissionSchema>;
-/** @private The map of the precomputed emission schemas, having the same keys as the provided EventsMap. */
-type EmissionMap = ReadonlyMap<string, EmissionSchema>;
+/** @private The schema of an actual message, wrapping the data into an object with event name and optional fields */
+type MessageSchema = ReturnType<typeof makeMessageSchema>;
+/** @private The map of the precomputed message schemas having the same keys as the provided EventsMap. */
+type MessagesMap = ReadonlyMap<string, MessageSchema>;
 
-export const makeEmissionMap = <E extends EventsMap>(events: E) =>
+export const makeMessagesMap = <E extends EventsMap>(events: E) =>
   new Map(
     Object.entries(events).map(([event, schema]) => [
       event,
-      makeEmissionSchema(event, schema),
+      makeMessageSchema(event, schema),
     ]),
   );
 
-export const formatEmission = (
-  schemas: EmissionMap,
+export const formatMessage = (
+  schemas: MessagesMap,
   event: string,
   data: unknown,
 ) => {
@@ -70,7 +70,7 @@ export const ensureStream = (response: Response) =>
     "cache-control": "no-cache",
   });
 
-export const makeMiddleware = <E extends EventsMap>(schemas: EmissionMap) =>
+export const makeMiddleware = <E extends EventsMap>(schemas: MessagesMap) =>
   new Middleware({
     handler: async ({ request, response }): Promise<Emitter<E>> => {
       const controller = new AbortController();
@@ -86,7 +86,7 @@ export const makeMiddleware = <E extends EventsMap>(schemas: EmissionMap) =>
         signal: controller.signal,
         emit: (event, data) => {
           ensureStream(response);
-          response.write(formatEmission(schemas, String(event), data), "utf-8");
+          response.write(formatMessage(schemas, String(event), data), "utf-8");
           /**
            * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
            * @link https://github.com/RobinTail/express-zod-api/issues/2347
@@ -97,7 +97,7 @@ export const makeMiddleware = <E extends EventsMap>(schemas: EmissionMap) =>
     },
   });
 
-export const makeResultHandler = (schemas: EmissionMap) =>
+export const makeResultHandler = (schemas: MessagesMap) =>
   new ResultHandler({
     positive: () => {
       const [first, ...rest] = [...schemas.values()];
@@ -133,7 +133,7 @@ export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   Emitter<E>
 > {
   constructor(events: E) {
-    const schemas = makeEmissionMap(events);
+    const schemas = makeMessagesMap(events);
     super(makeResultHandler(schemas));
     this.middlewares = [makeMiddleware<E>(schemas)];
   }

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -12,6 +12,7 @@ import {
 } from "./result-helpers";
 import { ResultHandlerError } from "./errors";
 
+/** @public The generic base for user's declaration mapping the event names to the schemas of their data. */
 type EventsMap = Record<string, z.ZodType>;
 
 export interface Emitter<E extends EventsMap> extends FlatObject {
@@ -31,7 +32,9 @@ export const makeEmissionSchema = (event: string, data: z.ZodType) =>
     retry: z.int().positive().optional(),
   });
 
+/** @private The schema of an actual emission, wrapping the data into an object with event name and optional fields */
 type EmissionSchema = ReturnType<typeof makeEmissionSchema>;
+/** @private The map of the precomputed emission schemas, having the same keys as the provided EventsMap. */
 type EmissionMap = ReadonlyMap<string, EmissionSchema>;
 
 export const makeEmissionMap = <E extends EventsMap>(events: E) =>

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -49,13 +49,17 @@ export const formatEmission = (
   schemas: EmissionMap,
   event: string,
   data: unknown,
-) =>
-  [
+) => {
+  const schema = schemas.get(event);
+  if (!schema) throw new Error(`Unknown event: ${event}`);
+  const { data: payload } = schema.parse({ event, data });
+  return [
     `event: ${event}`,
-    `data: ${JSON.stringify(schemas.get(event)!.parse({ event, data }).data)}`,
+    `data: ${JSON.stringify(payload)}`,
     "",
     "", // empty line: events separator
   ].join("\n");
+};
 
 const headersTimeout = 1e4; // 10s to respond with a status code other than 200
 export const ensureStream = (response: Response) =>

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -121,6 +121,7 @@ export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   undefined,
   Emitter<E>
 > {
+  /** @todo compile these schemas in v30 */
   constructor(events: E) {
     super(makeResultHandler(events));
     this.middlewares = [makeMiddleware(events)];

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -84,8 +84,8 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
     },
   });
 
-export const makeResultHandler = <E extends EventsMap>(events: E) => {
-  return new ResultHandler({
+export const makeResultHandler = <E extends EventsMap>(events: E) =>
+  new ResultHandler({
     positive: () => {
       const [first, ...rest] = Object.entries(events).map(([event, schema]) =>
         makeMessageSchema(event, schema),
@@ -116,7 +116,6 @@ export const makeResultHandler = <E extends EventsMap>(events: E) => {
       response.end();
     },
   });
-};
 
 export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   undefined,

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -37,8 +37,9 @@ export const formatMessage = (
   event: string,
   data: unknown,
 ) => {
-  const schema = events[event];
-  if (!schema) throw new Error(`Unknown event: ${event}`);
+  if (!Object.prototype.hasOwnProperty.call(events, event))
+    throw new Error(`Unknown event: ${event}`);
+  const schema = events[event]!; // ensured by hasOwnProperty
   const payload = schema.parse(data);
   return [
     `event: ${event}`,

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -12,7 +12,7 @@ import {
 } from "./result-helpers";
 import { ResultHandlerError } from "./errors";
 
-/** @public The generic base for user's declaration mapping the event names to the schemas of their data. */
+/** @desc The declaration mapping the event names to the schemas of their data. */
 type EventsMap = Record<string, z.ZodType>;
 
 export interface Emitter<E extends EventsMap> extends FlatObject {
@@ -32,27 +32,14 @@ export const makeMessageSchema = (event: string, data: z.ZodType) =>
     retry: z.int().positive().optional(),
   });
 
-/** @private The schema of an actual message, wrapping the data into an object with event name and optional fields */
-type MessageSchema = ReturnType<typeof makeMessageSchema>;
-/** @private The map of the precomputed message schemas having the same keys as the provided EventsMap. */
-type MessagesMap = ReadonlyMap<string, MessageSchema>;
-
-export const makeMessagesMap = <E extends EventsMap>(events: E) =>
-  new Map(
-    Object.entries(events).map(([event, schema]) => [
-      event,
-      makeMessageSchema(event, schema),
-    ]),
-  );
-
 export const formatMessage = (
-  schemas: MessagesMap,
+  events: EventsMap,
   event: string,
   data: unknown,
 ) => {
-  const schema = schemas.get(event);
+  const schema = events[event];
   if (!schema) throw new Error(`Unknown event: ${event}`);
-  const { data: payload } = schema.parse({ event, data });
+  const payload = schema.parse(data);
   return [
     `event: ${event}`,
     `data: ${JSON.stringify(payload)}`,
@@ -70,7 +57,7 @@ export const ensureStream = (response: Response) =>
     "cache-control": "no-cache",
   });
 
-export const makeMiddleware = <E extends EventsMap>(schemas: MessagesMap) =>
+export const makeMiddleware = <E extends EventsMap>(events: E) =>
   new Middleware({
     handler: async ({ request, response }): Promise<Emitter<E>> => {
       const controller = new AbortController();
@@ -86,7 +73,7 @@ export const makeMiddleware = <E extends EventsMap>(schemas: MessagesMap) =>
         signal: controller.signal,
         emit: (event, data) => {
           ensureStream(response);
-          response.write(formatMessage(schemas, String(event), data), "utf-8");
+          response.write(formatMessage(events, String(event), data), "utf-8");
           /**
            * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
            * @link https://github.com/RobinTail/express-zod-api/issues/2347
@@ -97,10 +84,12 @@ export const makeMiddleware = <E extends EventsMap>(schemas: MessagesMap) =>
     },
   });
 
-export const makeResultHandler = (schemas: MessagesMap) =>
-  new ResultHandler({
+export const makeResultHandler = (events: EventsMap) => {
+  return new ResultHandler({
     positive: () => {
-      const [first, ...rest] = [...schemas.values()];
+      const [first, ...rest] = Object.entries(events).map(([event, schema]) =>
+        makeMessageSchema(event, schema),
+      );
       if (!first) {
         const cause = new Error("At least one SSE event is required.");
         throw new ResultHandlerError(cause);
@@ -127,14 +116,14 @@ export const makeResultHandler = (schemas: MessagesMap) =>
       response.end();
     },
   });
+};
 
 export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   undefined,
   Emitter<E>
 > {
   constructor(events: E) {
-    const schemas = makeMessagesMap(events);
-    super(makeResultHandler(schemas));
-    this.middlewares = [makeMiddleware<E>(schemas)];
+    super(makeResultHandler(events));
+    this.middlewares = [makeMiddleware<E>(events)];
   }
 }

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -84,7 +84,7 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
     },
   });
 
-export const makeResultHandler = (events: EventsMap) => {
+export const makeResultHandler = <E extends EventsMap>(events: E) => {
   return new ResultHandler({
     positive: () => {
       const [first, ...rest] = Object.entries(events).map(([event, schema]) =>
@@ -124,6 +124,6 @@ export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
 > {
   constructor(events: E) {
     super(makeResultHandler(events));
-    this.middlewares = [makeMiddleware<E>(events)];
+    this.middlewares = [makeMiddleware(events)];
   }
 }

--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -23,7 +23,7 @@ export interface Emitter<E extends EventsMap> extends FlatObject {
   emit: <K extends keyof E>(event: K, data: z.input<E[K]>) => void;
 }
 
-export const makeEventSchema = (event: string, data: z.ZodType) =>
+export const makeEmissionSchema = (event: string, data: z.ZodType) =>
   z.object({
     data,
     event: z.literal(event),
@@ -31,21 +31,28 @@ export const makeEventSchema = (event: string, data: z.ZodType) =>
     retry: z.int().positive().optional(),
   });
 
-export const formatEvent = <E extends EventsMap>(
-  events: E,
-  event: keyof E,
+type EmissionSchema = ReturnType<typeof makeEmissionSchema>;
+type EmissionMap = ReadonlyMap<string, EmissionSchema>;
+
+export const makeEmissionMap = <E extends EventsMap>(events: E) =>
+  new Map(
+    Object.entries(events).map(([event, schema]) => [
+      event,
+      makeEmissionSchema(event, schema),
+    ]),
+  );
+
+export const formatEmission = (
+  schemas: EmissionMap,
+  event: string,
   data: unknown,
 ) =>
-  makeEventSchema(String(event), events[event]!) // ensured by key type
-    .transform((props) =>
-      [
-        `event: ${props.event}`,
-        `data: ${JSON.stringify(props.data)}`,
-        "",
-        "", // empty line: events separator
-      ].join("\n"),
-    )
-    .parse({ event, data });
+  [
+    `event: ${event}`,
+    `data: ${JSON.stringify(schemas.get(event)!.parse({ event, data }).data)}`,
+    "",
+    "", // empty line: events separator
+  ].join("\n");
 
 const headersTimeout = 1e4; // 10s to respond with a status code other than 200
 export const ensureStream = (response: Response) =>
@@ -56,7 +63,7 @@ export const ensureStream = (response: Response) =>
     "cache-control": "no-cache",
   });
 
-export const makeMiddleware = <E extends EventsMap>(events: E) =>
+export const makeMiddleware = <E extends EventsMap>(schemas: EmissionMap) =>
   new Middleware({
     handler: async ({ request, response }): Promise<Emitter<E>> => {
       const controller = new AbortController();
@@ -72,7 +79,7 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
         signal: controller.signal,
         emit: (event, data) => {
           ensureStream(response);
-          response.write(formatEvent(events, event, data), "utf-8");
+          response.write(formatEmission(schemas, String(event), data), "utf-8");
           /**
            * Issue 2347: flush is the method of compression, it must be called only when compression is enabled
            * @link https://github.com/RobinTail/express-zod-api/issues/2347
@@ -83,12 +90,10 @@ export const makeMiddleware = <E extends EventsMap>(events: E) =>
     },
   });
 
-export const makeResultHandler = <E extends EventsMap>(events: E) =>
+export const makeResultHandler = (schemas: EmissionMap) =>
   new ResultHandler({
     positive: () => {
-      const [first, ...rest] = Object.entries(events).map(([event, schema]) =>
-        makeEventSchema(event, schema),
-      );
+      const [first, ...rest] = [...schemas.values()];
       if (!first) {
         const cause = new Error("At least one SSE event is required.");
         throw new ResultHandlerError(cause);
@@ -121,7 +126,8 @@ export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   Emitter<E>
 > {
   constructor(events: E) {
-    super(makeResultHandler(events));
-    this.middlewares = [makeMiddleware(events)];
+    const schemas = makeEmissionMap(events);
+    super(makeResultHandler(schemas));
+    this.middlewares = [makeMiddleware<E>(schemas)];
   }
 }

--- a/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SSE > makeEmissionSchema() > should make a valid schema of SSE event 1`] = `
+exports[`SSE > makeMessageSchema() > should make a valid schema of SSE event 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,

--- a/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
+++ b/express-zod-api/tests/__snapshots__/sse.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SSE > makeEventSchema() > should make a valid schema of SSE event 1`] = `
+exports[`SSE > makeEmissionSchema() > should make a valid schema of SSE event 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -49,11 +49,14 @@ describe("SSE", () => {
         `event: test\ndata: "some\\ntext"\n\n`,
       );
     });
-    test("should fail for unknown event", () => {
-      expect(() =>
-        formatMessage({ test: z.string() }, "another", "text"),
-      ).toThrow(new Error("Unknown event: another"));
-    });
+    test.each(["another", "toString", "hasOwnProperty"])(
+      "should fail for unknown event %s",
+      (event) => {
+        expect(() => formatMessage({ test: z.string() }, event, "text")).toThrow(
+          new Error(`Unknown event: ${event}`),
+        );
+      },
+    );
     test("should fail for invalid data", () => {
       expect(() => formatMessage({ test: z.string() }, "test", 123)).toThrow(
         z.ZodError,

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -52,9 +52,9 @@ describe("SSE", () => {
     test.each(["another", "toString", "hasOwnProperty"])(
       "should fail for unknown event %s",
       (event) => {
-        expect(() => formatMessage({ test: z.string() }, event, "text")).toThrow(
-          new Error(`Unknown event: ${event}`),
-        );
+        expect(() =>
+          formatMessage({ test: z.string() }, event, "text"),
+        ).toThrow(new Error(`Unknown event: ${event}`));
       },
     );
     test("should fail for invalid data", () => {

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -11,9 +11,9 @@ import type { FlatObject } from "../src/common-helpers";
 import {
   type Emitter,
   ensureStream,
-  formatEmission,
-  makeEmissionMap,
-  makeEmissionSchema,
+  formatMessage,
+  makeMessagesMap,
+  makeMessageSchema,
   makeMiddleware,
   makeResultHandler,
 } from "../src/sse";
@@ -33,31 +33,31 @@ const useFakeTimers = () => {
 };
 
 describe("SSE", () => {
-  describe("makeEmissionSchema()", () => {
+  describe("makeMessageSchema()", () => {
     test("should make a valid schema of SSE event", () => {
-      expect(makeEmissionSchema("test", z.string())).toMatchSnapshot();
+      expect(makeMessageSchema("test", z.string())).toMatchSnapshot();
     });
   });
 
-  describe("formatEmission()", () => {
-    const schemas = makeEmissionMap({ test: z.string() });
+  describe("formatMessage()", () => {
+    const schemas = makeMessagesMap({ test: z.string() });
     test("should format a valid event into string", () => {
-      expect(formatEmission(schemas, "test", "something")).toBe(
+      expect(formatMessage(schemas, "test", "something")).toBe(
         `event: test\ndata: "something"\n\n`,
       );
     });
     test("should withstand newlines", () => {
-      expect(formatEmission(schemas, "test", "some\ntext")).toBe(
+      expect(formatMessage(schemas, "test", "some\ntext")).toBe(
         `event: test\ndata: "some\\ntext"\n\n`,
       );
     });
     test("should fail for unknown event", () => {
-      expect(() => formatEmission(schemas, "another", "text")).toThrow(
+      expect(() => formatMessage(schemas, "another", "text")).toThrow(
         new Error("Unknown event: another"),
       );
     });
     test("should fail for invalid data", () => {
-      expect(() => formatEmission(schemas, "test", 123)).toThrow(z.ZodError);
+      expect(() => formatMessage(schemas, "test", 123)).toThrow(z.ZodError);
     });
   });
 
@@ -82,7 +82,7 @@ describe("SSE", () => {
   });
 
   describe("makeMiddleware()", () => {
-    const schemas = makeEmissionMap({ test: z.string() });
+    const schemas = makeMessagesMap({ test: z.string() });
     // with and without response.flush()
     test.each([vi.fn(), undefined])(
       "should create a Middleware providing context for emission %#",
@@ -137,8 +137,8 @@ describe("SSE", () => {
 
   describe("makeResultHandler()", () => {
     test.each<Parameters<typeof makeResultHandler>[0]>([
-      makeEmissionMap({ test: z.string(), another: z.number() }),
-      makeEmissionMap({ single: z.string() }),
+      makeMessagesMap({ test: z.string(), another: z.number() }),
+      makeMessagesMap({ single: z.string() }),
     ])(
       "should create ResultHandler describing possible events and handling generic errors %#",
       async (schemas) => {
@@ -178,7 +178,7 @@ describe("SSE", () => {
     );
 
     test("its ::getPositiveResponse() method should throw when events map is empty", () => {
-      const rh = makeResultHandler(makeEmissionMap({}));
+      const rh = makeResultHandler(makeMessagesMap({}));
       expect(() =>
         rh.getPositiveResponse(z.object({})),
       ).toThrowErrorMatchingSnapshot();

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -52,10 +52,12 @@ describe("SSE", () => {
       );
     });
     test("should fail for unknown event", () => {
-      expect(() => formatEmission(schemas, "another", "text")).toThrowError();
+      expect(() => formatEmission(schemas, "another", "text")).toThrow(
+        new Error("Unknown event: another"),
+      );
     });
     test("should fail for invalid data", () => {
-      expect(() => formatEmission(schemas, "test", 123)).toThrowError();
+      expect(() => formatEmission(schemas, "test", 123)).toThrow(z.ZodError);
     });
   });
 

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -11,8 +11,9 @@ import type { FlatObject } from "../src/common-helpers";
 import {
   type Emitter,
   ensureStream,
-  formatEvent,
-  makeEventSchema,
+  formatEmission,
+  makeEmissionMap,
+  makeEmissionSchema,
   makeMiddleware,
   makeResultHandler,
 } from "../src/sse";
@@ -32,32 +33,29 @@ const useFakeTimers = () => {
 };
 
 describe("SSE", () => {
-  describe("makeEventSchema()", () => {
+  describe("makeEmissionSchema()", () => {
     test("should make a valid schema of SSE event", () => {
-      expect(makeEventSchema("test", z.string())).toMatchSnapshot();
+      expect(makeEmissionSchema("test", z.string())).toMatchSnapshot();
     });
   });
 
-  describe("formatEvent()", () => {
+  describe("formatEmission()", () => {
+    const schemas = makeEmissionMap({ test: z.string() });
     test("should format a valid event into string", () => {
-      expect(formatEvent({ test: z.string() }, "test", "something")).toBe(
+      expect(formatEmission(schemas, "test", "something")).toBe(
         `event: test\ndata: "something"\n\n`,
       );
     });
     test("should withstand newlines", () => {
-      expect(formatEvent({ test: z.string() }, "test", "some\ntext")).toBe(
+      expect(formatEmission(schemas, "test", "some\ntext")).toBe(
         `event: test\ndata: "some\\ntext"\n\n`,
       );
     });
     test("should fail for unknown event", () => {
-      expect(() =>
-        formatEvent({ test: z.string() }, "another" as "test", "text"),
-      ).toThrowError();
+      expect(() => formatEmission(schemas, "another", "text")).toThrowError();
     });
     test("should fail for invalid data", () => {
-      expect(() =>
-        formatEvent({ test: z.string() }, "test", 123),
-      ).toThrowError();
+      expect(() => formatEmission(schemas, "test", 123)).toThrowError();
     });
   });
 
@@ -82,11 +80,12 @@ describe("SSE", () => {
   });
 
   describe("makeMiddleware()", () => {
+    const schemas = makeEmissionMap({ test: z.string() });
     // with and without response.flush()
     test.each([vi.fn(), undefined])(
       "should create a Middleware providing context for emission %#",
       async (flushMock) => {
-        const middleware = makeMiddleware({ test: z.string() });
+        const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
         expect(middleware).toBeInstanceOf(Middleware);
         expectTypeOf(middleware).toEqualTypeOf<
           Middleware<FlatObject, Emitter<{ test: z.ZodString }>, string>
@@ -111,7 +110,7 @@ describe("SSE", () => {
     );
 
     test("should abort signal on connection close", async () => {
-      const middleware = makeMiddleware({ test: z.string() });
+      const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
       const { requestMock, output } = await testMiddleware({ middleware });
       const { signal } = output;
       expect(signal?.aborted).toBeFalsy();
@@ -121,7 +120,7 @@ describe("SSE", () => {
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
       using timers = useFakeTimers();
-      const middleware = makeMiddleware({ test: z.string() });
+      const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
       const { requestMock, responseMock, output } = await testMiddleware({
         middleware,
       });
@@ -136,12 +135,12 @@ describe("SSE", () => {
 
   describe("makeResultHandler()", () => {
     test.each<Parameters<typeof makeResultHandler>[0]>([
-      { test: z.string(), another: z.number() },
-      { single: z.string() },
+      makeEmissionMap({ test: z.string(), another: z.number() }),
+      makeEmissionMap({ single: z.string() }),
     ])(
       "should create ResultHandler describing possible events and handling generic errors %#",
-      async (events) => {
-        const resultHandler = makeResultHandler(events);
+      async (schemas) => {
+        const resultHandler = makeResultHandler(schemas);
         expect(resultHandler).toBeInstanceOf(ResultHandler);
         expect(
           resultHandler.getPositiveResponse(z.object({})),
@@ -177,7 +176,7 @@ describe("SSE", () => {
     );
 
     test("its ::getPositiveResponse() method should throw when events map is empty", () => {
-      const rh = makeResultHandler({});
+      const rh = makeResultHandler(makeEmissionMap({}));
       expect(() =>
         rh.getPositiveResponse(z.object({})),
       ).toThrowErrorMatchingSnapshot();

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -86,7 +86,7 @@ describe("SSE", () => {
     test.each([vi.fn(), undefined])(
       "should create a Middleware providing context for emission %#",
       async (flushMock) => {
-        const middleware = makeMiddleware<{ test: z.ZodString }>(events);
+        const middleware = makeMiddleware(events);
         expect(middleware).toBeInstanceOf(Middleware);
         expectTypeOf(middleware).toEqualTypeOf<
           Middleware<FlatObject, Emitter<{ test: z.ZodString }>, string>
@@ -111,7 +111,7 @@ describe("SSE", () => {
     );
 
     test("should abort signal on connection close", async () => {
-      const middleware = makeMiddleware<{ test: z.ZodString }>(events);
+      const middleware = makeMiddleware(events);
       const { requestMock, output } = await testMiddleware({ middleware });
       const { signal } = output;
       expect(signal?.aborted).toBeFalsy();
@@ -121,7 +121,7 @@ describe("SSE", () => {
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
       using timers = useFakeTimers();
-      const middleware = makeMiddleware<{ test: z.ZodString }>(events);
+      const middleware = makeMiddleware(events);
       const { requestMock, responseMock, output } = await testMiddleware({
         middleware,
       });

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -12,7 +12,6 @@ import {
   type Emitter,
   ensureStream,
   formatMessage,
-  makeMessagesMap,
   makeMessageSchema,
   makeMiddleware,
   makeResultHandler,
@@ -40,24 +39,24 @@ describe("SSE", () => {
   });
 
   describe("formatMessage()", () => {
-    const schemas = makeMessagesMap({ test: z.string() });
+    const events = { test: z.string() };
     test("should format a valid event into string", () => {
-      expect(formatMessage(schemas, "test", "something")).toBe(
+      expect(formatMessage(events, "test", "something")).toBe(
         `event: test\ndata: "something"\n\n`,
       );
     });
     test("should withstand newlines", () => {
-      expect(formatMessage(schemas, "test", "some\ntext")).toBe(
+      expect(formatMessage(events, "test", "some\ntext")).toBe(
         `event: test\ndata: "some\\ntext"\n\n`,
       );
     });
     test("should fail for unknown event", () => {
-      expect(() => formatMessage(schemas, "another", "text")).toThrow(
+      expect(() => formatMessage(events, "another", "text")).toThrow(
         new Error("Unknown event: another"),
       );
     });
     test("should fail for invalid data", () => {
-      expect(() => formatMessage(schemas, "test", 123)).toThrow(z.ZodError);
+      expect(() => formatMessage(events, "test", 123)).toThrow(z.ZodError);
     });
   });
 
@@ -82,12 +81,12 @@ describe("SSE", () => {
   });
 
   describe("makeMiddleware()", () => {
-    const schemas = makeMessagesMap({ test: z.string() });
+    const events = { test: z.string() };
     // with and without response.flush()
     test.each([vi.fn(), undefined])(
       "should create a Middleware providing context for emission %#",
       async (flushMock) => {
-        const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
+        const middleware = makeMiddleware<{ test: z.ZodString }>(events);
         expect(middleware).toBeInstanceOf(Middleware);
         expectTypeOf(middleware).toEqualTypeOf<
           Middleware<FlatObject, Emitter<{ test: z.ZodString }>, string>
@@ -112,7 +111,7 @@ describe("SSE", () => {
     );
 
     test("should abort signal on connection close", async () => {
-      const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
+      const middleware = makeMiddleware<{ test: z.ZodString }>(events);
       const { requestMock, output } = await testMiddleware({ middleware });
       const { signal } = output;
       expect(signal?.aborted).toBeFalsy();
@@ -122,7 +121,7 @@ describe("SSE", () => {
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
       using timers = useFakeTimers();
-      const middleware = makeMiddleware<{ test: z.ZodString }>(schemas);
+      const middleware = makeMiddleware<{ test: z.ZodString }>(events);
       const { requestMock, responseMock, output } = await testMiddleware({
         middleware,
       });
@@ -137,12 +136,12 @@ describe("SSE", () => {
 
   describe("makeResultHandler()", () => {
     test.each<Parameters<typeof makeResultHandler>[0]>([
-      makeMessagesMap({ test: z.string(), another: z.number() }),
-      makeMessagesMap({ single: z.string() }),
+      { test: z.string(), another: z.number() },
+      { single: z.string() },
     ])(
       "should create ResultHandler describing possible events and handling generic errors %#",
-      async (schemas) => {
-        const resultHandler = makeResultHandler(schemas);
+      async (events) => {
+        const resultHandler = makeResultHandler(events);
         expect(resultHandler).toBeInstanceOf(ResultHandler);
         expect(
           resultHandler.getPositiveResponse(z.object({})),
@@ -178,7 +177,7 @@ describe("SSE", () => {
     );
 
     test("its ::getPositiveResponse() method should throw when events map is empty", () => {
-      const rh = makeResultHandler(makeMessagesMap({}));
+      const rh = makeResultHandler({});
       expect(() =>
         rh.getPositiveResponse(z.object({})),
       ).toThrowErrorMatchingSnapshot();

--- a/express-zod-api/tests/sse.spec.ts
+++ b/express-zod-api/tests/sse.spec.ts
@@ -39,24 +39,25 @@ describe("SSE", () => {
   });
 
   describe("formatMessage()", () => {
-    const events = { test: z.string() };
     test("should format a valid event into string", () => {
-      expect(formatMessage(events, "test", "something")).toBe(
+      expect(formatMessage({ test: z.string() }, "test", "something")).toBe(
         `event: test\ndata: "something"\n\n`,
       );
     });
     test("should withstand newlines", () => {
-      expect(formatMessage(events, "test", "some\ntext")).toBe(
+      expect(formatMessage({ test: z.string() }, "test", "some\ntext")).toBe(
         `event: test\ndata: "some\\ntext"\n\n`,
       );
     });
     test("should fail for unknown event", () => {
-      expect(() => formatMessage(events, "another", "text")).toThrow(
-        new Error("Unknown event: another"),
-      );
+      expect(() =>
+        formatMessage({ test: z.string() }, "another", "text"),
+      ).toThrow(new Error("Unknown event: another"));
     });
     test("should fail for invalid data", () => {
-      expect(() => formatMessage(events, "test", 123)).toThrow(z.ZodError);
+      expect(() => formatMessage({ test: z.string() }, "test", 123)).toThrow(
+        z.ZodError,
+      );
     });
   });
 
@@ -81,12 +82,11 @@ describe("SSE", () => {
   });
 
   describe("makeMiddleware()", () => {
-    const events = { test: z.string() };
     // with and without response.flush()
     test.each([vi.fn(), undefined])(
       "should create a Middleware providing context for emission %#",
       async (flushMock) => {
-        const middleware = makeMiddleware(events);
+        const middleware = makeMiddleware({ test: z.string() });
         expect(middleware).toBeInstanceOf(Middleware);
         expectTypeOf(middleware).toEqualTypeOf<
           Middleware<FlatObject, Emitter<{ test: z.ZodString }>, string>
@@ -111,7 +111,7 @@ describe("SSE", () => {
     );
 
     test("should abort signal on connection close", async () => {
-      const middleware = makeMiddleware(events);
+      const middleware = makeMiddleware({ test: z.string() });
       const { requestMock, output } = await testMiddleware({ middleware });
       const { signal } = output;
       expect(signal?.aborted).toBeFalsy();
@@ -121,7 +121,7 @@ describe("SSE", () => {
 
     test("should clear the stream timeout when request closes before timeout fires", async () => {
       using timers = useFakeTimers();
-      const middleware = makeMiddleware(events);
+      const middleware = makeMiddleware({ test: z.string() });
       const { requestMock, responseMock, output } = await testMiddleware({
         middleware,
       });


### PR DESCRIPTION
Boosting the performance ~230x by removing the transforming schema created for each emission.
This should also enable compiling original schemas in the given map in #3643 

```
 ✓  bench  bench/sse-format.bench.ts (1 test) 5098ms
   ✓ Experiment for SSE event formatting 5097ms
     name                 hz     min     max    mean     p75     p99    p995    p999     rme   samples
     featured  10,559,812.85  0.0000  3.0415  0.0001  0.0001  0.0001  0.0002  0.0003  ±0.61%  10037074   fastest
     current       45,220.38  0.0194  4.0205  0.0255  0.0231  0.0343  0.0402  1.7776  ±3.65%     39140
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved Server-Sent Events (SSE) emission performance through more efficient validation and formatting.
  - SSE formatting is approximately 230 times faster in benchmarked scenarios.

- **Bug Fixes**
  - Unknown SSE events now return clear, descriptive errors, including inherited event names.
  - Invalid event data produces more precise validation errors.

- **API Updates**
  - Renamed SSE schema and message-formatting interfaces for consistency.
  - Updated SSE integration interfaces to work with event definitions directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->