### PR TITLE
feat(perf): Using compiled SSE schemas

### DIFF
--- a/express-zod-api/src/sse.ts
+++ b/express-zod-api/src/sse.ts
@@ -1,6 +1,6 @@
 import type { Response } from "express";
 import { z } from "zod";
-import type { FlatObject } from "./common-helpers";
+import { compileOnce, type FlatObject } from "./common-helpers";
 import { contentTypes } from "./content-type";
 import { EndpointsFactory } from "./endpoints-factory";
 import { Middleware } from "./middleware";
@@ -39,8 +39,7 @@ export const formatMessage = (
 ) => {
   if (!Object.prototype.hasOwnProperty.call(events, event))
     throw new Error(`Unknown event: ${event}`);
-  const schema = events[event]!; // ensured by hasOwnProperty
-  const payload = schema.parse(data);
+  const payload = events[event]!.parse(data); // ensured by hasOwnProperty
   return [
     `event: ${event}`,
     `data: ${JSON.stringify(payload)}`,
@@ -122,8 +121,13 @@ export class EventStreamFactory<E extends EventsMap> extends EndpointsFactory<
   undefined,
   Emitter<E>
 > {
-  /** @todo compile these schemas in v30 */
-  constructor(events: E) {
+  constructor(_events: E) {
+    const events = Object.fromEntries(
+      Object.entries(_events).map(([event, schema]) => [
+        event,
+        compileOnce(schema),
+      ]),
+    );
     super(makeResultHandler(events));
     this.middlewares = [makeMiddleware(events)];
   }


### PR DESCRIPTION
This is the last piece of Zod compiled schema puzzle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved Server-Sent Events schema processing by compiling event schemas before stream handling begins.
  - Stream event payload formatting now performs schema-based parsing inline.
  - Existing event-stream behavior remains unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->